### PR TITLE
Name and sort `population_age` vector

### DIFF
--- a/R/checkers.R
+++ b/R/checkers.R
@@ -12,9 +12,9 @@
     "column names should be 'age_limit' & 'risk'" =
       setequal(c("age_limit", "risk"), colnames(x)),
     "minimum age of lowest age group should match lower age range" =
-      age_range[1] == min(x$age_limit),
+      age_range[["lower"]] == min(x$age_limit),
     "lower bound of oldest age group must be lower than highest age range" =
-      age_range[2] > max(x$age_limit),
+      age_range[["upper"]] > max(x$age_limit),
     "age limit or risk cannot be NA or NaN" =
       !anyNA(x),
     "risk should be between 0 and 1" =
@@ -27,7 +27,7 @@
   x <- x[order(x$age_limit), ]
 
   # format risk data frame
-  age_range_ <- age_range[1]:age_range[2]
+  age_range_ <- age_range[["lower"]]:age_range[["upper"]]
   # findInterval inclusive/exclusive bound rules match age bracket
   age_groups <- unname(split(age_range_, findInterval(age_range_, x$age_limit)))
 

--- a/R/sim_contacts.R
+++ b/R/sim_contacts.R
@@ -67,14 +67,9 @@ sim_contacts <- function(contact_distribution,
 
   if (is.data.frame(population_age)) {
     population_age <- .check_age_df(population_age)
-    age_range <- c(
-      lower = min(population_age[, "min_age"]),
-      upper = max(population_age[, "max_age"])
-    )
   } else {
     population_age <- sort(population_age)
     names(population_age) <- c("lower", "upper")
-    age_range <- population_age
   }
 
   contacts <- .sim_internal(

--- a/R/sim_contacts.R
+++ b/R/sim_contacts.R
@@ -65,6 +65,18 @@ sim_contacts <- function(contact_distribution,
     population_age = population_age
   )
 
+  if (is.data.frame(population_age)) {
+    population_age <- .check_age_df(population_age)
+    age_range <- c(
+      lower = min(population_age[, "min_age"]),
+      upper = max(population_age[, "max_age"])
+    )
+  } else {
+    population_age <- sort(population_age)
+    names(population_age) <- c("lower", "upper")
+    age_range <- population_age
+  }
+
   contacts <- .sim_internal(
     sim_type = "contacts",
     contact_distribution = contact_distribution,

--- a/R/sim_internal.R
+++ b/R/sim_internal.R
@@ -96,7 +96,7 @@
     )
   } else {
     .data$age <- sample(
-      population_age[1]:population_age[2],
+      population_age[["lower"]]:population_age[["upper"]],
       size = nrow(.data),
       replace = TRUE
     )

--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -189,10 +189,12 @@ sim_linelist <- function(contact_distribution,
   if (is.data.frame(population_age)) {
     population_age <- .check_age_df(population_age)
     age_range <- c(
-      min(population_age[, "min_age"]),
-      max(population_age[, "max_age"])
+      lower = min(population_age[, "min_age"]),
+      upper = max(population_age[, "max_age"])
     )
   } else {
+    population_age <- sort(population_age)
+    names(population_age) <- c("lower", "upper")
     age_range <- population_age
   }
   if (is.data.frame(hosp_risk)) {

--- a/R/sim_outbreak.R
+++ b/R/sim_outbreak.R
@@ -114,10 +114,12 @@ sim_outbreak <- function(contact_distribution,
   if (is.data.frame(population_age)) {
     population_age <- .check_age_df(population_age)
     age_range <- c(
-      min(population_age[, "min_age"]),
-      max(population_age[, "max_age"])
+      lower = min(population_age[, "min_age"]),
+      upper = max(population_age[, "max_age"])
     )
   } else {
+    population_age <- sort(population_age)
+    names(population_age) <- c("lower", "upper")
     age_range <- population_age
   }
   if (is.data.frame(hosp_risk)) {

--- a/tests/testthat/_snaps/sim_contacts.md
+++ b/tests/testthat/_snaps/sim_contacts.md
@@ -237,3 +237,82 @@
       34        2023-01-12        N   under_followup
       35        2023-01-07        Y             case
 
+# sim_contacts works as expected with age structure
+
+    Code
+      sim_contacts(contact_distribution = contact_distribution, contact_interval = contact_interval,
+        prob_infect = 0.5, population_age = age_struct)
+    Output
+                        from                  to age sex date_first_contact
+      1         Shelbi Vitry     Kathryn Lapitan  76   f         2023-01-02
+      2         Shelbi Vitry      Larissa Wisham  65   f         2023-01-04
+      3      Kathryn Lapitan      Preston Miller  35   m         2023-01-05
+      4      Kathryn Lapitan          Derek Choi   9   m         2023-01-03
+      5      Kathryn Lapitan Chloe Moreno-Ferrel  89   f         2023-01-02
+      6      Kathryn Lapitan        Lisa Johnson  36   f         2022-12-31
+      7           Derek Choi         Jacob Begay  16   m         2023-01-01
+      8           Derek Choi  Mia Yokota-Stroman  82   f         2022-12-29
+      9  Chloe Moreno-Ferrel       Deja Elizondo  27   f         2023-01-04
+      10 Chloe Moreno-Ferrel         Jacob Glaub  35   m         2023-01-02
+      11 Chloe Moreno-Ferrel      Shandre Ostrom   2   f         2023-01-01
+      12         Jacob Begay         Kylie Hicar   6   f         2022-12-29
+      13         Jacob Begay        Woo Bin Park  23   m         2022-12-31
+      14         Jacob Begay       Jayson Brooks  90   m         2023-01-06
+      15         Jacob Begay         Mario Jones  47   m         2023-01-03
+      16         Jacob Begay             Tai Ali  64   m         2022-12-30
+      17       Deja Elizondo    Ronald Burgdorff  16   m         2023-01-03
+      18         Mario Jones        Rodrigo Leal  85   m         2023-01-03
+      19        Rodrigo Leal        Kelia Gentry  42   f         2023-01-02
+      20        Rodrigo Leal          Ana Romero  26   f         2023-01-04
+      21        Rodrigo Leal           Thao Pham  57   f         2023-01-03
+      22           Thao Pham    Nabeela al-Nazir  89   f         2023-01-03
+      23    Nabeela al-Nazir        David Nguyen  21   m         2023-01-02
+      24    Nabeela al-Nazir       Joshua Valeta  90   m         2023-01-03
+      25       Joshua Valeta         Evan Browne  48   m         2023-01-02
+      26         Evan Browne        Jordan Brown  62   m         2023-01-03
+      27         Evan Browne       Leighton Chun  20   m         2023-01-03
+      28         Evan Browne    Raymond Martinez   4   m         2022-12-29
+      29        Jordan Brown       Jalen Thrower   9   m         2023-01-04
+      30        Jordan Brown   Cleevens Smith Jr  29   m         2023-01-01
+      31        Jordan Brown      Saleel el-Dada  32   m         2022-12-31
+      32        Jordan Brown       Lashon Butler  82   f         2023-01-01
+      33       Jalen Thrower  Suhail al-Abdallah  75   m         2023-01-06
+      34       Jalen Thrower       Alison Truong   2   f         2023-01-08
+      35   Cleevens Smith Jr         Emma Weaver  79   f         2023-01-03
+         date_last_contact was_case           status
+      1         2023-01-05        Y             case
+      2         2023-01-07        N   under_followup
+      3         2023-01-08        N   under_followup
+      4         2023-01-04        Y             case
+      5         2023-01-04        Y             case
+      6         2023-01-03        N   under_followup
+      7         2023-01-03        Y             case
+      8         2023-01-04        Y             case
+      9         2023-01-07        Y             case
+      10        2023-01-04        N   under_followup
+      11        2023-01-03        N lost_to_followup
+      12        2023-01-02        N   under_followup
+      13        2023-01-04        N   under_followup
+      14        2023-01-07        N          unknown
+      15        2023-01-04        Y             case
+      16        2023-01-03        N lost_to_followup
+      17        2023-01-06        N   under_followup
+      18        2023-01-04        Y             case
+      19        2023-01-03        N lost_to_followup
+      20        2023-01-05        N   under_followup
+      21        2023-01-05        Y             case
+      22        2023-01-04        Y             case
+      23        2023-01-04        N   under_followup
+      24        2023-01-04        Y             case
+      25        2023-01-04        Y             case
+      26        2023-01-04        Y             case
+      27        2023-01-06        N   under_followup
+      28        2023-01-02        N   under_followup
+      29        2023-01-04        Y             case
+      30        2023-01-04        Y             case
+      31        2023-01-05        N lost_to_followup
+      32        2023-01-03        N   under_followup
+      33        2023-01-06        N lost_to_followup
+      34        2023-01-09        N   under_followup
+      35        2023-01-05        Y             case
+

--- a/tests/testthat/test-checkers.R
+++ b/tests/testthat/test-checkers.R
@@ -3,7 +3,10 @@ test_that(".check_risk_df works as expected", {
     age_limit = c(1, 5, 80),
     risk = c(0.1, 0.05, 0.2)
   )
-  age_dep_hosp_risk <- .check_risk_df(age_dep_hosp_risk, age_range = c(1, 90))
+  age_dep_hosp_risk <- .check_risk_df(
+    age_dep_hosp_risk,
+    age_range = c(lower = 1, upper = 90)
+  )
   expect_s3_class(age_dep_hosp_risk, class = "data.frame")
   expect_identical(dim(age_dep_hosp_risk), c(3L, 3L))
   expect_identical(colnames(age_dep_hosp_risk), c("min_age", "max_age", "risk"))
@@ -19,7 +22,7 @@ test_that(".check_risk_df fails as expected", {
     hosp_risk = c(0.1, 0.05, 0.2)
   )
   expect_error(
-    .check_risk_df(age_dep_hosp_risk, age_range = c(1, 91)),
+    .check_risk_df(age_dep_hosp_risk, age_range = c(lower = 1, upper = 91)),
     regexp = "column names should be 'age_limit' & 'risk'"
   )
 
@@ -28,7 +31,7 @@ test_that(".check_risk_df fails as expected", {
     risk = c(0.1, 0.05, 0.2)
   )
   expect_error(
-    .check_risk_df(age_dep_hosp_risk, age_range = c(1, 90)),
+    .check_risk_df(age_dep_hosp_risk, age_range = c(lower = 1, upper = 90)),
     regexp = "minimum age of lowest age group should match lower age range"
   )
 
@@ -37,7 +40,7 @@ test_that(".check_risk_df fails as expected", {
     risk = c(0.1, 0.05, 0.2)
   )
   expect_error(
-    .check_risk_df(age_dep_hosp_risk, age_range = c(1, 90)),
+    .check_risk_df(age_dep_hosp_risk, age_range = c(lower = 1, upper = 90)),
     regexp =
       "lower bound of oldest age group must be lower than highest age range"
   )
@@ -47,7 +50,7 @@ test_that(".check_risk_df fails as expected", {
     risk = c(-0.1, 0.5, 1.1)
   )
   expect_error(
-    .check_risk_df(age_dep_hosp_risk, age_range = c(1, 90)),
+    .check_risk_df(age_dep_hosp_risk, age_range = c(lower = 1, upper = 90)),
     regexp = "risk should be between 0 and 1"
   )
 
@@ -56,7 +59,7 @@ test_that(".check_risk_df fails as expected", {
     risk = c(0.1, 0.05, 0.2)
   )
   expect_error(
-    .check_risk_df(age_dep_hosp_risk, age_range = c(1, 90)),
+    .check_risk_df(age_dep_hosp_risk, age_range = c(lower = 1, upper = 90)),
     regexp = "age limit in risk data frame must be unique"
   )
 
@@ -65,7 +68,7 @@ test_that(".check_risk_df fails as expected", {
     risk = c(0.1, 0.05, NA)
   )
   expect_error(
-    .check_risk_df(age_dep_hosp_risk, age_range = c(1, 90)),
+    .check_risk_df(age_dep_hosp_risk, age_range = c(lower = 1, upper = 90)),
     regexp = "age limit or risk cannot be NA or NaN"
   )
 })

--- a/tests/testthat/test-sim_contacts.R
+++ b/tests/testthat/test-sim_contacts.R
@@ -79,3 +79,20 @@ test_that("sim_contacts fails as expected with empty config", {
     regexp = "Network incorrectly specified, check config"
   )
 })
+
+test_that("sim_contacts works as expected with age structure", {
+  age_struct <- data.frame(
+    age_range = c("1-4", "5-79", "80-90"),
+    proportion = c(0.1, 0.7, 0.2),
+    stringsAsFactors = FALSE
+  )
+  set.seed(1)
+  expect_snapshot(
+    sim_contacts(
+      contact_distribution = contact_distribution,
+      contact_interval = contact_interval,
+      prob_infect = 0.5,
+      population_age = age_struct
+    )
+  )
+})


### PR DESCRIPTION
This PR addresses comments raised by the package review PR #73. It names the `population_age` vector with `"lower"` and `"upper"` and sorts the vector in case the user provides the age vector as `c(upper_bound, lower_bound)`. 

Throughout the code elements of `population_age` are now extracted as `[["lower"]]` and `[["upper"]]` instead of `[1]` and `[2]`.

This development also found a bug in `sim_contacts()` when age structured populations are supplied to `population_age`. The `<data.frame>` supplied by the user was not being transformed (by `.check_age_df()`) before being passed to `.sim_internal()` (which was happening in `sim_linelist()` and `sim_outbreak()`). This has been fixed and a test added to check this use case.

 