### PR TITLE
Normalise `DESCRIPTION`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -67,17 +67,6 @@ references:
     name: R Foundation for Statistical Computing
   version: '>= 3.6.0'
 - type: software
-  title: stats
-  abstract: 'R: A Language and Environment for Statistical Computing'
-  notes: Imports
-  authors:
-  - name: R Core Team
-  location:
-    name: Vienna, Austria
-  year: '2024'
-  institution:
-    name: R Foundation for Statistical Computing
-- type: software
   title: checkmate
   abstract: 'checkmate: Fast and Versatile Argument Checks'
   notes: Imports
@@ -130,18 +119,52 @@ references:
     email: hadley@posit.co
   year: '2024'
 - type: software
-  title: incidence2
-  abstract: 'incidence2: Compute, Handle and Plot Incidence of Dated Events'
-  notes: Suggests
-  url: https://www.reconverse.org/incidence2/
-  repository: https://CRAN.R-project.org/package=incidence2
+  title: stats
+  abstract: 'R: A Language and Environment for Statistical Computing'
+  notes: Imports
   authors:
-  - family-names: Taylor
-    given-names: Tim
-    email: tim.taylor@hiddenelephants.co.uk
-    orcid: https://orcid.org/0000-0002-8587-7113
+  - name: R Core Team
+  location:
+    name: Vienna, Austria
   year: '2024'
-  version: '>= 2.1.0'
+  institution:
+    name: R Foundation for Statistical Computing
+- type: software
+  title: bookdown
+  abstract: 'bookdown: Authoring Books and Technical Documents with R Markdown'
+  notes: Suggests
+  url: https://pkgs.rstudio.com/bookdown/
+  repository: https://CRAN.R-project.org/package=bookdown
+  authors:
+  - family-names: Xie
+    given-names: Yihui
+    email: xie@yihui.name
+    orcid: https://orcid.org/0000-0003-0645-5666
+  year: '2024'
+- type: software
+  title: dplyr
+  abstract: 'dplyr: A Grammar of Data Manipulation'
+  notes: Suggests
+  url: https://dplyr.tidyverse.org
+  repository: https://CRAN.R-project.org/package=dplyr
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+    orcid: https://orcid.org/0000-0003-4757-117X
+  - family-names: François
+    given-names: Romain
+    orcid: https://orcid.org/0000-0002-2444-4226
+  - family-names: Henry
+    given-names: Lionel
+  - family-names: Müller
+    given-names: Kirill
+    orcid: https://orcid.org/0000-0002-1416-3412
+  - family-names: Vaughan
+    given-names: Davis
+    email: davis@posit.co
+    orcid: https://orcid.org/0000-0003-4777-038X
+  year: '2024'
 - type: software
   title: epicontacts
   abstract: 'epicontacts: Handling, Visualisation and Analysis of Epidemiological
@@ -173,42 +196,6 @@ references:
     email: zkamvar@gmail.com
   year: '2024'
   version: '>= 1.1.3'
-- type: software
-  title: knitr
-  abstract: 'knitr: A General-Purpose Package for Dynamic Report Generation in R'
-  notes: Suggests
-  url: https://yihui.org/knitr/
-  repository: https://CRAN.R-project.org/package=knitr
-  authors:
-  - family-names: Xie
-    given-names: Yihui
-    email: xie@yihui.name
-    orcid: https://orcid.org/0000-0003-0645-5666
-  year: '2024'
-- type: software
-  title: dplyr
-  abstract: 'dplyr: A Grammar of Data Manipulation'
-  notes: Suggests
-  url: https://dplyr.tidyverse.org
-  repository: https://CRAN.R-project.org/package=dplyr
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-    orcid: https://orcid.org/0000-0003-4757-117X
-  - family-names: François
-    given-names: Romain
-    orcid: https://orcid.org/0000-0002-2444-4226
-  - family-names: Henry
-    given-names: Lionel
-  - family-names: Müller
-    given-names: Kirill
-    orcid: https://orcid.org/0000-0002-1416-3412
-  - family-names: Vaughan
-    given-names: Davis
-    email: davis@posit.co
-    orcid: https://orcid.org/0000-0003-4777-038X
-  year: '2024'
 - type: software
   title: ggplot2
   abstract: 'ggplot2: Create Elegant Data Visualisations Using the Grammar of Graphics'
@@ -245,11 +232,24 @@ references:
     orcid: https://orcid.org/0000-0002-9415-4582
   year: '2024'
 - type: software
