### PR TITLE
Add {epicontacts} section to visualisation vignette

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -119,6 +119,37 @@ references:
   year: '2023'
   version: '>= 2.1.0'
 - type: software
+  title: epicontacts
+  abstract: 'epicontacts: Handling, Visualisation and Analysis of Epidemiological
+    Contacts'
+  notes: Suggests
+  url: https://www.repidemicsconsortium.org/epicontacts/
+  repository: https://CRAN.R-project.org/package=epicontacts
+  authors:
+  - family-names: Campbell
+    given-names: Finlay
+    email: finlaycampbell93@gmail.com
+  - family-names: Jombart
+    given-names: Thibaut
+    email: thibautjombart@gmail.com
+  - family-names: Randhawa
+    given-names: Nistara
+    email: nrandhawa@ucdavis.edu
+  - family-names: Sudre
+    given-names: Bertrand
+    email: Bertrand.Sudre@ecdc.europa.eu
+  - family-names: Nagraj
+    given-names: VP
+    email: nagraj@nagraj.net
+  - family-names: Crellen
+    given-names: Thomas
+    email: tc13@sanger.ac.uk
+  - family-names: Kamvar
+    given-names: Zhian N.
+    email: zkamvar@gmail.com
+  year: '2023'
+  version: '>= 1.1.3'
+- type: software
   title: knitr
   abstract: 'knitr: A General-Purpose Package for Dynamic Report Generation in R'
   notes: Suggests

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
     randomNames
 Suggests: 
     incidence2 (>= 2.1.0),
+    epicontacts (>= 1.1.3),
     knitr,
     ggplot2,
     bookdown,

--- a/R/create_contacts.R
+++ b/R/create_contacts.R
@@ -23,7 +23,7 @@
       "date_first_contact", "date_last_contact")
   )
   colnames(contact_investigation) <- c(
-    "infector", "part_name", "contact_name", "cnt_age", "cnt_gender",
+    "infector", "from", "to", "cnt_age", "cnt_gender",
     "date_first_contact", "date_last_contact"
   )
   contact_investigation <- contact_investigation[-1, ]
@@ -31,7 +31,7 @@
 
   other_contacts <- subset(.data, select = c("infector", "infector_time"))
   other_contacts <- other_contacts[-1, ]
-  other_contacts$part_name <- contact_investigation$part_name
+  other_contacts$from <- contact_investigation$from
   other_contacts <- subset(
     other_contacts,
     subset = !duplicated(other_contacts$infector)
@@ -74,7 +74,7 @@
   )
 
   #Add corresponding names acc to the gender V
-  other_contacts$contact_name <- randomNames::randomNames(
+  other_contacts$to <- randomNames::randomNames(
     which.names = "both",
     name.sep = " ",
     name.order = "first.last",
@@ -98,7 +98,7 @@
   other_contacts <- subset(
     other_contacts,
     select = c(
-      "infector", "part_name", "contact_name", "cnt_age", "cnt_gender",
+      "infector", "from", "to", "cnt_age", "cnt_gender",
       "date_first_contact", "date_last_contact"
     )
   )

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -11,6 +11,7 @@ db
 dist
 epi
 Epi
+epicontacts
 epidist
 epiparameter
 Epiverse
@@ -39,4 +40,6 @@ sim
 st
 stochasticity
 svg
+threejs
+visNetwork
 yaml

--- a/tests/testthat/test-sim_contacts.R
+++ b/tests/testthat/test-sim_contacts.R
@@ -26,8 +26,8 @@ test_that("sim_contacts works as expected", {
   expect_identical(dim(contacts), c(170L, 8L))
   expect_identical(
     colnames(contacts),
-    c("part_name", "contact_name", "cnt_age", "cnt_gender",
-      "date_first_contact", "date_last_contact", "was_case", "status")
+    c("from", "to", "cnt_age", "cnt_gender", "date_first_contact",
+      "date_last_contact", "was_case", "status")
   )
 })
 
@@ -52,8 +52,8 @@ test_that("sim_contacts works as expected with modified config", {
   expect_identical(dim(contacts), c(178L, 8L))
   expect_identical(
     colnames(contacts),
-    c("part_name", "contact_name", "cnt_age", "cnt_gender",
-      "date_first_contact", "date_last_contact", "was_case", "status")
+    c("from", "to", "cnt_age", "cnt_gender", "date_first_contact",
+      "date_last_contact", "was_case", "status")
   )
 })
 
@@ -72,8 +72,8 @@ test_that("sim_contacts works as expected with modified config parameters", {
   expect_identical(dim(contacts), c(170L, 8L)) # TODO check why nrow is diff
   expect_identical(
     colnames(contacts),
-    c("part_name", "contact_name", "cnt_age", "cnt_gender",
-      "date_first_contact", "date_last_contact", "was_case", "status")
+    c("from", "to", "cnt_age", "cnt_gender", "date_first_contact",
+      "date_last_contact", "was_case", "status")
   )
 })
 

--- a/tests/testthat/test-sim_outbreak.R
+++ b/tests/testthat/test-sim_outbreak.R
@@ -51,8 +51,8 @@ test_that("sim_outbreak works as expected", {
   )
   expect_identical(
     colnames(outbreak$contacts),
-    c("part_name", "contact_name", "cnt_age", "cnt_gender",
-      "date_first_contact", "date_last_contact", "was_case", "status")
+    c("from", "to", "cnt_age", "cnt_gender", "date_first_contact",
+      "date_last_contact", "was_case", "status")
   )
 })
 
@@ -80,8 +80,8 @@ test_that("sim_outbreak works as expected with add_names = FALSE", {
   )
   expect_identical(
     colnames(outbreak$contacts),
-    c("part_name", "contact_name", "cnt_age", "cnt_gender",
-      "date_first_contact", "date_last_contact", "was_case", "status")
+    c("from", "to", "cnt_age", "cnt_gender", "date_first_contact",
+      "date_last_contact", "was_case", "status")
   )
 })
 
