### PR TITLE
Fix ORCID links

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,15 +3,15 @@ Title: Tools to Simulate Line List and Contacts Data
 Version: 0.1.0.9000
 Authors@R: c(
     person(given = "Joshua W.", family = "Lambert", email = "joshua.lambert@lshtm.ac.uk", role = c("aut", "cre", "cph"),
-           comment = c(ORCID = "https://orcid.org/0000-0001-5218-3046")),
+           comment = c(ORCID = "0000-0001-5218-3046")),
     person(given = "Carmen", family = "Tamayo", email = "carmen.tamayo-cuartero@lshtm.ac.uk", role = c("aut"),
-           comment = c(ORCID = "https://orcid.org/0000-0003-4184-2864")),
+           comment = c(ORCID = "0000-0003-4184-2864")),
     person(given = "Hugo", family = "Gruson", email = "hugo@data.org", role = c("ctb", "rev"),
-           comment = c(ORCID = "https://orcid.org/0000-0002-4094-1476")),
+           comment = c(ORCID = "0000-0002-4094-1476")),
     person(given = "Pratik R.", family = "Gupte", role = c("ctb"), email = "pratik.gupte@lshtm.ac.uk",
-           comment = c(ORCID = "https://orcid.org/0000-0001-5294-7819")),
+           comment = c(ORCID = "0000-0001-5294-7819")),
     person(given = "Adam", family = "Kucharski", role = c("rev"), email = "adam.kucharski@lshtm.ac.uk", 
-           comment = c(ORCID = "https://orcid.org/0000-0001-8814-9421"))
+           comment = c(ORCID = "0000-0001-8814-9421"))
            )
 Description: Tools to simulate raw case data for an epidemic in the form of 
     line lists and contacts using a branching process.


### PR DESCRIPTION
This PR fixes the ORCID links for the `pkgdown` page. See also upstream change to the template - https://github.com/epiverse-trace/packagetemplate/pull/126