### PR TITLE
Refactor `add_cols` functions

### DIFF
--- a/R/create_linelist.R
+++ b/R/create_linelist.R
@@ -16,8 +16,8 @@
 #' ([sim_linelist()]) after setting the seed to 1 (`set.seed(1)`). The
 #' scenarios are before each function call, for example,
 #' `"pre_date_last_contact"` is the state of the line list prior to calling
-#' [.add_date_last_contact()], and `"pre_names"` is the state of the line list
-#' prior to calling [.add_names()].
+#' `.add_date_contact(..., contact_type = "last")`, and `"pre_names"` is the
+#' state of the line list prior to calling [.add_names()].
 #'
 #' ## Script to reproduce data:
 #' ```

--- a/R/sim_contacts_tbl.R
+++ b/R/sim_contacts_tbl.R
@@ -80,14 +80,16 @@
   )
 
   # add contact dates
-  other_contacts <- .add_date_last_contact(
+  other_contacts <- .add_date_contact(
     .data = other_contacts,
-    outbreak_start_date = outbreak_start_date,
+    contact_type = "last",
     distribution = config$last_contact_distribution,
-    config$last_contact_distribution_params
+    config$last_contact_distribution_params,
+    outbreak_start_date = outbreak_start_date
   )
-  other_contacts <- .add_date_first_contact(
+  other_contacts <- .add_date_contact(
     .data = other_contacts,
+    contact_type = "first",
     distribution = config$first_contact_distribution,
     config$first_contact_distribution_params
   )

--- a/R/sim_utils.R
+++ b/R/sim_utils.R
@@ -50,14 +50,16 @@ NULL
   chain <- chain[col_order]
   row.names(chain) <- NULL
 
-  chain <- .add_date_last_contact(
+  chain <- .add_date_contact(
     .data = chain,
-    outbreak_start_date = outbreak_start_date,
+    contact_type = "last",
     distribution = config$last_contact_distribution,
-    config$last_contact_distribution_params
+    config$last_contact_distribution_params,
+    outbreak_start_date = outbreak_start_date
   )
-  chain <- .add_date_first_contact(
+  chain <- .add_date_contact(
     .data = chain,
+    contact_type = "first",
     distribution = config$first_contact_distribution,
     config$first_contact_distribution_params
   )

--- a/man/dot-add_date.Rd
+++ b/man/dot-add_date.Rd
@@ -2,19 +2,17 @@
 % Please edit documentation in R/add_cols.R
 \name{.add_date}
 \alias{.add_date}
-\alias{.add_date_first_contact}
-\alias{.add_date_last_contact}
+\alias{.add_date_contact}
 \alias{.add_hospitalisation}
 \alias{.add_deaths}
 \title{Add event date as column to infectious history \verb{<data.frame>}}
 \usage{
-.add_date_first_contact(.data, distribution = c("pois", "geom"), ...)
-
-.add_date_last_contact(
+.add_date_contact(
   .data,
-  outbreak_start_date,
+  contact_type = c("first", "last"),
   distribution = c("pois", "geom"),
-  ...
+  ...,
+  outbreak_start_date
 )
 
 .add_hospitalisation(.data, onset_to_hosp, hosp_rate)
@@ -23,7 +21,10 @@
 }
 \arguments{
 \item{.data}{A \verb{<data.frame>} containing the infectious history from a
-branching process simulation}
+branching process simulation.}
+
+\item{contact_type}{A \code{character} with the type of contact, either first
+contact (\code{"first"}), or last contact (\code{"last"}).}
 
 \item{distribution}{A \code{character} with the name of the distribution,
 following the base R convention for distribution naming (e.g. Poisson

--- a/man/dot-create_linelist.Rd
+++ b/man/dot-create_linelist.Rd
@@ -32,8 +32,8 @@ of the  line list \verb{<data.frame>} are each stage of the simulation
 (\code{\link[=sim_linelist]{sim_linelist()}}) after setting the seed to 1 (\code{set.seed(1)}). The
 scenarios are before each function call, for example,
 \code{"pre_date_last_contact"} is the state of the line list prior to calling
-\code{\link[=.add_date_last_contact]{.add_date_last_contact()}}, and \code{"pre_names"} is the state of the line list
-prior to calling \code{\link[=.add_names]{.add_names()}}.
+\link{.add_date_contact(..., contact_type = "last")}, and \code{"pre_names"} is the
+state of the line list prior to calling \code{\link[=.add_names]{.add_names()}}.
 \subsection{Script to reproduce data:}{
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{# load data required to simulate line list

--- a/man/dot-create_linelist.Rd
+++ b/man/dot-create_linelist.Rd
@@ -32,7 +32,7 @@ of the  line list \verb{<data.frame>} are each stage of the simulation
 (\code{\link[=sim_linelist]{sim_linelist()}}) after setting the seed to 1 (\code{set.seed(1)}). The
 scenarios are before each function call, for example,
 \code{"pre_date_last_contact"} is the state of the line list prior to calling
-\link{.add_date_contact(..., contact_type = "last")}, and \code{"pre_names"} is the
+\code{.add_date_contact(..., contact_type = "last")}, and \code{"pre_names"} is the
 state of the line list prior to calling \code{\link[=.add_names]{.add_names()}}.
 \subsection{Script to reproduce data:}{
 

--- a/man/dot-sim_contacts_tbl.Rd
+++ b/man/dot-sim_contacts_tbl.Rd
@@ -15,7 +15,7 @@
 }
 \arguments{
 \item{.data}{A \verb{<data.frame>} containing the infectious history from a
-branching process simulation}
+branching process simulation.}
 
 \item{outbreak_start_date}{A \code{date} for the start of the outbreak.}
 

--- a/tests/testthat/test-add_cols.R
+++ b/tests/testthat/test-add_cols.R
@@ -15,10 +15,11 @@ suppressMessages({
   ))
 })
 
-test_that(".add_date_last_contact works as expected", {
+test_that(".add_date_contact works as expected with contact_type = 'last'", {
   ll <- .create_linelist(scenario = "pre_date_last_contact")
-  linelist <- .add_date_last_contact(
+  linelist <- .add_date_contact(
     .data = ll,
+    contact_type = "last",
     outbreak_start_date = as.Date("2023-01-01"),
     distribution = "pois",
     lambda = 3
@@ -29,10 +30,25 @@ test_that(".add_date_last_contact works as expected", {
   expect_identical(colnames(linelist), c(colnames(ll), "date_last_contact"))
 })
 
-test_that(".add_date_last_contact works as expected with different parameter", {
-  ll <- .create_linelist(scenario = "pre_date_last_contact")
-  linelist <- .add_date_last_contact(
+test_that(".add_date_contact works as expected with contact_type = 'first'", {
+  ll <- .create_linelist(scenario = "pre_date_first_contact")
+  linelist <- .add_date_contact(
     .data = ll,
+    contact_type = "first",
+    distribution = "pois",
+    lambda = 3
+  )
+  expect_s3_class(linelist, class = "data.frame")
+  expect_s3_class(linelist$date_first_contact, class = "Date")
+  expect_identical(dim(linelist), c(nrow(ll), ncol(ll) + 1L))
+  expect_identical(colnames(linelist), c(colnames(ll), "date_first_contact"))
+})
+
+test_that(".add_date_contact (last) works as expected with different param", {
+  ll <- .create_linelist(scenario = "pre_date_last_contact")
+  linelist <- .add_date_contact(
+    .data = ll,
+    contact_type = "last",
     outbreak_start_date = as.Date("2023-01-01"),
     distribution = "pois",
     lambda = 1
@@ -43,66 +59,11 @@ test_that(".add_date_last_contact works as expected with different parameter", {
   expect_identical(colnames(linelist), c(colnames(ll), "date_last_contact"))
 })
 
-test_that(".add_date_last_contact fails as expected", {
-  ll <- .create_linelist(scenario = "pre_date_last_contact")
-  expect_error(
-    .add_date_last_contact(
-      .data = ll,
-      outbreak_start_date = as.Date("2023-01-01"),
-      distribution = "nbinom",
-      size = 10,
-      prob = 0.5
-    ),
-    regexp = "(arg)*(should be)*(pois)"
-  )
-
-  expect_error(
-    .add_date_last_contact(
-      .data = ll,
-      outbreak_start_date = as.Date("2023-01-01"),
-      distribution = "pois"
-    ),
-    regexp = "Distribution parameters are missing, check config"
-  )
-
-  expect_error(
-    .add_date_last_contact(
-      .data = ll,
-      outbreak_start_date = as.Date("2023-01-01"),
-      distribution = "pois",
-      prob = 0.5
-    ),
-    regexp = "Incorrect parameterisation of distribution, check config"
-  )
-
-  expect_error(
-    .add_date_last_contact(
-      .data = ll,
-      outbreak_start_date = as.Date("2023-01-01"),
-      distribution = "pois",
-      lambda = NA
-    ),
-    regexp = "Incorrect parameterisation of distribution, check config"
-  )
-})
-
-test_that(".add_date_first_contact works as expected", {
+test_that(".add_date_contact (first) works as expected with different param", {
   ll <- .create_linelist(scenario = "pre_date_first_contact")
-  linelist <- .add_date_first_contact(
+  linelist <- .add_date_contact(
     .data = ll,
-    distribution = "pois",
-    lambda = 3
-  )
-  expect_s3_class(linelist, class = "data.frame")
-  expect_s3_class(linelist$date_first_contact, class = "Date")
-  expect_identical(dim(linelist), c(nrow(ll), ncol(ll) + 1L))
-  expect_identical(colnames(linelist), c(colnames(ll), "date_first_contact"))
-})
-
-test_that(".add_date_first_contact works as expected with different param", {
-  ll <- .create_linelist(scenario = "pre_date_first_contact")
-  linelist <- .add_date_first_contact(
-    .data = ll,
+    contact_type = "first",
     distribution = "pois",
     lambda = 1
   )
@@ -112,11 +73,13 @@ test_that(".add_date_first_contact works as expected with different param", {
   expect_identical(colnames(linelist), c(colnames(ll), "date_first_contact"))
 })
 
-test_that(".add_date_first_contact fails as expected", {
-  ll <- .create_linelist(scenario = "pre_date_first_contact")
+test_that(".add_date_contact fails as expected", {
+  ll <- .create_linelist(scenario = "pre_date_last_contact")
   expect_error(
-    .add_date_first_contact(
+    .add_date_contact(
       .data = ll,
+      contact_type = "last",
+      outbreak_start_date = as.Date("2023-01-01"),
       distribution = "nbinom",
       size = 10,
       prob = 0.5
@@ -125,16 +88,20 @@ test_that(".add_date_first_contact fails as expected", {
   )
 
   expect_error(
-    .add_date_first_contact(
+    .add_date_contact(
       .data = ll,
+      contact_type = "last",
+      outbreak_start_date = as.Date("2023-01-01"),
       distribution = "pois"
     ),
     regexp = "Distribution parameters are missing, check config"
   )
 
   expect_error(
-    .add_date_first_contact(
+    .add_date_contact(
       .data = ll,
+      contact_type = "last",
+      outbreak_start_date = as.Date("2023-01-01"),
       distribution = "pois",
       prob = 0.5
     ),
@@ -142,8 +109,10 @@ test_that(".add_date_first_contact fails as expected", {
   )
 
   expect_error(
-    .add_date_first_contact(
+    .add_date_contact(
       .data = ll,
+      contact_type = "last",
+      outbreak_start_date = as.Date("2023-01-01"),
       distribution = "pois",
       lambda = NA
     ),

--- a/tests/testthat/test-sim_outbreak.R
+++ b/tests/testthat/test-sim_outbreak.R
@@ -42,7 +42,7 @@ test_that("sim_outbreak works as expected", {
   expect_s3_class(outbreak$linelist, class = "data.frame")
   expect_s3_class(outbreak$contacts, class = "data.frame")
   expect_identical(dim(outbreak$linelist), c(42L, 10L))
-  expect_identical(dim(outbreak$contacts), c(163L, 8L))
+  expect_identical(dim(outbreak$contacts), c(168L, 8L))
   expect_identical(
     colnames(outbreak$linelist),
     c(
@@ -75,7 +75,7 @@ test_that("sim_outbreak works as expected with add_names = FALSE", {
   expect_s3_class(outbreak$linelist, class = "data.frame")
   expect_s3_class(outbreak$contacts, class = "data.frame")
   expect_identical(dim(outbreak$linelist), c(42L, 9L))
-  expect_identical(dim(outbreak$contacts), c(168L, 8L))
+  expect_identical(dim(outbreak$contacts), c(170L, 8L))
   expect_identical(
     colnames(outbreak$linelist),
     c(
@@ -122,7 +122,7 @@ test_that("sim_outbreak works as expected with age-strat rates", {
   expect_s3_class(outbreak$linelist, class = "data.frame")
   expect_s3_class(outbreak$contacts, class = "data.frame")
   expect_identical(dim(outbreak$linelist), c(42L, 10L))
-  expect_identical(dim(outbreak$contacts), c(177L, 8L))
+  expect_identical(dim(outbreak$contacts), c(168L, 8L))
   expect_identical(
     colnames(outbreak$linelist),
     c(
@@ -160,7 +160,7 @@ test_that("sim_outbreak works as expected with age structure", {
   expect_s3_class(outbreak$linelist, class = "data.frame")
   expect_s3_class(outbreak$contacts, class = "data.frame")
   expect_identical(dim(outbreak$linelist), c(42L, 10L))
-  expect_identical(dim(outbreak$contacts), c(177L, 8L))
+  expect_identical(dim(outbreak$contacts), c(176L, 8L))
   expect_identical(
     colnames(outbreak$linelist),
     c(


### PR DESCRIPTION
This PR updates the function categorised as `add_cols` (including `.add_date` and `.add_info` functions), with suggestions from PR #33. The updates include:

- Merging `.add_date_first_contact()` and `.add_date_last_contact()` and renaming to `.add_date_contact()` to reduce duplicated code. This new function contains the argument `contact_type` to select which type of date to add.
- Assignments from `tryCatch()` are now made outside the `tryCatch()` rather than within to remove implicit assignment. 
- Dots (`...`) are no longer stored in a variable and a comment is added to explain why dots are checked in a vector over a list.
- A typo in `apply_death_rate()` internal function is fixed.

Other functions that call `.add_date_contact()` are updated, documentation and tests are updated and duplicated tests for `.add_date_contact()` are removed.