### PR TITLE
Add PR link to setup-options

### DIFF
--- a/tests/testthat/setup-options.R
+++ b/tests/testthat/setup-options.R
@@ -3,5 +3,6 @@
 options(
   warnPartialMatchAttr = TRUE,
   warnPartialMatchDollar = TRUE,
+  # https://github.com/CenterForAssessment/randomNames/pull/82
   warnPartialMatchArgs = FALSE # temp FALSE due to PartialMatchArgs in import
 )


### PR DESCRIPTION
This PR adds the link to the PR in a package dependency which will allow `warnPartialMatchArgs` to be set to `TRUE`.