### PR TITLE
Add information to `add_ct` argument

### DIFF
--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -52,8 +52,10 @@
 #' @param outbreak_start_date A `date` for the start of the outbreak.
 #' @param add_names A `logical` boolean for whether to add names to each row
 #' of the line list. Default is `TRUE`.
-#' @param add_ct A `logical` boolean for whether to add Ct values to each row
-#' of the line list. Default is `TRUE`.
+#' @param add_ct A `logical` boolean for whether to add Ct values to each
+#' confirmed case and `NA` otherwise for each case in the line list.
+#' Default is `TRUE`. Ct refers to the Cycle threshold from a Real-time
+#' PCR or quantitative PCR (qPCR).
 #' @param min_outbreak_size A single `numeric` defining the minimum chain size
 #' for the simulated outbreak. Default is `10`. This can be increased when the
 #' function should simulate a larger outbreak.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -39,6 +39,7 @@ pkgdown
 Poisson
 Pratik
 prob
+qPCR
 randomNames
 RECON
 rmarkdown

--- a/man/dot-check_sim_input.Rd
+++ b/man/dot-check_sim_input.Rd
@@ -56,8 +56,10 @@ the onset to death delay distribution.}
 \item{add_names}{A \code{logical} boolean for whether to add names to each row
 of the line list. Default is \code{TRUE}.}
 
-\item{add_ct}{A \code{logical} boolean for whether to add Ct values to each row
-of the line list. Default is \code{TRUE}.}
+\item{add_ct}{A \code{logical} boolean for whether to add Ct values to each
+confirmed case and \code{NA} otherwise for each case in the line list.
+Default is \code{TRUE}. Ct refers to the Cycle threshold from a Real-time
+PCR or quantitative PCR (qPCR).}
 
 \item{case_type_probs}{A named \code{numeric} vector with the probability of
 each case type. The names of the vector must be \code{"suspected"}, \code{"probable"},

--- a/man/dot-sim_utils.Rd
+++ b/man/dot-sim_utils.Rd
@@ -89,8 +89,10 @@ for more information.}
 \item{add_names}{A \code{logical} boolean for whether to add names to each row
 of the line list. Default is \code{TRUE}.}
 
-\item{add_ct}{A \code{logical} boolean for whether to add Ct values to each row
-of the line list. Default is \code{TRUE}.}
+\item{add_ct}{A \code{logical} boolean for whether to add Ct values to each
+confirmed case and \code{NA} otherwise for each case in the line list.
+Default is \code{TRUE}. Ct refers to the Cycle threshold from a Real-time
+PCR or quantitative PCR (qPCR).}
 
 \item{case_type_probs}{A named \code{numeric} vector with the probability of
 each case type. The names of the vector must be \code{"suspected"}, \code{"probable"},

--- a/man/sim_linelist.Rd
+++ b/man/sim_linelist.Rd
@@ -65,8 +65,10 @@ for more information.}
 \item{add_names}{A \code{logical} boolean for whether to add names to each row
 of the line list. Default is \code{TRUE}.}
 
-\item{add_ct}{A \code{logical} boolean for whether to add Ct values to each row
-of the line list. Default is \code{TRUE}.}
+\item{add_ct}{A \code{logical} boolean for whether to add Ct values to each
+confirmed case and \code{NA} otherwise for each case in the line list.
+Default is \code{TRUE}. Ct refers to the Cycle threshold from a Real-time
+PCR or quantitative PCR (qPCR).}
 
 \item{min_outbreak_size}{A single \code{numeric} defining the minimum chain size
 for the simulated outbreak. Default is \code{10}. This can be increased when the

--- a/man/sim_outbreak.Rd
+++ b/man/sim_outbreak.Rd
@@ -67,8 +67,10 @@ for more information.}
 \item{add_names}{A \code{logical} boolean for whether to add names to each row
 of the line list. Default is \code{TRUE}.}
 
-\item{add_ct}{A \code{logical} boolean for whether to add Ct values to each row
-of the line list. Default is \code{TRUE}.}
+\item{add_ct}{A \code{logical} boolean for whether to add Ct values to each
+confirmed case and \code{NA} otherwise for each case in the line list.
+Default is \code{TRUE}. Ct refers to the Cycle threshold from a Real-time
+PCR or quantitative PCR (qPCR).}
 
 \item{min_outbreak_size}{A single \code{numeric} defining the minimum chain size
 for the simulated outbreak. Default is \code{10}. This can be increased when the


### PR DESCRIPTION
This PR addresses #59 by adding the suggested information to the `add_ct` argument documentation.

Thanks @avallecam for the suggestion.