### PR TITLE
Add transmission network to visualisation vignette

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -4,6 +4,7 @@ linters: all_linters(
     implicit_integer_linter = NULL,
     extraction_operator_linter = NULL,
     todo_comment_linter = NULL,
+    library_call_linter = NULL,
     undesirable_function_linter(
       modify_defaults(
         default_undesirable_functions,

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -186,6 +186,30 @@ references:
     orcid: https://orcid.org/0000-0003-0645-5666
   year: '2024'
 - type: software
+  title: dplyr
+  abstract: 'dplyr: A Grammar of Data Manipulation'
+  notes: Suggests
+  url: https://dplyr.tidyverse.org
+  repository: https://CRAN.R-project.org/package=dplyr
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+    orcid: https://orcid.org/0000-0003-4757-117X
+  - family-names: François
+    given-names: Romain
+    orcid: https://orcid.org/0000-0002-2444-4226
+  - family-names: Henry
+    given-names: Lionel
+  - family-names: Müller
+    given-names: Kirill
+    orcid: https://orcid.org/0000-0002-1416-3412
+  - family-names: Vaughan
+    given-names: Davis
+    email: davis@posit.co
+    orcid: https://orcid.org/0000-0003-4777-038X
+  year: '2024'
+- type: software
   title: ggplot2
   abstract: 'ggplot2: Create Elegant Data Visualisations Using the Grammar of Graphics'
   notes: Suggests

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Suggests:
     incidence2 (>= 2.1.0),
     epicontacts (>= 1.1.3),
     knitr,
+    dplyr,
     ggplot2,
     bookdown,
     rmarkdown,

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -51,7 +51,9 @@ socialmixr
 st
 stochasticity
 svg
+tabset
 testthat
 threejs
+Tidyverse
 visNetwork
 yaml

--- a/vignettes/vis-linelist.Rmd
+++ b/vignettes/vis-linelist.Rmd
@@ -226,6 +226,50 @@ plot(epicontacts)
 
 There is also the option to plot the contacts network in 3D using the `epicontacts::graph3D()`. 
 
+By default the outbreak simulated by `sim_outbreak()` contains contacts of cases that were not infected. These are shown in the previous network plot by terminal nodes that do not pass on infection to other individuals (note that terminal nodes can also be infected individuals that did not infect anybody else, either due to not have any contacts or due to the probabilistic nature of infection transmission). Here we show how to subset the contacts table in order to only plot the transmission network of cases from the outbreak. 
+
+### Subset contact network to transmission network {.tabset}
+
+#### Base R
+
+```{r, subset-linelist-base-r}
+outbreak$contacts <- outbreak$contacts[outbreak$contacts$was_case == "Y", ]
+```
+
+#### Tidyverse
+
+```{r, subset-linelist-tidyverse, message=FALSE}
+library(dplyr)
+outbreak$contacts <- outbreak$contacts %>%
+  dplyr::filter(was_case == "Y")
+```
+
+## {-}
+
+```{r, inspect-data}
+head(outbreak$linelist)
+head(outbreak$contacts)
+```
+
+```{r, create-cases-epicontacts}
+epicontacts <- make_epicontacts(
+  linelist = outbreak$linelist,
+  contacts = outbreak$contacts,
+  id = "case_name",
+  from = "from",
+  to = "to",
+  directed = TRUE
+)
+```
+
+```{r, print-cases-epicontacts}
+epicontacts
+```
+
+```{r, plot-cases-epicontacts, fig.cap="Figure 6: Transmission chain from infectious disease outbreak. This includes only individuals that were infected, including confirmed, probable and suspected cases."}
+plot(epicontacts)
+```
+
 ## Visualising other line list information
 
 If there are other aspects of line list data that can be plotted and you would like to them added to this vignette please make an [issue](https://github.com/epiverse-trace/simulist/issues) or [pull request](https://github.com/epiverse-trace/simulist/pulls).


### PR DESCRIPTION
This PR adds information to the data visualisation (`vis-linelist.Rmd`) vignette on how to subset the contacts table to only includes infected individuals and plot the resulting transmission network using {epicontacts}. This addition includes tabs for subsetting with base R and tidyverse, and so takes on {dplyr} as a suggested dependency.