### PR TITLE
Update `create_config()` to use dynamic dots

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -44,7 +44,7 @@ references:
   - name: R Core Team
   location:
     name: Vienna, Austria
-  year: '2023'
+  year: '2024'
   institution:
     name: R Foundation for Statistical Computing
 - type: software
@@ -58,7 +58,7 @@ references:
     given-names: Michel
     email: michellang@gmail.com
     orcid: https://orcid.org/0000-0001-9754-0393
-  year: '2023'
+  year: '2024'
 - type: software
   title: epiparameter
   abstract: 'epiparameter: Library of Epidemiological Parameters'
@@ -73,7 +73,7 @@ references:
     given-names: Adam
     email: adam.kucharski@lshtm.ac.uk
     orcid: https://orcid.org/0000-0001-8814-9421
-  year: '2023'
+  year: '2024'
 - type: software
   title: bpmodels
   abstract: 'bpmodels: Simulating and Analysing Transmission Chain Statistics using
@@ -93,7 +93,7 @@ references:
     given-names: Sebastian
     email: sebastian.funk@lshtm.ac.uk
     orcid: https://orcid.org/0000-0002-2842-3406
-  year: '2023'
+  year: '2024'
 - type: software
   title: randomNames
   abstract: 'randomNames: Generate Random Given and Surnames'
@@ -104,19 +104,33 @@ references:
   - family-names: Betebenner
     given-names: Damian W.
     email: dbetebenner@nciea.org
-  year: '2023'
+  year: '2024'
+- type: software
+  title: rlang
+  abstract: 'rlang: Functions for Base Types and Core R and ''Tidyverse'' Features'
+  notes: Imports
+  url: https://rlang.r-lib.org
+  repository: https://CRAN.R-project.org/package=rlang
+  authors:
+  - family-names: Henry
+    given-names: Lionel
+    email: lionel@posit.co
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  year: '2024'
 - type: software
   title: incidence2
   abstract: 'incidence2: Compute, Handle and Plot Incidence of Dated Events'
   notes: Suggests
-  url: https://github.com/reconverse/incidence2
+  url: https://www.reconverse.org/incidence2/
   repository: https://CRAN.R-project.org/package=incidence2
   authors:
   - family-names: Taylor
     given-names: Tim
     email: tim.taylor@hiddenelephants.co.uk
     orcid: https://orcid.org/0000-0002-8587-7113
-  year: '2023'
+  year: '2024'
   version: '>= 2.1.0'
 - type: software
   title: epicontacts
@@ -147,7 +161,7 @@ references:
   - family-names: Kamvar
     given-names: Zhian N.
     email: zkamvar@gmail.com
-  year: '2023'
+  year: '2024'
   version: '>= 1.1.3'
 - type: software
   title: knitr
@@ -160,7 +174,7 @@ references:
     given-names: Yihui
     email: xie@yihui.name
     orcid: https://orcid.org/0000-0003-0645-5666
-  year: '2023'
+  year: '2024'
 - type: software
   title: ggplot2
   abstract: 'ggplot2: Create Elegant Data Visualisations Using the Grammar of Graphics'
@@ -195,7 +209,7 @@ references:
   - family-names: Dunnington
     given-names: Dewey
     orcid: https://orcid.org/0000-0002-9415-4582
-  year: '2023'
+  year: '2024'
 - type: software
   title: bookdown
   abstract: 'bookdown: Authoring Books and Technical Documents with R Markdown'
@@ -207,7 +221,7 @@ references:
     given-names: Yihui
     email: xie@yihui.name
     orcid: https://orcid.org/0000-0003-0645-5666
-  year: '2023'
+  year: '2024'
 - type: software
   title: rmarkdown
   abstract: 'rmarkdown: Dynamic Documents for R'
@@ -250,7 +264,7 @@ references:
     given-names: Richard
     email: rich@posit.co
     orcid: https://orcid.org/0000-0003-3925-190X
-  year: '2023'
+  year: '2024'
 - type: software
   title: spelling
   abstract: 'spelling: Tools for Spell Checking in R'
@@ -265,7 +279,7 @@ references:
   - family-names: Hester
     given-names: Jim
     email: james.hester@rstudio.com
-  year: '2023'
+  year: '2024'
 - type: software
   title: testthat
   abstract: 'testthat: Unit Testing for R'
@@ -276,5 +290,5 @@ references:
   - family-names: Wickham
     given-names: Hadley
     email: hadley@posit.co
-  year: '2023'
+  year: '2024'
   version: '>= 3.0.0'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Imports:
     checkmate,
     epiparameter,
     bpmodels,
-    randomNames
+    randomNames,
+    rlang
 Suggests: 
     incidence2 (>= 2.1.0),
     epicontacts (>= 1.1.3),

--- a/R/create_config.R
+++ b/R/create_config.R
@@ -35,8 +35,18 @@ create_config <- function(...) {
     ct_distribution_params = c(mean = 25, sd = 2)
   )
 
