### PR TITLE
Restructure rate data frames input

### DIFF
--- a/R/add_cols.R
+++ b/R/add_cols.R
@@ -121,13 +121,7 @@ NULL
     .data$hospitalisation[pop_sample] <- NA
   } else {
     for (i in seq_len(nrow(hosp_rate))) {
-      if (i == nrow(hosp_rate)) {
-        # oldest age bracket has inclusive upper bound
-        age_bracket <- hosp_rate$min_age[i]:hosp_rate$max_age[i]
-      } else {
-        # remove last integer from bracket due to exclusive upper bound
-        age_bracket <- hosp_rate$min_age[i]:(hosp_rate$max_age[i] - 1)
-      }
+      age_bracket <- hosp_rate$min_age[i]:hosp_rate$max_age[i]
       age_group <- which(.data$age %in% age_bracket)
       not_hosp_prob <- 1 - hosp_rate$rate[i]
       age_group_sample <- sample(
@@ -161,14 +155,7 @@ NULL
       .data$deaths[pop_sample] <- NA
     } else {
       for (i in seq_len(nrow(hosp_death_rate))) {
-        if (i == nrow(hosp_death_rate)) {
-          # oldest age bracket has inclusive upper bound
-          age_bracket <- hosp_death_rate$min_age[i]:hosp_death_rate$max_age[i]
-        } else {
-          # remove last integer from bracket due to exclusive upper bound
-          age_bracket <-
-            hosp_death_rate$min_age[i]:(hosp_death_rate$max_age[i] - 1)
-        }
+        age_bracket <- hosp_death_rate$min_age[i]:hosp_death_rate$max_age[i]
         if (hosp) {
           age_group <- which(
             .data$age %in% age_bracket & !is.na(.data$hospitalisation)
@@ -240,7 +227,7 @@ NULL
   )
   .data <- .data[order(is.na(.data$infector_name), decreasing = TRUE), ]
   .data <- .data[col_order]
-  rownames(.data) <- NULL
+  row.names(.data) <- NULL
 
   # return named line list
   .data

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -7,44 +7,42 @@
 #' invalid.
 #' @keywords internal
 .check_rate_df <- function(x, age_range) {
-
-  # get vector of all age groups
-  age_groups <- apply(x, 1, function(y) y[1]:y[2])
-
-  # remove last integer from bracket due to exclusive upper bound
-  # oldest age bracket has inclusive upper bound
-  age_groups_ <- lapply(
-    age_groups,
-    FUN = function(x) x[-length(x)]
-  )
-  age_groups_[length(age_groups)] <- age_groups[length(age_groups)]
-  age_vec <- unlist(age_groups_)
-
+  # check input
   stopifnot(
-    "column names should be 'min_age', 'max_age' & 'rate'" =
-      c("min_age", "max_age", "rate") %in% colnames(x),
+    "column names should be 'age_limit' & 'rate'" =
+      setequal(c("age_limit", "rate"), colnames(x)),
     "minimum age of lowest age group should match lower age range" =
-      age_range[1] == min(x$min_age),
-    "maximum age of the highest age group should match upper age range" =
-      age_range[2] == max(x$max_age),
+      age_range[1] == min(x$age_limit),
+    "lower bound of oldest age group must be lower than highest age range" =
+      age_range[2] > max(x$age_limit),
+    "age limit or rate cannot be NA or NaN" =
+      !anyNA(x),
     "rate should be between 0 and 1" =
       min(x$rate) >= 0 & max(x$rate) <= 1,
-    "age groups should be non-overlapping" =
-      !anyDuplicated(age_vec) > 0,
-    "age groups should be contiguous" =
-      all(age_range[1]:age_range[2] %in% unique(age_vec))
+    "age limit in rate data frame must be unique" =
+      !(anyDuplicated(x$age_limit) > 0)
   )
 
-  rownames(x) <- paste0(
-    "[", x$min_age, ",", x$max_age, ")"
-  )
+  # order rate df on age_limit
+  x <- x[order(x$age_limit), ]
 
+  # format rate data frame
+  age_range_ <- age_range[1]:age_range[2]
+  # findInterval inclusive/exclusive bound rules match age bracket
+  age_groups <- unname(split(age_range_, findInterval(age_range_, x$age_limit)))
+
+  # add and sort data frames cols
+  x$max_age <- vapply(age_groups, max, FUN.VALUE = numeric(1))
+  colnames(x) <- c("min_age", "rate", "max_age")
+  x <- x[, c("min_age", "max_age", "rate")]
+
+  # add informative row names
+  row.names(x) <- paste0(
+    "[", x$min_age, ",", (x$max_age + 1), ")"
+  )
   # last age bracket has inclusive upper bound
-  rownames(x)[nrow(x)] <- gsub(
-    pattern = ")",
-    replacement = "]",
-    x = rownames(x)[nrow(x)],
-    fixed = TRUE
+  row.names(x)[nrow(x)] <- paste0(
+    "[", x$min_age[nrow(x)], ",", x$max_age[nrow(x)], "]"
   )
 
   # return rate data frame

--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -5,11 +5,9 @@
 #'
 #' @details For age-stratified hospitalised and death rates a `<data.frame>`
 #' will need to be passed to the `hosp_rate` and/or `hosp_death_rate`
-#' arguments. This `<data.frame>` should have three columns:
-#' * `min_age`: a column with one `numeric` per cell for the minimum age of
-#' the age group (inclusive).
-#' * `max_age`: a column with one `numeric` per cell for the maximum age of
-#' the age group (exclusive).
+#' arguments. This `<data.frame>` should have two columns:
+#' * `age_limit`: a column with one `numeric` per cell for the lower bound
+#' (minimum) age of the age group (inclusive).
 #' * `rate`: a column with one `numeric` per cell for the proportion
 #' (or probability) of hospitalisation for that age group. Should be between
 #' 0 and 1.
@@ -96,8 +94,7 @@
 #' # 10% for under 5s
 #' # 5% for the rest
 #' age_dep_hosp_rate <- data.frame(
-#'   min_age = c(1, 5, 80),
-#'   max_age = c(5, 80, 90),
+#'   age_limit = c(1, 5, 80),
 #'   rate = c(0.1, 0.05, 0.2)
 #' )
 #' linelist <- sim_linelist(

--- a/R/sim_utils.R
+++ b/R/sim_utils.R
@@ -48,7 +48,7 @@ NULL
   chain <- merge(chain, id_time, by = "infector", all.x = TRUE)
   chain <- chain[order(is.na(chain$infector), decreasing = TRUE), ]
   chain <- chain[col_order]
-  rownames(chain) <- NULL
+  row.names(chain) <- NULL
 
   chain <- .add_date_last_contact(
     .data = chain,

--- a/man/sim_linelist.Rd
+++ b/man/sim_linelist.Rd
@@ -87,12 +87,10 @@ parameterised with previously published epidemiological parameters.
 \details{
 For age-stratified hospitalised and death rates a \verb{<data.frame>}
 will need to be passed to the \code{hosp_rate} and/or \code{hosp_death_rate}
-arguments. This \verb{<data.frame>} should have three columns:
+arguments. This \verb{<data.frame>} should have two columns:
 \itemize{
-\item \code{min_age}: a column with one \code{numeric} per cell for the minimum age of
-the age group (inclusive).
-\item \code{max_age}: a column with one \code{numeric} per cell for the maximum age of
-the age group (exclusive).
+\item \code{age_limit}: a column with one \code{numeric} per cell for the lower bound
+(minimum) age of the age group (inclusive).
 \item \code{rate}: a column with one \code{numeric} per cell for the proportion
 (or probability) of hospitalisation for that age group. Should be between
 0 and 1.
@@ -134,8 +132,7 @@ linelist <- sim_linelist(
 # 10\% for under 5s
 # 5\% for the rest
 age_dep_hosp_rate <- data.frame(
-  min_age = c(1, 5, 80),
-  max_age = c(5, 80, 90),
+  age_limit = c(1, 5, 80),
   rate = c(0.1, 0.05, 0.2)
 )
 linelist <- sim_linelist(

--- a/man/sim_outbreak.Rd
+++ b/man/sim_outbreak.Rd
@@ -105,12 +105,10 @@ parameters.
 \details{
 For age-stratified hospitalised and death rates a \verb{<data.frame>}
 will need to be passed to the \code{hosp_rate} and/or \code{hosp_death_rate}
-arguments. This \verb{<data.frame>} should have three columns:
+arguments. This \verb{<data.frame>} should have two columns:
 \itemize{
-\item \code{min_age}: a column with one \code{numeric} per cell for the minimum age of
-the age group (inclusive).
-\item \code{max_age}: a column with one \code{numeric} per cell for the maximum age of
-the age group (exclusive).
+\item \code{age_limit}: a column with one \code{numeric} per cell for the lower bound
+(minimum) age of the age group (inclusive).
 \item \code{rate}: a column with one \code{numeric} per cell for the proportion
 (or probability) of hospitalisation for that age group. Should be between
 0 and 1.

--- a/tests/testthat/test-add_cols.R
+++ b/tests/testthat/test-add_cols.R
@@ -186,7 +186,7 @@ test_that(".add_hospitalisation works as expected with age-strat rates", {
   ll <- .create_linelist(scenario = "pre_hospitalisation")
   age_dep_hosp_rate <- data.frame(
     min_age = c(1, 5, 80),
-    max_age = c(5, 80, 90),
+    max_age = c(4, 79, 90),
     rate = c(0.1, 0.05, 0.2)
   )
   linelist <- .add_hospitalisation(
@@ -241,12 +241,12 @@ test_that(".add_deaths works as expected with age-strat rates", {
   ll <- .create_linelist(scenario = "pre_death")
   age_dep_hosp_death_rate <- data.frame(
     min_age = c(1, 5, 80),
-    max_age = c(5, 80, 90),
+    max_age = c(4, 79, 90),
     rate = c(0.1, 0.05, 0.2)
   )
   age_dep_non_hosp_death_rate <- data.frame(
     min_age = c(1, 5, 80),
-    max_age = c(5, 80, 90),
+    max_age = c(4, 79, 90),
     rate = c(0.05, 0.025, 0.1)
   )
   linelist <- .add_deaths(

--- a/tests/testthat/test-checkers.R
+++ b/tests/testthat/test-checkers.R
@@ -1,30 +1,30 @@
 test_that(".check_rate_df works as expected", {
   age_dep_hosp_rate <- data.frame(
-    min_age = c(1, 5, 80),
-    max_age = c(5, 80, 90),
+    age_limit = c(1, 5, 80),
     rate = c(0.1, 0.05, 0.2)
   )
   age_dep_hosp_rate <- .check_rate_df(age_dep_hosp_rate, age_range = c(1, 90))
   expect_s3_class(age_dep_hosp_rate, class = "data.frame")
   expect_identical(dim(age_dep_hosp_rate), c(3L, 3L))
   expect_identical(colnames(age_dep_hosp_rate), c("min_age", "max_age", "rate"))
-  expect_identical(rownames(age_dep_hosp_rate), c("[1,5)", "[5,80)", "[80,90]"))
+  expect_identical(
+    row.names(age_dep_hosp_rate),
+    c("[1,5)", "[5,80)", "[80,90]")
+  )
 })
 
 test_that(".check_rate_df fails as expected", {
   age_dep_hosp_rate <- data.frame(
     age_min = c(1, 5, 80),
-    age_max = c(5, 80, 90),
     hosp_rate = c(0.1, 0.05, 0.2)
   )
   expect_error(
     .check_rate_df(age_dep_hosp_rate, age_range = c(1, 91)),
-    regexp = "column names should be 'min_age', 'max_age' & 'rate'"
+    regexp = "column names should be 'age_limit' & 'rate'"
   )
 
   age_dep_hosp_rate <- data.frame(
-    min_age = c(2, 5, 80),
-    max_age = c(5, 80, 90),
+    age_limit = c(2, 5, 80),
     rate = c(0.1, 0.05, 0.2)
   )
   expect_error(
@@ -33,18 +33,17 @@ test_that(".check_rate_df fails as expected", {
   )
 
   age_dep_hosp_rate <- data.frame(
-    min_age = c(1, 5, 80),
-    max_age = c(5, 80, 90),
+    age_limit = c(1, 5, 90),
     rate = c(0.1, 0.05, 0.2)
   )
   expect_error(
-    .check_rate_df(age_dep_hosp_rate, age_range = c(1, 91)),
-    regexp = "maximum age of the highest age group should match upper age range"
+    .check_rate_df(age_dep_hosp_rate, age_range = c(1, 90)),
+    regexp =
+      "lower bound of oldest age group must be lower than highest age range"
   )
 
   age_dep_hosp_rate <- data.frame(
-    min_age = c(1, 5, 80),
-    max_age = c(5, 80, 90),
+    age_limit = c(1, 5, 80),
     rate = c(-0.1, 0.5, 1.1)
   )
   expect_error(
@@ -53,22 +52,20 @@ test_that(".check_rate_df fails as expected", {
   )
 
   age_dep_hosp_rate <- data.frame(
-    min_age = c(1, 5, 60),
-    max_age = c(10, 70, 90),
+    age_limit = c(1, 5, 5),
     rate = c(0.1, 0.05, 0.2)
   )
   expect_error(
     .check_rate_df(age_dep_hosp_rate, age_range = c(1, 90)),
-    regexp = "age groups should be non-overlapping"
+    regexp = "age limit in rate data frame must be unique"
   )
 
   age_dep_hosp_rate <- data.frame(
-    min_age = c(1, 10, 80),
-    max_age = c(3, 60, 90),
-    rate = c(0.1, 0.05, 0.2)
+    age_limit = c(1, 10, 80),
+    rate = c(0.1, 0.05, NA)
   )
   expect_error(
     .check_rate_df(age_dep_hosp_rate, age_range = c(1, 90)),
-    regexp = "age groups should be contiguous"
+    regexp = "age limit or rate cannot be NA or NaN"
   )
 })

--- a/tests/testthat/test-sim_linelist.R
+++ b/tests/testthat/test-sim_linelist.R
@@ -41,18 +41,15 @@ test_that("sim_list works as expected", {
 
 test_that("sim_list works as expected with age-strat rates", {
   age_dep_hosp_rate <- data.frame(
-    min_age = c(1, 5, 80),
-    max_age = c(5, 80, 90),
+    age_limit = c(1, 5, 80),
     rate = c(0.1, 0.05, 0.2)
   )
   age_dep_hosp_death_rate <- data.frame(
-    min_age = c(1, 5, 80),
-    max_age = c(5, 80, 90),
+    age_limit = c(1, 5, 80),
     rate = c(0.1, 0.05, 0.2)
   )
   age_dep_non_hosp_death_rate <- data.frame(
-    min_age = c(1, 5, 80),
-    max_age = c(5, 80, 90),
+    age_limit = c(1, 5, 80),
     rate = c(0.05, 0.025, 0.1)
   )
   set.seed(1)

--- a/tests/testthat/test-sim_outbreak.R
+++ b/tests/testthat/test-sim_outbreak.R
@@ -85,18 +85,15 @@ test_that("sim_outbreak works as expected with add_names = FALSE", {
 
 test_that("sim_outbreak works as expected with age-strat rates", {
   age_dep_hosp_rate <- data.frame(
-    min_age = c(1, 5, 80),
-    max_age = c(5, 80, 90),
+    age_limit = c(1, 5, 80),
     rate = c(0.1, 0.05, 0.2)
   )
   age_dep_hosp_death_rate <- data.frame(
-    min_age = c(1, 5, 80),
-    max_age = c(5, 80, 90),
+    age_limit = c(1, 5, 80),
     rate = c(0.1, 0.05, 0.2)
   )
   age_dep_non_hosp_death_rate <- data.frame(
-    min_age = c(1, 5, 80),
-    max_age = c(5, 80, 90),
+    age_limit = c(1, 5, 80),
     rate = c(0.05, 0.025, 0.1)
   )
   set.seed(1)

--- a/vignettes/age-strat-rates.Rmd
+++ b/vignettes/age-strat-rates.Rmd
@@ -24,7 +24,7 @@ If you are unfamiliar with the {simulist} package or the `sim_linelist()` functi
 
 This vignette will describe how to simulate a line list with age-stratified (or age-dependent) hospitalisation and death rates. 
 
-There are three rates in {simulist}, specifically in the `sim_linelist()` function, that relate to hospitalisations and deaths:
+There are three rates in {simulist}, specifically in the `sim_linelist()` and `sim_outbreak()` functions, that relate to hospitalisations and deaths:
 
 1. Hospitalisation rate (`hosp_rate`)
 2. Death rate in hospitals (`hosp_death_rate`)
@@ -110,7 +110,7 @@ head(linelist)
 
 ## Age-stratified rates
 
-Now we can run age-stratified rates by creating a table (`<data.frame>`) which contains the lower and upper limits of the age groups and their respective rates.
+Now we can run age-stratified rates by creating a table (`<data.frame>`) which contains the lower limits of the age groups and their respective rates.
 
 In this example the hospitalisation rate will be:
 
@@ -118,12 +118,11 @@ In this example the hospitalisation rate will be:
 * `0.1` (or 10%) for under 5s
 * `0.05` (or 5%) for the rest
 
-The minimum age of each age group is inclusive, and the maximum age of each age group is exclusive, except the oldest age group which is inclusive of the minimum and maximum age. The age groups are formed by their position in the input vectors. In this example the first age group is the first element of each vector, so the minimum age is 1, maximum age is five and the hospitalisation rate for that group is 0.1. Each age group forms a row in the table.
+The minimum age of each age group is inclusive, and the maximum age of each age group is exclusive, except the oldest age group which is inclusive of the minimum and maximum age. In this example the first age group is the first element of each vector, so the minimum age is 1, maximum age is four (as the next age group starts at five), and the hospitalisation rate for that group is 0.1. Each age group forms a row in the table. The oldest age group stops at the upper age range given in the `age_range` argument. The default upper age range in 90, so in this example the oldest age bracket will be 80-90 (inclusive).
 
 ```{r, make-hosp-rate-df}
 age_dep_hosp_rate <- data.frame(
-  min_age = c(1, 5, 80),
-  max_age = c(5, 80, 90),
+  age_limit = c(1, 5, 80),
   rate = c(0.1, 0.05, 0.2)
 )
 age_dep_hosp_rate
@@ -143,18 +142,17 @@ head(linelist)
 
 ::: {.alert .alert-warning}
 
-The minimum age of the youngest age group and the maximum age of the oldest age group must match the age range specified in the `age_range` argument of `sim_linelist()`. If it does not the function will error.
+The minimum age of the youngest age group must match the age range specified in the `age_range` argument of `sim_linelist()`, and the largest age limit in the rate `<data.frame>` must not be older than the upper age range. If these conditions are not met the function will error.
 
 If the age-stratified rate table does not match the default (`c(1, 90)`), the `age_range` argument will need to be set to match.
 
 :::
 
-For example, the default age range of the population is 1 to 90 (inclusive). In our example above, the lowest age group started at 1 and the oldest age group stopped at 90. This matches the default `age_range = c(1, 90)`. However, see here that if the oldest age bracket was up to 95 the function will not run.
+For example, the default age range of the population is 1 to 90 (inclusive). In our example above, the lowest age group started at 1 and the oldest age group stopped at 90. This matches the default `age_range = c(1, 90)`. However, see here that if the lower age limit exceeds the age range the function will not run.
 
 ```{r, sim-age_strat_linelist-error, error=TRUE}
 age_dep_hosp_rate <- data.frame(
-  min_age = c(1, 5, 80),
-  max_age = c(5, 80, 95),
+  age_limit = c(1, 5, 95),
   rate = c(0.1, 0.05, 0.2)
 )
 age_dep_hosp_rate
@@ -168,12 +166,11 @@ linelist <- sim_linelist(
 )
 ```
 
-In order to make this code run with the age-stratified hospitalisation rate given, the `age_range` can be adjusted.
+In order to make this code run with the age-stratified hospitalisation rate given, the `age_range` can be adjusted. Here the oldest age bracket is now 95 to 100 (`[95, 100]`).
 
 ```{r, sim-age_strat-linelist-diff-age-range}
 age_dep_hosp_rate <- data.frame(
-  min_age = c(1, 5, 80),
-  max_age = c(5, 80, 95),
+  age_limit = c(1, 5, 95),
   rate = c(0.1, 0.05, 0.2)
 )
 
@@ -183,7 +180,7 @@ linelist <- sim_linelist(
   onset_to_hosp = onset_to_hosp,
   onset_to_death = onset_to_death,
   hosp_rate = age_dep_hosp_rate,
-  age_range = c(1, 95)
+  age_range = c(1, 100)
 )
 
 head(linelist)
@@ -195,8 +192,7 @@ Here are a couple of examples:
 
 ```{r, sim-age_strat_linelist-hosp-death-rate}
 age_dep_hosp_death_rate <- data.frame(
-  min_age = c(1, 5, 80),
-  max_age = c(5, 80, 90),
+  age_limit = c(1, 5, 80),
   rate = c(0.3, 0.1, 0.6)
 )
 age_dep_hosp_death_rate
@@ -212,8 +208,7 @@ linelist <- sim_linelist(
 
 ```{r, sim-age_strat_linelist-non-hosp-death-rate}
 age_dep_non_hosp_death_rate <- data.frame(
-  min_age = c(1, 5, 80),
-  max_age = c(5, 80, 90),
+  age_limit = c(1, 5, 80),
   rate = c(0.1, 0.05, 0.1)
 )
 age_dep_non_hosp_death_rate
@@ -231,18 +226,15 @@ Up until now these age-stratified tables have only been supplied to one rate. Ho
 
 ```{r, sim-age-strat-linelist-all}
 age_dep_hosp_rate <- data.frame(
-  min_age = c(1, 5, 80),
-  max_age = c(5, 80, 90),
+  age_limit = c(1, 5, 80),
   rate = c(0.1, 0.05, 0.2)
 )
 age_dep_hosp_death_rate <- data.frame(
-  min_age = c(1, 5, 80),
-  max_age = c(5, 80, 90),
+  age_limit = c(1, 5, 80),
   rate = c(0.3, 0.1, 0.6)
 )
 age_dep_non_hosp_death_rate <- data.frame(
-  min_age = c(1, 5, 80),
-  max_age = c(5, 80, 90),
+  age_limit = c(1, 5, 80),
   rate = c(0.1, 0.05, 0.1)
 )
 


### PR DESCRIPTION
The `sim_linelist()` and `sim_outbreak()` functions can simulate with age-stratified rates of hospitalisation or death (hospital deaths and community deaths). This PR updates the `<data.frame>` that specifies the age groups and their respective rates. 

It removes the min and max age bounds for each age group and instead automatically computes each age group from the lower bound of each group. This is a similar implementation to `age.limits` argument in [`contact_matrix()` function in {socialmixr}](https://github.com/epiforecasts/socialmixr/blob/main/R/contact_matrix.r).

The documentation, including function documentation and `age-strat-rates.Rmd` vignette, have been updated. Tests have also been updated.