### PR TITLE
Move number of line list cases inline in Visualising simulated data vignette

### DIFF
--- a/vignettes/vis-linelist.Rmd
+++ b/vignettes/vis-linelist.Rmd
@@ -67,10 +67,7 @@ linelist <- sim_linelist(
 )
 ```
 
-
-```{r num-cases, echo=FALSE}
-message("This line list contains ", nrow(linelist), " cases.")
-```
+This line list contains `r nrow(linelist)` cases.
 
 ## Visualising incidence of onset, hospitalisation and death
 


### PR DESCRIPTION
This PR updates the Visualising simulated data vignette (`vis-linelist.Rmd`) by moving a code chunk to calculate the number of cases/rows in a line list (with `echo = FALSE`) to be inline code (evaluated within the text). 