### PR TITLE
Set `<data.frame>` `row.names` to default before returning 

### DIFF
--- a/R/sim_contacts.R
+++ b/R/sim_contacts.R
@@ -81,6 +81,7 @@ sim_contacts <- function(contact_distribution,
     .data = chain,
     contact_tracing_status_probs = contact_tracing_status_probs
   )
+  row.names(chain) <- NULL
 
   # return line list
   contacts

--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -240,6 +240,7 @@ sim_linelist <- function(contact_distribution,
 
   linelist$chain <- linelist$chain[linelist$chain$infected == "infected", ]
   chain <- linelist$chain[, linelist$cols]
+  row.names(chain) <- NULL
 
   # return line list
   chain

--- a/R/sim_outbreak.R
+++ b/R/sim_outbreak.R
@@ -170,6 +170,7 @@ sim_outbreak <- function(contact_distribution,
 
   linelist$chain <- linelist$chain[linelist$chain$infected == "infected", ]
   chain <- linelist$chain[, linelist$cols]
+  row.names(chain) <- NULL
 
   # return outbreak data
   list(


### PR DESCRIPTION
This PR removes the row names before returning line list and contact table data from `sim_linelist()`, `sim_contacts()` and `sim_outbreak()`, which ensures the `row.names` are `1:nrow`. Prior to this the row names would be a non-consecutive series of numbers due to filtering rows that are not infected, in the case of line list data, or not start at 1, in the case of contacts table that did not include the index case.