### PR TITLE
Add comment when defining infections

### DIFF
--- a/R/sim_network_bp.R
+++ b/R/sim_network_bp.R
@@ -110,6 +110,8 @@
   # remove unused IDs
   id <- seq_along(generation)
   infected <- infected[seq_along(generation)]
+  # if the outcome names are changed, please find and update all
+  # logical expressions, e.g., x == "infected" or x == "contact"
   infected <- ifelse(test = infected, yes = "infected", no = "contact")
   time <- time[seq_along(generation)]
 


### PR DESCRIPTION
This PR addresses a comment from the package review PR #73 on the definition and later use of the `infected` column of the line list data. It is used at several points in the simulation in conditional statements such as `.data$infected == "infected"` which could produce erroneous results if the character strings in the columns does not exactly match `"infected"`. A comment has been added to `.sim_network_bp()` to remind developers that if the definition of the infections or contacts (`infected <- ifelse(test = infected, yes = "infected", no = "contact")`) is changed to also update the conditional statements.