-  # replace default args if in dots (remove args not for sim_linelist)
-  args <- utils::modifyList(args, list(...)[...names() %in% names(args)])
+  # capture dynamic dots
+  dots <- rlang::dots_list(..., .ignore_empty = "none", .homonyms = "error")
+  dots_names <- names(dots)
+
+  # check arguments in dots match arg list
+  stopifnot(
+    "Incorrect argument names supplied to create_config" =
+    all(dots_names %in% names(args))
+  )
+
+  # replace default args if in dots
+  args <- utils::modifyList(args, dots)
 
   # return args list
   args

--- a/R/create_config.R
+++ b/R/create_config.R
@@ -19,9 +19,9 @@
 #' arguments to accommodate these and the `config` argument keeps the function
 #' signature simpler and more readable.
 #'
-#'
-#' @param ... [dots] Named elements to replace default settings. Only if names
-#' match exactly are elements replaced.
+#' @param ... <[`dynamic-dots`][rlang::dyn-dots]> Named elements to replace
+#' default settings. Only if names match exactly are elements replaced,
+#' otherwise the function errors.
 #'
 #' @return A list of settings for [sim_linelist()]
 #' @export

--- a/man/create_config.Rd
+++ b/man/create_config.Rd
@@ -7,8 +7,9 @@
 create_config(...)
 }
 \arguments{
-\item{...}{\link{dots} Named elements to replace default settings. Only if names
-match exactly are elements replaced.}
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> Named elements to replace
+default settings. Only if names match exactly are elements replaced,
+otherwise the function errors.}
 }
 \value{
 A list of settings for \code{\link[=sim_linelist]{sim_linelist()}}

--- a/tests/testthat/test-create_config.R
+++ b/tests/testthat/test-create_config.R
@@ -27,9 +27,13 @@ test_that("create_config works as expected modifying element", {
   expect_identical(config$last_contact_distribution, "geom")
 })
 
-test_that("create_config works as expected misspelling modifying element", {
-  # test also checks that partial name matching of list names does not happen
-  config <- create_config(last_contact_dist = "geom")
+test_that("create_config works as expected with spliced list", {
+  config <- create_config(
+    !!!list(
+      ct_distribution = "lnorm",
+      ct_distribution_params = c(meanlog = 2, sdlog = 1)
+    )
+  )
   expect_type(config, type = "list")
   expect_length(config, 6)
   expect_named(
@@ -40,5 +44,65 @@ test_that("create_config works as expected misspelling modifying element", {
       "ct_distribution", "ct_distribution_params"
     )
   )
-  expect_identical(config$last_contact_distribution, "pois")
+  expect_identical(config$ct_distribution, "lnorm")
+  expect_identical(config$ct_distribution_params, c(meanlog = 2, sdlog = 1))
+
+  config <- create_config(
+    last_contact_distribution = "geom",
+    !!!list(
+      ct_distribution = "lnorm",
+      ct_distribution_params = c(meanlog = 2, sdlog = 1)
+    )
+  )
+  expect_type(config, type = "list")
+  expect_length(config, 6)
+  expect_named(
+    config,
+    c(
+      "last_contact_distribution", "last_contact_distribution_params",
+      "first_contact_distribution", "first_contact_distribution_params",
+      "ct_distribution", "ct_distribution_params"
+    )
+  )
+  expect_identical(config$last_contact_distribution, "geom")
+  expect_identical(config$ct_distribution, "lnorm")
+  expect_identical(config$ct_distribution_params, c(meanlog = 2, sdlog = 1))
+})
+
+test_that("create_config fails as expected misspelling modifying element", {
+  # test also checks that partial name matching of list names does not happen
+  expect_error(
+    create_config(last_contact_dist = "geom"),
+    regexp = "Incorrect argument names supplied to create_config"
+  )
+})
+
+test_that("create_config fails as expected with unnamed elements", {
+  expect_error(
+    create_config("lnorm", c(meanlog = 2, sdlog = 1)),
+    regexp = "Incorrect argument names supplied to create_config"
+  )
+  expect_error(
+    create_config(ct_distribution = "lnorm", c(meanlog = 2, sdlog = 1)),
+    regexp = "Incorrect argument names supplied to create_config"
+  )
+})
+
+test_that("create_config fails as expected with list input", {
+  expect_error(
+    create_config(
+      list(
+        ct_distribution = "lnorm",
+        ct_distribution_params = c(meanlog = 2, sdlog = 1)
+      )
+    ),
+    regexp = "Incorrect argument names supplied to create_config"
+  )
+  expect_error(
+    create_config(
+      list(ct_distribution = "lnorm"),
+      ct_distribution_params = c(meanlog = 2, sdlog = 1)
+    ),
+    regexp = "Incorrect argument names supplied to create_config"
+  )
 })


### PR DESCRIPTION
This PR updates the behaviour of `create_config()` as suggested in PR #33. The function is updated to use [dynamic dots](https://rlang.r-lib.org/reference/dyn-dots.html), and therefore the {rlang} dependency is added to the package. The behaviour of the function is changed to disallow silently swallowing arguments in the dots (`...`) and instead error if the argument names do not match the config argument list.

Tests for `create_config()` are updated and new tests are added to check new functionality. Function documentation is updated and dynamic dots is linked.