@@ -123,8 +123,8 @@ test_that("sim_outbreak works as expected with age-strat rates", {
   )
   expect_identical(
     colnames(outbreak$contacts),
-    c("part_name", "contact_name", "cnt_age", "cnt_gender",
-      "date_first_contact", "date_last_contact", "was_case", "status")
+    c("from", "to", "cnt_age", "cnt_gender", "date_first_contact",
+      "date_last_contact", "was_case", "status")
   )
 })
 
@@ -157,7 +157,7 @@ test_that("sim_outbreak works as expected with age structure", {
   )
   expect_identical(
     colnames(outbreak$contacts),
-    c("part_name", "contact_name", "cnt_age", "cnt_gender",
-      "date_first_contact", "date_last_contact", "was_case", "status")
+    c("from", "to", "cnt_age", "cnt_gender", "date_first_contact",
+      "date_last_contact", "was_case", "status")
   )
 })

--- a/vignettes/vis-linelist.Rmd
+++ b/vignettes/vis-linelist.Rmd
@@ -159,7 +159,7 @@ The benefit of using {epicontacts} is the same as {incidence2}, in the fact that
 
 _Advanced_
 
-Additionally, {epicontacts} provides access to network plotting from Javascript libraries via the [{visNetwork}](https://CRAN.R-project.org/package=visNetwork) and [{threejs}](https://CRAN.R-project.org/package=threejs) R packages.
+Additionally, {epicontacts} provides access to network plotting from JavaScript libraries via the [{visNetwork}](https://CRAN.R-project.org/package=visNetwork) and [{threejs}](https://CRAN.R-project.org/package=threejs) R packages.
 
 :::
 
@@ -212,7 +212,7 @@ To plot the contact network we can use the plotting method that is supplied by {
 
 ::: {.alert .alert-primary}
 
-If you are viewing this vignette on the web (or on a web browser) the graph below is interactive and will allow you to highlight individuals in the network using the dropdown menu, to zoom in and out of the plot by scrolling, and to move the network using the mouse to drag and drop.
+If you are viewing this vignette on the web (or on a web browser) the graph below is interactive and will allow you to highlight individuals in the network using the drop-down menu, to zoom in and out of the plot by scrolling, and to move the network using the mouse to drag and drop.
 
 :::
 

--- a/vignettes/vis-linelist.Rmd
+++ b/vignettes/vis-linelist.Rmd
@@ -26,6 +26,7 @@ Plotting can be useful to identify certain transmission dynamics and patterns in
 library(simulist)
 library(epiparameter)
 library(incidence2)
+library(epicontacts)
 ```
 
 First we load the required delay distributions using the {epiparameter} package.
@@ -145,6 +146,79 @@ plot(daily)
 Please see the [Age structured population vignette](age-struct-pop.html) for examples of how to plot the distribution of ages within a line list data set, including age pyramids. 
 
 The plotting code in vignettes is hidden by default, click the Code button with arrow to reveal the plotting code.
+
+## Visualising contact data
+
+::: {.alert .alert-info}
+
+This section of the vignette is based upon examples from the [{epicontacts} R package documentation](https://www.repidemicsconsortium.org/epicontacts/index.html) and the examples provided in the [The Epidemiological R Handbook chapter on transmission chains](https://epirhandbook.com/en/transmission-chains.html). We recommend going to the documentation of the {epicontacts} R package to see the all plotting and data wrangling functionality.
+
+:::
+
+Just as we utilised the `<incidence2>` class from the {incidence2} package to handle and plot incidence data, we are going to use the `<epicontacts>` class from the {epicontacts} R package to handle and plot epidemiological contact data.
+
+::: {.alert .alert-success}
+
+The benefit of using {epicontacts} is the same as {incidence2}, in the fact that a default plotting method is supplied by the package.
+
+_Advanced_
+
+Additionally, for {epicontacts} there is access to network plotting from Javascript libraries via the {visnetwork} and {threejs} R packages.
+
+:::
+
+The {epicontacts} function `make_epicontacts()` requires both the line list and contact table, so we will run the `sim_outbreak()` function to produce both. We will use the same epidemiological delay distributions that we used to simulate a line list above. We need an extra distribution to simulate an outbreak, a contact distribution (see the documentation `?sim_outbreak` for more detail). We create this distribution using the {epiparameter} package.
+
+```{r, create-contact-dist}
+contact_distribution <- epiparameter::epidist(
+  disease = "COVID-19",
+  epi_dist = "contact_distribution",
+  prob_distribution = "pois",
+  prob_distribution_params = c(l = 5)
+)
+```
+
+Now we can simulate an outbreak:
+
+```{r, sim-outbreak}
+set.seed(1)
+outbreak <- sim_outbreak(
+  R = 1.1,
+  serial_interval = serial_interval,
+  onset_to_hosp = onset_to_hosp,
+  onset_to_death = onset_to_death,
+  contact_distribution = contact_distribution
+)
+head(outbreak$linelist)
+head(outbreak$contacts)
+```
+
+Using the line list and contacts data simulated we can create the `<epicontacts>` object.
+
+```{r, create-epicontacts}
+epicontacts <- make_epicontacts(
+  linelist = outbreak$linelist, 
+  contacts = outbreak$contacts, 
+  id = "case_name", 
+  from = "from", 
+  to = "to", 
+  directed = TRUE
+)
+```
+
+The `<epicontacts>` object comes with a custom printing feature to see the data.
+
+```{r, print-epicontacts}
+epicontacts
+```
+
+To plot the contact network we can use the plotting method that is supplied by epicontacts and will be automatically recognised if the {epicontacts} package is loaded (as done above with `library(epicontacts)`).
+
+```{r, plot-epicontacts}
+plot(epicontacts)
+```
+
+There is also the option to plot the contacts network in 3D using the `epicontacts::graph3D()`. 
 
 ## Visualising other line list information
 

--- a/vignettes/vis-linelist.Rmd
+++ b/vignettes/vis-linelist.Rmd
@@ -14,7 +14,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-This vignette gives an overview of the ways to plot the line list data output from the `sim_linelist()` function.
+This vignette gives an overview of the ways to plot the line list and contacts data output from the `sim_linelist()` and `sim_outbreak()` functions.
 
 Plotting can be useful to identify certain transmission dynamics and patterns in the simulated data, or just to check that the simulated data looks as expected given how the simulation was parameterised.
 
@@ -95,7 +95,7 @@ daily <- incidence(x = linelist, date_index = "onset_date", interval = "daily")
 
 It is possible that not every date had the onset of symptoms, resulting in some dates missing entries. This is taken care of by the `complete_dates()` function in {incidence2}.
 
-```{r, complete-dates, fig.cap="Daily incidence of cases from symptom onset including days with zero cases.", fig.width = 8, fig.height = 5}
+```{r, complete-dates, fig.cap="Figure 1: Daily incidence of cases from symptom onset including days with zero cases.", fig.width = 8, fig.height = 5}
 # impute for days without cases
 daily <- complete_dates(daily)
 plot(daily)
@@ -103,14 +103,14 @@ plot(daily)
 
 Alternatively, incidence can be plotting weekly:
 
-```{r plot-weekly, fig.cap="Weekly incidence of cases from symptom onset", fig.width = 8, fig.height = 5}
+```{r plot-weekly, fig.cap="Figure 2: Weekly incidence of cases from symptom onset", fig.width = 8, fig.height = 5}
 weekly <- incidence(linelist, date_index = "onset_date", interval = "isoweek")
 plot(weekly)
 ```
 
 In order to check differences between a group in the line list data, for example gender, the `<incidence2>` data object can be recreated, specifying which columns to group by.
 
-```{r, group-by-gender, fig.cap="Weekly incidence of cases from symptom onset facetted by gender.", fig.width = 8, fig.height = 5}
+```{r, group-by-gender, fig.cap="Figure 3: Weekly incidence of cases from symptom onset facetted by gender.", fig.width = 8, fig.height = 5}
 weekly <- incidence(
   linelist,
   date_index = "onset_date",
@@ -122,7 +122,7 @@ plot(weekly)
  
 To visualise the onset, hospitalisation and death incidence in the same plot they can be jointly specified to the `date_index` argument of `incidence2::incidence()`. 
  
-```{r, plot-onset-hospitalisation, fig.cap="Daily incidence of cases from symptom onset and incidence of hospitalisations and deaths.", fig.width = 8, fig.height = 5}
+```{r, plot-onset-hospitalisation, fig.cap="Figure 4: Daily incidence of cases from symptom onset and incidence of hospitalisations and deaths.", fig.width = 8, fig.height = 5}
 daily <- incidence(
   linelist,
   date_index = c(
@@ -159,11 +159,11 @@ The benefit of using {epicontacts} is the same as {incidence2}, in the fact that
 
 _Advanced_
 
-Additionally, for {epicontacts} there is access to network plotting from Javascript libraries via the {visnetwork} and {threejs} R packages.
+Additionally, {epicontacts} provides access to network plotting from Javascript libraries via the [{visNetwork}](https://CRAN.R-project.org/package=visNetwork) and [{threejs}](https://CRAN.R-project.org/package=threejs) R packages.
 
 :::
 
-The {epicontacts} function `make_epicontacts()` requires both the line list and contact table, so we will run the `sim_outbreak()` function to produce both. We will use the same epidemiological delay distributions that we used to simulate a line list above. We need an extra distribution to simulate an outbreak, a contact distribution (see the documentation `?sim_outbreak` for more detail). We create this distribution using the {epiparameter} package.
+The {epicontacts} function `make_epicontacts()` requires both the line list and contacts table, so we will run the `sim_outbreak()` function to produce both. We will use the same epidemiological delay distributions that we used to simulate a line list above. We need an extra distribution to simulate an outbreak, a contact distribution (see the documentation `?sim_outbreak` for more detail). We create this distribution using the {epiparameter} package.
 
 ```{r, create-contact-dist}
 contact_distribution <- epiparameter::epidist(
@@ -208,9 +208,15 @@ The `<epicontacts>` object comes with a custom printing feature to see the data.
 epicontacts
 ```
 
-To plot the contact network we can use the plotting method that is supplied by epicontacts and will be automatically recognised if the {epicontacts} package is loaded (as done above with `library(epicontacts)`).
+To plot the contact network we can use the plotting method that is supplied by {epicontacts} and will be automatically recognised if the {epicontacts} package is loaded (as done above with `library(epicontacts)`).
 
-```{r, plot-epicontacts}
+::: {.alert .alert-primary}
+
+If you are viewing this vignette on the web (or on a web browser) the graph below is interactive and will allow you to highlight individuals in the network using the dropdown menu, to zoom in and out of the plot by scrolling, and to move the network using the mouse to drag and drop.
+
+:::
+
+```{r, plot-epicontacts, fig.cap="Figure 5: Contact network from infectious disease outbreak. This includes all contacts, i.e. individuals that were infected and not infected"}
 plot(epicontacts)
 ```
 

--- a/vignettes/vis-linelist.Rmd
+++ b/vignettes/vis-linelist.Rmd
@@ -193,11 +193,11 @@ Using the line list and contacts data simulated we can create the `<epicontacts>
 
 ```{r, create-epicontacts}
 epicontacts <- make_epicontacts(
-  linelist = outbreak$linelist, 
-  contacts = outbreak$contacts, 
-  id = "case_name", 
-  from = "from", 
-  to = "to", 
+  linelist = outbreak$linelist,
+  contacts = outbreak$contacts,
+  id = "case_name",
+  from = "from",
+  to = "to",
   directed = TRUE
 )
 ```

--- a/vignettes/vis-linelist.Rmd
+++ b/vignettes/vis-linelist.Rmd
@@ -1,10 +1,6 @@
 ---
 title: "Visualising simulated data"
-output: 
-  bookdown::html_vignette2:
-    code_folding: show
-pkgdown:
-  as_is: true
+output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Visualising simulated data}
   %\VignetteEngine{knitr::rmarkdown}


### PR DESCRIPTION
This PR adds a section to the `vis-linelist.Rmd` vignette on using the {epicontacts} package with {simulist}. 

The primary aim of the vignette section is to show how simulated outbreak data (line list + contacts table) can be plotted using the interactive functionality exported by {epicontacts}, but also shows how easily and interoperable the simulated outbreak data can be converted into a `<epicontacts>` object. The `part_name` and `contact_name` columns in the `$contacts` object output from `sim_contacts()` and `sim_outbreak()` have been changed to `from` and `to`, respectively, in order to match the naming in `<epicontacts>` and so that they are not silently converted by `epicontacts::make_epicontacts()`. 

{epicontacts} is added as a soft dependency (`Suggests`). 

The `CITATION` and `WORDLIST` files have been updated, as well as some of the tests.