### PR TITLE
Remove running tests in parallel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,6 @@ Remotes:
     epiverse-trace/epiparameter,
     epiverse-trace/bpmodels
 Config/testthat/edition: 3
-Config/testthat/parallel: true
 Config/Needs/website:
     epiverse-trace/epiversetheme
 Language: en-GB


### PR DESCRIPTION
This PR remove the {testthat} configuration to run the unit tests in parallel. Parallel testing causes an `Rplots.pdf` to be produced (`tests/testthat/Rplots.pdf)` (both when running the tests and the check) which has to be manually deleted. When run in parallel, the tests take ~5 seconds. When `Config/testthat/parallel: true` is removed from the DESCRIPTION file the tests run in ~4 seconds and no files are produced as byproducts. 