### PR TITLE
Add bounds to probability assertions

### DIFF
--- a/R/checkers.R
+++ b/R/checkers.R
@@ -148,7 +148,7 @@
     .check_func_req_args(onset_to_death)
     checkmate::assert_logical(add_names, len = 1)
     checkmate::assert_logical(add_ct, len = 1)
-    checkmate::assert_numeric(case_type_probs, len = 3)
+    checkmate::assert_numeric(case_type_probs, len = 3, lower = 0, upper = 1)
     checkmate::assert_names(
       names(case_type_probs),
       permutation.of = c("suspected", "probable", "confirmed")

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -170,7 +170,9 @@
   }
 
   if (sim_type %in% c("contacts", "outbreak")) {
-    checkmate::assert_numeric(contact_tracing_status_probs, len = 3)
+    checkmate::assert_numeric(
+      contact_tracing_status_probs, len = 3, lower = 0, upper = 1
+    )
     checkmate::assert_names(
       names(contact_tracing_status_probs),
       permutation.of = c("under_followup", "lost_to_followup", "unknown")


### PR DESCRIPTION
This PR addresses a comment made in the package review #73, where the probability parameters for the simulation (`case_type_probs` & `contact_tracing_status_probs`) were checked for length and names, but not for upper and lower bounds. Given they are all probabilities (0, 1), this was added to the `checkmate::assert_numeric()` call.