### PR TITLE
Add death date to line list output

### DIFF
--- a/R/create_linelist.R
+++ b/R/create_linelist.R
@@ -19,7 +19,29 @@
 #' [.add_date_last_contact()], and `"pre_names"` is the state of the line list
 #' prior to calling [.add_names()].
 #'
-#' # Script to reproduce data:
+#' ## Script to reproduce data:
+#' ```
+#' # load data required to simulate line list
+#' serial_interval <- epiparameter::epidist(
+#'   disease = "COVID-19",
+#'   epi_dist = "serial interval",
+#'   prob_distribution = "gamma",
+#'   prob_distribution_params = c(shape = 1, scale = 1)
+#' )
+#'
+#' # get onset to hospital admission from {epiparameter} database
+#' onset_to_hosp <- epiparameter::epidist_db(
+#'   disease = "COVID-19",
+#'   epi_dist = "onset to hospitalisation",
+#'   single_epidist = TRUE
+#' )
+#'
+#' # get onset to death from {epiparameter} database
+#' onset_to_death <- epiparameter::epidist_db(
+#'   disease = "COVID-19",
+#'   epi_dist = "onset to death",
+#'   single_epidist = TRUE
+#' )
 #' set.seed(1)
 #'
 #' linelist <- sim_linelist(
@@ -30,7 +52,7 @@
 #'   hosp_rate = 0.5,
 #'   add_ct = TRUE
 #' )
-#'
+#' ```
 #' @return A `<data.frame>`.
 #' @keywords internal
 .create_linelist <- function(scenario) {

--- a/R/sim_utils.R
+++ b/R/sim_utils.R
@@ -118,7 +118,7 @@ NULL
 
   linelist_cols <- c(
     "id", "case_type", "gender", "age", "onset_date", "hospitalisation_date",
-    "date_first_contact", "date_last_contact"
+    "death_date", "date_first_contact", "date_last_contact"
   )
 
   if (add_names) {

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -7,7 +7,11 @@ CoV
 COVID
 Ct
 ct
+db
+dist
+epi
 Epi
+epidist
 epiparameter
 Epiverse
 facetted
@@ -23,8 +27,10 @@ Lifecycle
 linelist
 olds
 packagename
+params
 parameterised
 Poisson
+prob
 randomNames
 RECON
 resimulate

--- a/man/dot-create_linelist.Rd
+++ b/man/dot-create_linelist.Rd
@@ -34,18 +34,40 @@ scenarios are before each function call, for example,
 \code{"pre_date_last_contact"} is the state of the line list prior to calling
 \code{\link[=.add_date_last_contact]{.add_date_last_contact()}}, and \code{"pre_names"} is the state of the line list
 prior to calling \code{\link[=.add_names]{.add_names()}}.
-}
-\section{Script to reproduce data:}{
+\subsection{Script to reproduce data:}{
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{# load data required to simulate line list
+serial_interval <- epiparameter::epidist(
+  disease = "COVID-19",
+  epi_dist = "serial interval",
+  prob_distribution = "gamma",
+  prob_distribution_params = c(shape = 1, scale = 1)
+)
+
+# get onset to hospital admission from \{epiparameter\} database
+onset_to_hosp <- epiparameter::epidist_db(
+  disease = "COVID-19",
+  epi_dist = "onset to hospitalisation",
+  single_epidist = TRUE
+)
+
+# get onset to death from \{epiparameter\} database
+onset_to_death <- epiparameter::epidist_db(
+  disease = "COVID-19",
+  epi_dist = "onset to death",
+  single_epidist = TRUE
+)
 set.seed(1)
 
 linelist <- sim_linelist(
-R = 1.1,
-serial_interval = serial_interval,
-onset_to_hosp = onset_to_hosp,
-onset_to_death = onset_to_death,
-hosp_rate = 0.5,
-add_ct = TRUE
+  R = 1.1,
+  serial_interval = serial_interval,
+  onset_to_hosp = onset_to_hosp,
+  onset_to_death = onset_to_death,
+  hosp_rate = 0.5,
+  add_ct = TRUE
 )
+}\if{html}{\out{</div>}}
 }
-
+}
 \keyword{internal}

--- a/tests/testthat/test-sim_linelist.R
+++ b/tests/testthat/test-sim_linelist.R
@@ -31,11 +31,12 @@ test_that("sim_list works as expected", {
   )
 
   expect_s3_class(linelist, class = "data.frame")
-  expect_identical(dim(linelist), c(42L, 9L))
+  expect_identical(dim(linelist), c(42L, 10L))
   expect_identical(
     colnames(linelist),
     c("id", "case_name", "case_type", "gender", "age", "onset_date",
-      "hospitalisation_date", "date_first_contact", "date_last_contact")
+      "hospitalisation_date", "death_date", "date_first_contact",
+      "date_last_contact")
   )
 })
 
