### PR TITLE
Optimise `.sim_network_bp()`

### DIFF
--- a/R/sim_network_bp.R
+++ b/R/sim_network_bp.R
@@ -51,17 +51,17 @@
   ancestor_idx <- 1L
   prev_ancestors <- 1L
 
+  if (config$network == "adjusted") {
+    # sample contact distribution (excess degree distribution)
+    q <- contact_distribution(0:1e4 + 1) * (0:1e4 + 1)
+    q <- q / sum(q)
+  } else {
+    q <- contact_distribution(0:1e4)
+  }
+
   # run loop until no more individuals are sampled
   while (next_gen_size > 0) {
-    if (config$network == "adjusted") {
-      # sample contact distribution (excess degree distribution)
-      q <- contact_distribution(0:1e4 + 1) * (0:1e4 + 1)
-      q <- q / sum(q)
-    } else {
-      q <- contact_distribution(0:1e4)
-    }
     contacts <- sample(0:1e4, size = next_gen_size, replace = TRUE, prob = q)
-
     # add contacts if sampled
     if (sum(contacts) > 0L) {
       chain_size <- chain_size + sum(contacts)


### PR DESCRIPTION
This PR addresses a comment from the package review #73. It optimises the `.sim_network_bp()` function by moving the computation of the contact distribution density outside of the loop sampling contacts. This density is static given the input parameters and does not need to be updated during the simulation. 