### PR TITLE
Install {epiparameter} remote dependency from `main` branch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Suggests:
     spelling,
     testthat (>= 3.0.0)
 Remotes:
-    epiverse-trace/epiparameter@reexport_generics,
+    epiverse-trace/epiparameter,
     epiverse-trace/bpmodels
 Config/testthat/edition: 3
 Config/Needs/website:


### PR DESCRIPTION
This PR removes `@reexport_generics` from the {epiparameter} dependency in the `Remotes` section of the `DESCRIPTION`.