### PR TITLE
Remove {dplyr} as dependency

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -97,30 +97,6 @@ references:
     email: dbetebenner@nciea.org
   year: '2023'
 - type: software
-  title: dplyr
-  abstract: 'dplyr: A Grammar of Data Manipulation'
-  notes: Imports
-  url: https://dplyr.tidyverse.org
-  repository: https://CRAN.R-project.org/package=dplyr
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-    orcid: https://orcid.org/0000-0003-4757-117X
-  - family-names: François
-    given-names: Romain
-    orcid: https://orcid.org/0000-0002-2444-4226
-  - family-names: Henry
-    given-names: Lionel
-  - family-names: Müller
-    given-names: Kirill
-    orcid: https://orcid.org/0000-0002-1416-3412
-  - family-names: Vaughan
-    given-names: Davis
-    email: davis@posit.co
-    orcid: https://orcid.org/0000-0003-4777-038X
-  year: '2023'
-- type: software
   title: incidence2
   abstract: 'incidence2: Compute, Handle and Plot Incidence of Dated Events'
   notes: Suggests

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,8 +19,7 @@ Imports:
     checkmate,
     epiparameter,
     bpmodels,
-    randomNames,
-    dplyr
+    randomNames
 Suggests: 
     incidence2,
     knitr,

--- a/R/add_cols.R
+++ b/R/add_cols.R
@@ -213,14 +213,15 @@ NULL
   .data$case_name[.data$gender == "m"] <- names$names_masc # move to start of df
   .data$case_name[.data$gender == "f"] <- names$names_fem
 
-  # add corresponding names to infectors
-  infector_names <- .data[, c("id", "case_name")]
-  names(infector_names)[2] <- "infector_name"
-  .data <- dplyr::left_join(
-    .data,
-    infector_names,
-    by = dplyr::join_by(infector == id) # nolint global var
+  # left join corresponding names to infectors preserving column and row order
+  infector_names <- data.frame(id = .data$id, infector_name = .data$case_name)
+  col_order <- c(colnames(.data), "infector_name")
+  .data <- merge(
+    .data, infector_names, by.x = "infector", by.y = "id", all.x = TRUE
   )
+  .data <- .data[order(is.na(.data$infector_name), decreasing = TRUE), ]
+  .data <- .data[col_order]
+  rownames(.data) <- NULL
 
   # return named linelist
   .data

--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -208,7 +208,13 @@ sim_linelist <- function(R, # nolint cyclocomp
 
   # add exposure date for cases
   id_time <- data.frame(infector = chain$id, infector_time = chain$time)
-  chain <- dplyr::left_join(chain, id_time, by = "infector")
+
+  # left join infector time to data preserving column and row order
+  col_order <- c(colnames(chain), "infector_time")
+  chain <- merge(chain, id_time, by = "infector", all.x = TRUE)
+  chain <- chain[order(is.na(chain$infector), decreasing = TRUE), ]
+  chain <- chain[col_order]
+  rownames(chain) <- NULL
 
   chain <- .add_date_last_contact(
     .data = chain,


### PR DESCRIPTION
This PR removes the {dplyr} package as an imported dependency and removes any calls of {dplyr} functions from within {simulist}. 

{dplyr} was being used for joining, specifically `left_join()`, the functional replacement of this is `merge()` with some extra code for the joining to have behaviour similar to {dplyr}'s join (e.g. preserve column and row ordering).