@@ -64,11 +65,12 @@ test_that("sim_list works as expected with age-strat rates", {
   )
 
   expect_s3_class(linelist, class = "data.frame")
-  expect_identical(dim(linelist), c(42L, 9L))
+  expect_identical(dim(linelist), c(42L, 10L))
   expect_identical(
     colnames(linelist),
     c("id", "case_name", "case_type", "gender", "age", "onset_date",
-      "hospitalisation_date", "date_first_contact", "date_last_contact")
+      "hospitalisation_date", "death_date", "date_first_contact",
+      "date_last_contact")
   )
 })
 
@@ -83,12 +85,12 @@ test_that("sim_list works as expected with Ct", {
   )
 
   expect_s3_class(linelist, class = "data.frame")
-  expect_identical(dim(linelist), c(42L, 10L))
+  expect_identical(dim(linelist), c(42L, 11L))
   expect_identical(
     colnames(linelist),
     c("id", "case_name", "case_type", "gender", "age", "onset_date",
-      "hospitalisation_date", "date_first_contact", "date_last_contact",
-      "ct_value")
+      "hospitalisation_date", "death_date", "date_first_contact",
+      "date_last_contact", "ct_value")
   )
 })
 
@@ -103,11 +105,12 @@ test_that("sim_list works as expected with anonymous", {
   )
 
   expect_s3_class(linelist, class = "data.frame")
-  expect_identical(dim(linelist), c(42L, 8L))
+  expect_identical(dim(linelist), c(42L, 9L))
   expect_identical(
     colnames(linelist),
     c("id", "case_type", "gender", "age", "onset_date",
-      "hospitalisation_date", "date_first_contact", "date_last_contact")
+      "hospitalisation_date", "death_date", "date_first_contact",
+      "date_last_contact")
   )
 })
 
@@ -127,11 +130,12 @@ test_that("sim_list works as expected with age structure", {
   )
 
   expect_s3_class(linelist, class = "data.frame")
-  expect_identical(dim(linelist), c(42L, 9L))
+  expect_identical(dim(linelist), c(42L, 10L))
   expect_identical(
     colnames(linelist),
     c("id", "case_name", "case_type", "gender", "age", "onset_date",
-      "hospitalisation_date", "date_first_contact", "date_last_contact")
+      "hospitalisation_date", "death_date", "date_first_contact",
+      "date_last_contact")
   )
 })
 
@@ -156,11 +160,12 @@ test_that("sim_list works as expected with age-strat rates & age structure", {
   )
 
   expect_s3_class(linelist, class = "data.frame")
-  expect_identical(dim(linelist), c(42L, 9L))
+  expect_identical(dim(linelist), c(42L, 10L))
   expect_identical(
     colnames(linelist),
     c("id", "case_name", "case_type", "gender", "age", "onset_date",
-      "hospitalisation_date", "date_first_contact", "date_last_contact")
+      "hospitalisation_date", "death_date", "date_first_contact",
+      "date_last_contact")
   )
 })
 
@@ -212,11 +217,12 @@ test_that("sim_list works as expected with modified config", {
   )
 
   expect_s3_class(linelist, class = "data.frame")
-  expect_identical(dim(linelist), c(42L, 9L))
+  expect_identical(dim(linelist), c(42L, 10L))
   expect_identical(
     colnames(linelist),
     c("id", "case_name", "case_type", "gender", "age", "onset_date",
-      "hospitalisation_date", "date_first_contact", "date_last_contact")
+      "hospitalisation_date", "death_date", "date_first_contact",
+      "date_last_contact")
   )
 })
 
