### PR TITLE
Miscellaneous `add_cols` updates

### DIFF
--- a/R/add_cols.R
+++ b/R/add_cols.R
@@ -95,7 +95,7 @@ NULL
       replace = FALSE,
       size = (1 - hosp_risk) * num_infected
     )
-    .data$hospitalisation[pop_sample] <- NA
+    .data$hospitalisation[pop_sample] <- NA_real_
   } else {
     for (i in seq_len(nrow(hosp_risk))) {
       age_bracket <- hosp_risk$min_age[i]:hosp_risk$max_age[i]
@@ -107,7 +107,7 @@ NULL
         replace = FALSE,
         size = not_hosp_prob * length(age_group)
       )
-      .data$hospitalisation[age_group_sample] <- NA
+      .data$hospitalisation[age_group_sample] <- NA_real_
     }
   }
 
@@ -134,7 +134,7 @@ NULL
         replace = FALSE,
         size = (1 - risk) * num_infected
       )
-      .data$deaths[pop_sample] <- NA
+      .data$deaths[pop_sample] <- NA_real_
     } else {
       for (i in seq_len(nrow(risk))) {
         age_bracket <- risk$min_age[i]:risk$max_age[i]
@@ -154,7 +154,7 @@ NULL
           replace = FALSE,
           size = not_hosp_death_prob * length(age_group)
         )
-        .data$deaths[age_group_sample] <- NA
+        .data$deaths[age_group_sample] <- NA_real_
       }
     }
     .data

--- a/R/add_cols.R
+++ b/R/add_cols.R
@@ -87,6 +87,7 @@ NULL
   .data$hospitalisation[infected_idx] <- .data$time[infected_idx] +
     onset_to_hosp(num_infected)
 
+  # hosp_risk is either numeric or <data.frame>
   if (is.numeric(hosp_risk)) {
     pop_sample <- sample(
       which(infected_idx),

--- a/R/add_cols.R
+++ b/R/add_cols.R
@@ -27,14 +27,14 @@ NULL
                               contact_type = c("first", "last"),
                               distribution = c("pois", "geom"),
                               ...,
-                              outbreak_start_date) {
+                              outbreak_start_date = NULL) {
   contact_type <- match.arg(contact_type)
   distribution <- match.arg(distribution)
 
   stopifnot(
     "outbreak_start_date is only required for adding date of last contact" =
-      contact_type == "last" && !missing(outbreak_start_date) ||
-      contact_type == "first" && missing(outbreak_start_date)
+      contact_type == "last" && !is.null(outbreak_start_date) ||
+      contact_type == "first" && is.null(outbreak_start_date)
   )
 
   rdist <- switch(distribution,

--- a/R/add_cols.R
+++ b/R/add_cols.R
@@ -89,6 +89,7 @@ NULL
 
   # hosp_risk is either numeric or <data.frame>
   if (is.numeric(hosp_risk)) {
+    # size is converted to an integer internally in sample()
     pop_sample <- sample(
       which(infected_idx),
       replace = FALSE,
@@ -100,6 +101,7 @@ NULL
       age_bracket <- hosp_risk$min_age[i]:hosp_risk$max_age[i]
       age_group <- which(.data$age %in% age_bracket)
       not_hosp_prob <- 1 - hosp_risk$risk[i]
+      # size is converted to an integer internally in sample()
       age_group_sample <- sample(
         age_group,
         replace = FALSE,
@@ -126,6 +128,7 @@ NULL
 
   apply_death_risk <- function(.data, risk, hosp = TRUE) {
     if (is.numeric(risk)) {
+      # size is converted to an integer internally in sample()
       pop_sample <- sample(
         which(infected_idx),
         replace = FALSE,
@@ -145,6 +148,7 @@ NULL
           )
         }
         not_hosp_death_prob <- 1 - risk$risk[i]
+        # size is converted to an integer internally in sample()
         age_group_sample <- sample(
           age_group,
           replace = FALSE,

--- a/man/dot-add_date.Rd
+++ b/man/dot-add_date.Rd
@@ -12,7 +12,7 @@
   contact_type = c("first", "last"),
   distribution = c("pois", "geom"),
   ...,
-  outbreak_start_date
+  outbreak_start_date = NULL
 )
 
 .add_hospitalisation(.data, onset_to_hosp, hosp_risk)


### PR DESCRIPTION
This PR addresses comments from the package review #73 on updating the `add_cols.R` functions.

Updates include:

- Adding a `NULL` default to `outbreak_start_date` argument in `.add_date_contact()`
- Use typed `NA` (`NA_real_`) in `add_cols` functions
- Add comment on implicit conversion of `size` to an integer in `sample()`
- Add comment on `hosp_risk` types in `.add_date_contact()`