### PR TITLE
Clarify documentation of `contact_distribution`

### DIFF
--- a/R/sim_contacts.R
+++ b/R/sim_contacts.R
@@ -3,8 +3,7 @@
 #' @inheritParams sim_linelist
 #' @param contact_distribution An `<epidist>` object or anonymous function for
 #' the contact distribution. This is similar to the offspring distribution,
-#' but describes the heterogeneity of all contact patterns, including contacts
-#' that go on to be infected or not infected.
+#' but describes the heterogeneity of contacts that are not infected.
 #' @param contact_tracing_status_probs A named `numeric` vector with the
 #' probability of each contact tracing status. The names of the vector must
 #' be `"under_followup"`, `"lost_to_followup"`, `"unknown"`. Values of each

--- a/man/dot-check_sim_input.Rd
+++ b/man/dot-check_sim_input.Rd
@@ -46,8 +46,7 @@ the onset to death delay distribution.}
 
 \item{contact_distribution}{An \verb{<epidist>} object or anonymous function for
 the contact distribution. This is similar to the offspring distribution,
-but describes the heterogeneity of all contact patterns, including contacts
-that go on to be infected or not infected.}
+but describes the heterogeneity of contacts that are not infected.}
 
 \item{add_names}{A \code{logical} boolean for whether to add names to each row
 of the line list. Default is \code{TRUE}.}

--- a/man/dot-sim_contacts_tbl.Rd
+++ b/man/dot-sim_contacts_tbl.Rd
@@ -21,8 +21,7 @@ branching process simulation.}
 
 \item{contact_distribution}{An \verb{<epidist>} object or anonymous function for
 the contact distribution. This is similar to the offspring distribution,
-but describes the heterogeneity of all contact patterns, including contacts
-that go on to be infected or not infected.}
+but describes the heterogeneity of contacts that are not infected.}
 
 \item{population_age}{Either a \code{numeric} vector with two elements or a
 \verb{<data.frame>} with age structure in the population. Use a \code{numeric} vector

--- a/man/sim_contacts.Rd
+++ b/man/sim_contacts.Rd
@@ -24,8 +24,7 @@ the serial interval.}
 
 \item{contact_distribution}{An \verb{<epidist>} object or anonymous function for
 the contact distribution. This is similar to the offspring distribution,
-but describes the heterogeneity of all contact patterns, including contacts
-that go on to be infected or not infected.}
+but describes the heterogeneity of contacts that are not infected.}
 
 \item{outbreak_start_date}{A \code{date} for the start of the outbreak.}
 

--- a/man/sim_outbreak.Rd
+++ b/man/sim_outbreak.Rd
@@ -38,8 +38,7 @@ the onset to death delay distribution.}
 
 \item{contact_distribution}{An \verb{<epidist>} object or anonymous function for
 the contact distribution. This is similar to the offspring distribution,
-but describes the heterogeneity of all contact patterns, including contacts
-that go on to be infected or not infected.}
+but describes the heterogeneity of contacts that are not infected.}
 
 \item{hosp_risk}{Either a single \code{numeric} for the hospitalisation risk of
 everyone in the population, or a \verb{<data.frame>} with age specific


### PR DESCRIPTION
This PR updates the function documentation for the `contact_distribution` argument, it related #35.