@@ -233,11 +239,12 @@ test_that("sim_list works as expected with modified config parameters", {
   )
 
   expect_s3_class(linelist, class = "data.frame")
-  expect_identical(dim(linelist), c(42L, 9L))
+  expect_identical(dim(linelist), c(42L, 10L))
   expect_identical(
     colnames(linelist),
     c("id", "case_name", "case_type", "gender", "age", "onset_date",
-      "hospitalisation_date", "date_first_contact", "date_last_contact")
+      "hospitalisation_date", "death_date", "date_first_contact",
+      "date_last_contact")
   )
 })
 

--- a/tests/testthat/test-sim_outbreak.R
+++ b/tests/testthat/test-sim_outbreak.R
@@ -41,12 +41,13 @@ test_that("sim_outbreak works as expected", {
   expect_type(outbreak, type = "list")
   expect_s3_class(outbreak$linelist, class = "data.frame")
   expect_s3_class(outbreak$contacts, class = "data.frame")
-  expect_identical(dim(outbreak$linelist), c(42L, 9L))
+  expect_identical(dim(outbreak$linelist), c(42L, 10L))
   expect_identical(dim(outbreak$contacts), c(163L, 8L))
   expect_identical(
     colnames(outbreak$linelist),
     c("id", "case_name", "case_type", "gender", "age", "onset_date",
-      "hospitalisation_date", "date_first_contact", "date_last_contact")
+      "hospitalisation_date", "death_date", "date_first_contact",
+      "date_last_contact")
   )
   expect_identical(
     colnames(outbreak$contacts),
@@ -69,12 +70,13 @@ test_that("sim_outbreak works as expected with add_names = FALSE", {
   expect_type(outbreak, type = "list")
   expect_s3_class(outbreak$linelist, class = "data.frame")
   expect_s3_class(outbreak$contacts, class = "data.frame")
-  expect_identical(dim(outbreak$linelist), c(42L, 8L))
+  expect_identical(dim(outbreak$linelist), c(42L, 9L))
   expect_identical(dim(outbreak$contacts), c(168L, 8L))
   expect_identical(
     colnames(outbreak$linelist),
     c("id", "case_type", "gender", "age", "onset_date",
-      "hospitalisation_date", "date_first_contact", "date_last_contact")
+      "hospitalisation_date", "death_date", "date_first_contact",
+      "date_last_contact")
   )
   expect_identical(
     colnames(outbreak$contacts),
@@ -111,12 +113,13 @@ test_that("sim_outbreak works as expected with age-strat rates", {
   expect_type(outbreak, type = "list")
   expect_s3_class(outbreak$linelist, class = "data.frame")
   expect_s3_class(outbreak$contacts, class = "data.frame")
-  expect_identical(dim(outbreak$linelist), c(42L, 9L))
+  expect_identical(dim(outbreak$linelist), c(42L, 10L))
   expect_identical(dim(outbreak$contacts), c(177L, 8L))
   expect_identical(
     colnames(outbreak$linelist),
     c("id", "case_name", "case_type", "gender", "age", "onset_date",
-      "hospitalisation_date", "date_first_contact", "date_last_contact")
+      "hospitalisation_date", "death_date", "date_first_contact",
+      "date_last_contact")
   )
   expect_identical(
     colnames(outbreak$contacts),
@@ -144,12 +147,13 @@ test_that("sim_outbreak works as expected with age structure", {
   expect_type(outbreak, type = "list")
   expect_s3_class(outbreak$linelist, class = "data.frame")
   expect_s3_class(outbreak$contacts, class = "data.frame")
-  expect_identical(dim(outbreak$linelist), c(42L, 9L))
+  expect_identical(dim(outbreak$linelist), c(42L, 10L))
   expect_identical(dim(outbreak$contacts), c(177L, 8L))
   expect_identical(
     colnames(outbreak$linelist),
     c("id", "case_name", "case_type", "gender", "age", "onset_date",
-      "hospitalisation_date", "date_first_contact", "date_last_contact")
+      "hospitalisation_date", "death_date", "date_first_contact",
+      "date_last_contact")
   )
   expect_identical(
     colnames(outbreak$contacts),


### PR DESCRIPTION
This PR adds the `death_date` column to the line list `<data.frame>` output by `sim_linelist()` and `sim_outbreak()`. 

This column was already being generated in the simulation, but was being dropped before the output was returned from the function. This has been updated to not drop the column.

Test expectations are updated to reflect the extra column. 

The reprex script in the `.create_linelist()` documentation is updated to include the full script.

The `WORDLIST` is updated.