-  title: bookdown
-  abstract: 'bookdown: Authoring Books and Technical Documents with R Markdown'
+  title: incidence2
+  abstract: 'incidence2: Compute, Handle and Plot Incidence of Dated Events'
   notes: Suggests
-  url: https://pkgs.rstudio.com/bookdown/
-  repository: https://CRAN.R-project.org/package=bookdown
+  url: https://www.reconverse.org/incidence2/
+  repository: https://CRAN.R-project.org/package=incidence2
+  authors:
+  - family-names: Taylor
+    given-names: Tim
+    email: tim.taylor@hiddenelephants.co.uk
+    orcid: https://orcid.org/0000-0002-8587-7113
+  year: '2024'
+  version: '>= 2.1.0'
+- type: software
+  title: knitr
+  abstract: 'knitr: A General-Purpose Package for Dynamic Report Generation in R'
+  notes: Suggests
+  url: https://yihui.org/knitr/
+  repository: https://CRAN.R-project.org/package=knitr
   authors:
   - family-names: Xie
     given-names: Yihui

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,47 +2,48 @@ Package: simulist
 Title: Tools to Simulate Line List and Contacts Data
 Version: 0.1.0.9000
 Authors@R: c(
-    person(given = "Joshua W.", family = "Lambert", email = "joshua.lambert@lshtm.ac.uk", role = c("aut", "cre", "cph"),
+    person("Joshua W.", "Lambert", , "joshua.lambert@lshtm.ac.uk", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-5218-3046")),
-    person(given = "Carmen", family = "Tamayo", email = "carmen.tamayo-cuartero@lshtm.ac.uk", role = c("aut"),
+    person("Carmen", "Tamayo", , "carmen.tamayo-cuartero@lshtm.ac.uk", role = "aut",
            comment = c(ORCID = "0000-0003-4184-2864")),
-    person(given = "Hugo", family = "Gruson", email = "hugo@data.org", role = c("ctb", "rev"),
+    person("Hugo", "Gruson", , "hugo@data.org", role = c("ctb", "rev"),
            comment = c(ORCID = "0000-0002-4094-1476")),
-    person(given = "Pratik R.", family = "Gupte", role = c("ctb"), email = "pratik.gupte@lshtm.ac.uk",
+    person("Pratik R.", "Gupte", , "pratik.gupte@lshtm.ac.uk", role = "ctb",
            comment = c(ORCID = "0000-0001-5294-7819")),
-    person(given = "Adam", family = "Kucharski", role = c("rev"), email = "adam.kucharski@lshtm.ac.uk", 
+    person("Adam", "Kucharski", , "adam.kucharski@lshtm.ac.uk", role = "rev",
            comment = c(ORCID = "0000-0001-8814-9421"))
-           )
-Description: Tools to simulate raw case data for an epidemic in the form of 
-    line lists and contacts using a branching process.
+  )
+Description: Tools to simulate raw case data for an epidemic in the form
+    of line lists and contacts using a branching process.
 License: MIT + file LICENSE
-URL: https://github.com/epiverse-trace/simulist, https://epiverse-trace.github.io/simulist/
+URL: https://github.com/epiverse-trace/simulist,
+    https://epiverse-trace.github.io/simulist/
 BugReports: https://github.com/epiverse-trace/simulist/issues
-Encoding: UTF-8
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
 Depends: 
     R (>= 3.6.0)
 Imports:
-    stats,
     checkmate,
     epiparameter,
     randomNames,
-    rlang
+    rlang,
+    stats
 Suggests: 
-    incidence2 (>= 2.1.0),
-    epicontacts (>= 1.1.3),
-    knitr,
-    dplyr,
-    ggplot2,
     bookdown,
+    dplyr,
+    epicontacts (>= 1.1.3),
+    ggplot2,
+    incidence2 (>= 2.1.0),
+    knitr,
     rmarkdown,
     spelling,
     testthat (>= 3.0.0)
+VignetteBuilder: 
+    knitr
 Remotes:
     epiverse-trace/epiparameter
+Config/Needs/website:epiverse-trace/epiversetheme
 Config/testthat/edition: 3
-Config/Needs/website:
-    epiverse-trace/epiversetheme
+Encoding: UTF-8
 Language: en-GB
-VignetteBuilder: knitr
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.2.3


### PR DESCRIPTION
This PR addresses a comment from the package review #73 to normalise the `DESCRIPTION` file using {desc} (`desc_normalize()`).