### PR TITLE
Fix time delay bug

### DIFF
--- a/R/sim_network_bp.R
+++ b/R/sim_network_bp.R
@@ -92,9 +92,9 @@
           infect <- stats::rbinom(n = contacts[i], size = 1, prob = prob_infect)
           infected[vec_idx] <- as.numeric(infect)
 
-          # add delay time, removing first element of ancestor time as it is NA
+          # add delay time
           time[vec_idx] <- contact_interval(length(vec_idx)) +
-            time[ancestor == ancestor_idx[i]][-1]
+            time[ancestor_idx[i]]
         }
       }
       ancestor_idx <- setdiff(which(infected == 1), prev_ancestors)

--- a/tests/testthat/_snaps/sim_contacts.md
+++ b/tests/testthat/_snaps/sim_contacts.md
@@ -11,35 +11,35 @@
       4       Sammi Elizondo     Faadil al-Toure  42   m         2023-01-03
       5       Sammi Elizondo          Tami Hicar  60   f         2023-01-02
       6       Sammi Elizondo      Kristin Gentry  65   f         2022-12-31
-      7      Faadil al-Toure        Elias Schell  28   m         2023-01-01
-      8      Faadil al-Toure   Stephanie Quezada  78   f         2022-12-29
-      9           Tami Hicar         Alison Pham  31   f         2023-01-04
-      10          Tami Hicar        Joe Martinez  12   m         2023-01-02
-      11          Tami Hicar    Muneera al-Nazir  80   f         2023-01-01
-      12        Elias Schell         Alea Butler  44   f         2022-12-29
-      13        Elias Schell          Neal Amery  74   m         2022-12-31
-      14        Elias Schell          Luis Mejia  26   m         2023-01-06
-      15        Elias Schell       Awad el-Amara  33   m         2023-01-03
-      16        Elias Schell        Joseph Plutt   4   m         2022-12-30
-      17         Alison Pham    Cleevens Thrower  53   m         2023-01-03
-      18       Awad el-Amara      James Smith Jr  86   m         2023-01-03
-      19      James Smith Jr        Kalia Truong  89   f         2023-01-02
-      20      James Smith Jr         Mary Weaver  24   f         2023-01-04
-      21      James Smith Jr      Sydney Aguilar  37   f         2023-01-03
-      22      Sydney Aguilar       Mariah Garcia  15   f         2023-01-03
-      23       Mariah Garcia        Cade Gilbert  14   m         2023-01-02
-      24       Mariah Garcia          Travis Roy  81   m         2023-01-03
-      25          Travis Roy            Marc Xue  82   m         2023-01-02
-      26            Marc Xue     Mathew Mcintire  72   m         2023-01-03
-      27            Marc Xue        Steven Smith  53   m         2023-01-03
-      28            Marc Xue     Cleevens Taylor  56   m         2022-12-29
-      29     Mathew Mcintire    Saisuriya Wilson  71   m         2023-01-04
-      30     Mathew Mcintire     Alejandro Lopez  50   m         2023-01-01
-      31     Mathew Mcintire       Dakota Harvie  73   m         2022-12-31
-      32     Mathew Mcintire  Nabeela al-Rahmani  20   f         2023-01-01
-      33    Saisuriya Wilson      Jerry Williams  75   m         2023-01-06
-      34    Saisuriya Wilson Manaahil al-Ebrahim   2   f         2023-01-08
-      35     Alejandro Lopez   Kelsey Mcclintock   3   f         2023-01-03
+      7      Faadil al-Toure        Elias Schell  28   m         2023-01-02
+      8      Faadil al-Toure   Stephanie Quezada  78   f         2022-12-30
+      9           Tami Hicar         Alison Pham  31   f         2023-01-06
+      10          Tami Hicar        Joe Martinez  12   m         2023-01-04
+      11          Tami Hicar    Muneera al-Nazir  80   f         2023-01-03
+      12        Elias Schell         Alea Butler  44   f         2022-12-30
+      13        Elias Schell          Neal Amery  74   m         2023-01-01
+      14        Elias Schell          Luis Mejia  26   m         2023-01-07
+      15        Elias Schell       Awad el-Amara  33   m         2023-01-04
+      16        Elias Schell        Joseph Plutt   4   m         2022-12-31
+      17         Alison Pham    Cleevens Thrower  53   m         2023-01-06
+      18       Awad el-Amara      James Smith Jr  86   m         2023-01-06
+      19      James Smith Jr        Kalia Truong  89   f         2023-01-05
+      20      James Smith Jr         Mary Weaver  24   f         2023-01-07
+      21      James Smith Jr      Sydney Aguilar  37   f         2023-01-06
+      22      Sydney Aguilar       Mariah Garcia  15   f         2023-01-07
+      23       Mariah Garcia        Cade Gilbert  14   m         2023-01-06
+      24       Mariah Garcia          Travis Roy  81   m         2023-01-07
+      25          Travis Roy            Marc Xue  82   m         2023-01-07
+      26            Marc Xue     Mathew Mcintire  72   m         2023-01-10
+      27            Marc Xue        Steven Smith  53   m         2023-01-10
+      28            Marc Xue     Cleevens Taylor  56   m         2023-01-05
+      29     Mathew Mcintire    Saisuriya Wilson  71   m         2023-01-11
+      30     Mathew Mcintire     Alejandro Lopez  50   m         2023-01-08
+      31     Mathew Mcintire       Dakota Harvie  73   m         2023-01-07
+      32     Mathew Mcintire  Nabeela al-Rahmani  20   f         2023-01-08
+      33    Saisuriya Wilson      Jerry Williams  75   m         2023-01-15
+      34    Saisuriya Wilson Manaahil al-Ebrahim   2   f         2023-01-17
+      35     Alejandro Lopez   Kelsey Mcclintock   3   f         2023-01-12
          date_last_contact was_case           status
       1         2023-01-05        Y             case
       2         2023-01-07        N   under_followup
@@ -47,35 +47,35 @@
       4         2023-01-04        Y             case
       5         2023-01-04        Y             case
       6         2023-01-03        N   under_followup
-      7         2023-01-03        Y             case
-      8         2023-01-04        Y             case
-      9         2023-01-07        Y             case
-      10        2023-01-04        N   under_followup
-      11        2023-01-03        N lost_to_followup
-      12        2023-01-02        N   under_followup
-      13        2023-01-04        N lost_to_followup
-      14        2023-01-07        N   under_followup
-      15        2023-01-04        Y             case
-      16        2023-01-03        N lost_to_followup
-      17        2023-01-06        N   under_followup
-      18        2023-01-04        Y             case
-      19        2023-01-03        N   under_followup
-      20        2023-01-05        N lost_to_followup
-      21        2023-01-05        Y             case
-      22        2023-01-04        Y             case
-      23        2023-01-04        N   under_followup
-      24        2023-01-04        Y             case
-      25        2023-01-04        Y             case
-      26        2023-01-04        Y             case
-      27        2023-01-06        N   under_followup
-      28        2023-01-02        N   under_followup
-      29        2023-01-04        Y             case
-      30        2023-01-04        Y             case
-      31        2023-01-05        N   under_followup
-      32        2023-01-03        N   under_followup
-      33        2023-01-06        N   under_followup
-      34        2023-01-09        N   under_followup
-      35        2023-01-05        Y             case
+      7         2023-01-04        Y             case
+      8         2023-01-05        Y             case
+      9         2023-01-09        Y             case
+      10        2023-01-06        N   under_followup
+      11        2023-01-05        N lost_to_followup
+      12        2023-01-03        N   under_followup
+      13        2023-01-05        N lost_to_followup
+      14        2023-01-08        N   under_followup
+      15        2023-01-05        Y             case
+      16        2023-01-04        N lost_to_followup
+      17        2023-01-09        N   under_followup
+      18        2023-01-07        Y             case
+      19        2023-01-06        N   under_followup
+      20        2023-01-08        N lost_to_followup
+      21        2023-01-08        Y             case
+      22        2023-01-08        Y             case
+      23        2023-01-08        N   under_followup
+      24        2023-01-08        Y             case
+      25        2023-01-09        Y             case
+      26        2023-01-11        Y             case
+      27        2023-01-13        N   under_followup
+      28        2023-01-09        N   under_followup
+      29        2023-01-11        Y             case
+      30        2023-01-11        Y             case
+      31        2023-01-12        N   under_followup
+      32        2023-01-10        N   under_followup
+      33        2023-01-15        N   under_followup
+      34        2023-01-18        N   under_followup
+      35        2023-01-14        Y             case
 
 # sim_contacts works as expected with modified config
 
@@ -91,35 +91,35 @@
       4    Sabeeka al-Mattar     Karie Phanthavongsa  15   f         2023-01-01
       5    Sabeeka al-Mattar       Laura Ann Daniels  28   f         2022-12-31
       6    Sabeeka al-Mattar Josue Aguilera-Aguilera  55   m         2022-12-29
-      7  Karie Phanthavongsa              Khanh Long  69   m         2022-12-30
-      8  Karie Phanthavongsa              Aleia Pope  78   f         2022-12-30
-      9    Laura Ann Daniels          Astitwa Czajka  37   m         2022-12-31
-      10   Laura Ann Daniels               Sara Fish  43   f         2023-01-01
-      11   Laura Ann Daniels              Jung Allen  81   m         2022-12-26
-      12          Khanh Long           Xylonna Curry   1   f         2023-01-01
-      13          Khanh Long               Joe Ortiz  90   m         2022-12-30
-      14          Khanh Long           Danica Boykin  45   f         2022-12-31
-      15          Khanh Long          Joshua Jackson  83   m         2022-12-31
-      16          Khanh Long        Afeef al-Shaheen  90   m         2022-12-27
-      17      Astitwa Czajka         Elijah Hartmann  23   m         2022-12-30
-      18      Joshua Jackson      Nasreen al-Salameh  68   f         2022-12-27
-      19  Nasreen al-Salameh      Menandez Tall Bull  80   m         2022-12-28
-      20  Nasreen al-Salameh           Sarah Elliott  57   f         2022-12-29
-      21  Nasreen al-Salameh          Sahar el-Hasan  52   f         2022-12-30
-      22      Sahar el-Hasan        Mitchell Jackson  80   m         2022-12-29
-      23    Mitchell Jackson        Ty' Esha Wilkins  34   f         2022-12-26
-      24    Mitchell Jackson      Jazmine Watkins IV  35   f         2023-01-01
-      25  Jazmine Watkins IV        Daleel al-Shahan  74   m         2022-12-31
-      26    Daleel al-Shahan        Shabaan el-Pasha  70   m         2022-12-28
-      27    Daleel al-Shahan            Steven Eagle  60   m         2022-12-31
-      28    Daleel al-Shahan      Caleb Mbasi-Botuli  39   m         2022-12-31
-      29    Shabaan el-Pasha          Melissa Ingham  49   f         2022-12-30
-      30    Shabaan el-Pasha       Mahbooba al-Fadel  87   f         2023-01-05
-      31    Shabaan el-Pasha      Mukarram al-Greiss  62   m         2022-12-31
-      32    Shabaan el-Pasha        Leeann Lakkaraju  33   f         2022-12-26
-      33      Melissa Ingham         Sadeeqa el-Aman  35   f         2022-12-29
-      34      Melissa Ingham           Devante Owens  11   m         2023-01-04
-      35   Mahbooba al-Fadel      Jordan Greene-King  13   m         2022-12-29
+      7  Karie Phanthavongsa              Khanh Long  69   m         2022-12-31
+      8  Karie Phanthavongsa              Aleia Pope  78   f         2022-12-31
+      9    Laura Ann Daniels          Astitwa Czajka  37   m         2023-01-02
+      10   Laura Ann Daniels               Sara Fish  43   f         2023-01-03
+      11   Laura Ann Daniels              Jung Allen  81   m         2022-12-28
+      12          Khanh Long           Xylonna Curry   1   f         2023-01-02
+      13          Khanh Long               Joe Ortiz  90   m         2022-12-31
+      14          Khanh Long           Danica Boykin  45   f         2023-01-01
+      15          Khanh Long          Joshua Jackson  83   m         2023-01-01
+      16          Khanh Long        Afeef al-Shaheen  90   m         2022-12-28
+      17      Astitwa Czajka         Elijah Hartmann  23   m         2023-01-02
+      18      Joshua Jackson      Nasreen al-Salameh  68   f         2022-12-30
+      19  Nasreen al-Salameh      Menandez Tall Bull  80   m         2022-12-31
+      20  Nasreen al-Salameh           Sarah Elliott  57   f         2023-01-01
+      21  Nasreen al-Salameh          Sahar el-Hasan  52   f         2023-01-02
+      22      Sahar el-Hasan        Mitchell Jackson  80   m         2023-01-02
+      23    Mitchell Jackson        Ty' Esha Wilkins  34   f         2022-12-30
+      24    Mitchell Jackson      Jazmine Watkins IV  35   f         2023-01-05
+      25  Jazmine Watkins IV        Daleel al-Shahan  74   m         2023-01-05
+      26    Daleel al-Shahan        Shabaan el-Pasha  70   m         2023-01-04
+      27    Daleel al-Shahan            Steven Eagle  60   m         2023-01-07
+      28    Daleel al-Shahan      Caleb Mbasi-Botuli  39   m         2023-01-07
+      29    Shabaan el-Pasha          Melissa Ingham  49   f         2023-01-06
+      30    Shabaan el-Pasha       Mahbooba al-Fadel  87   f         2023-01-12
+      31    Shabaan el-Pasha      Mukarram al-Greiss  62   m         2023-01-07
+      32    Shabaan el-Pasha        Leeann Lakkaraju  33   f         2023-01-02
+      33      Melissa Ingham         Sadeeqa el-Aman  35   f         2023-01-07
+      34      Melissa Ingham           Devante Owens  11   m         2023-01-13
+      35   Mahbooba al-Fadel      Jordan Greene-King  13   m         2023-01-07
          date_last_contact was_case           status
       1         2023-01-01        Y             case
       2         2023-01-02        N   under_followup
@@ -127,35 +127,35 @@
       4         2023-01-02        Y             case
       5         2023-01-05        Y             case
       6         2023-01-02        N   under_followup
-      7         2023-01-01        Y             case
-      8         2023-01-02        Y             case
-      9         2023-01-01        Y             case
-      10        2023-01-03        N   under_followup
-      11        2023-01-02        N   under_followup
-      12        2023-01-04        N lost_to_followup
-      13        2023-01-03        N   under_followup
-      14        2023-01-02        N          unknown
-      15        2023-01-02        Y             case
-      16        2023-01-04        N          unknown
-      17        2023-01-04        N lost_to_followup
-      18        2023-01-02        Y             case
-      19        2023-01-01        N lost_to_followup
-      20        2023-01-02        N   under_followup
-      21        2023-01-01        Y             case
-      22        2023-01-02        Y             case
-      23        2023-01-02        N lost_to_followup
-      24        2023-01-03        Y             case
-      25        2023-01-02        Y             case
-      26        2023-01-01        Y             case
-      27        2023-01-01        N   under_followup
-      28        2023-01-02        N   under_followup
-      29        2023-01-02        Y             case
-      30        2023-01-06        Y             case
-      31        2023-01-03        N   under_followup
-      32        2023-01-02        N   under_followup
-      33        2023-01-06        N   under_followup
-      34        2023-01-05        N   under_followup
-      35        2023-01-01        Y             case
+      7         2023-01-02        Y             case
+      8         2023-01-03        Y             case
+      9         2023-01-03        Y             case
+      10        2023-01-05        N   under_followup
+      11        2023-01-04        N   under_followup
+      12        2023-01-05        N lost_to_followup
+      13        2023-01-04        N   under_followup
+      14        2023-01-03        N          unknown
+      15        2023-01-03        Y             case
+      16        2023-01-05        N          unknown
+      17        2023-01-07        N lost_to_followup
+      18        2023-01-05        Y             case
+      19        2023-01-04        N lost_to_followup
+      20        2023-01-05        N   under_followup
+      21        2023-01-04        Y             case
+      22        2023-01-06        Y             case
+      23        2023-01-06        N lost_to_followup
+      24        2023-01-07        Y             case
+      25        2023-01-07        Y             case
+      26        2023-01-08        Y             case
+      27        2023-01-08        N   under_followup
+      28        2023-01-09        N   under_followup
+      29        2023-01-09        Y             case
+      30        2023-01-13        Y             case
+      31        2023-01-10        N   under_followup
+      32        2023-01-09        N   under_followup
+      33        2023-01-15        N   under_followup
+      34        2023-01-14        N   under_followup
+      35        2023-01-10        Y             case
 
 # sim_contacts works as expected with modified config parameters
 
@@ -171,35 +171,35 @@
       4       Sammi Elizondo     Faadil al-Toure  42   m         2023-01-05
       5       Sammi Elizondo          Tami Hicar  60   f         2023-01-03
       6       Sammi Elizondo      Kristin Gentry  65   f         2023-01-02
-      7      Faadil al-Toure        Elias Schell  28   m         2023-01-03
-      8      Faadil al-Toure   Stephanie Quezada  78   f         2022-12-31
-      9           Tami Hicar         Alison Pham  31   f         2023-01-06
-      10          Tami Hicar        Joe Martinez  12   m         2023-01-04
-      11          Tami Hicar    Muneera al-Nazir  80   f         2023-01-02
-      12        Elias Schell         Alea Butler  44   f         2022-12-31
-      13        Elias Schell          Neal Amery  74   m         2023-01-02
-      14        Elias Schell          Luis Mejia  26   m         2023-01-08
-      15        Elias Schell       Awad el-Amara  33   m         2023-01-05
-      16        Elias Schell        Joseph Plutt   4   m         2023-01-01
-      17         Alison Pham    Cleevens Thrower  53   m         2023-01-05
-      18       Awad el-Amara      James Smith Jr  86   m         2023-01-06
-      19      James Smith Jr        Kalia Truong  89   f         2023-01-04
-      20      James Smith Jr         Mary Weaver  24   f         2023-01-06
-      21      James Smith Jr      Sydney Aguilar  37   f         2023-01-05
-      22      Sydney Aguilar       Mariah Garcia  15   f         2023-01-05
-      23       Mariah Garcia        Cade Gilbert  14   m         2023-01-03
-      24       Mariah Garcia          Travis Roy  81   m         2023-01-05
-      25          Travis Roy            Marc Xue  82   m         2023-01-04
-      26            Marc Xue     Mathew Mcintire  72   m         2023-01-05
-      27            Marc Xue        Steven Smith  53   m         2023-01-06
-      28            Marc Xue     Cleevens Taylor  56   m         2022-12-31
-      29     Mathew Mcintire    Saisuriya Wilson  71   m         2023-01-06
-      30     Mathew Mcintire     Alejandro Lopez  50   m         2023-01-02
-      31     Mathew Mcintire       Dakota Harvie  73   m         2023-01-01
-      32     Mathew Mcintire  Nabeela al-Rahmani  20   f         2023-01-03
-      33    Saisuriya Wilson      Jerry Williams  75   m         2023-01-08
-      34    Saisuriya Wilson Manaahil al-Ebrahim   2   f         2023-01-11
-      35     Alejandro Lopez   Kelsey Mcclintock   3   f         2023-01-05
+      7      Faadil al-Toure        Elias Schell  28   m         2023-01-04
+      8      Faadil al-Toure   Stephanie Quezada  78   f         2023-01-01
+      9           Tami Hicar         Alison Pham  31   f         2023-01-08
+      10          Tami Hicar        Joe Martinez  12   m         2023-01-06
+      11          Tami Hicar    Muneera al-Nazir  80   f         2023-01-04
+      12        Elias Schell         Alea Butler  44   f         2023-01-01
+      13        Elias Schell          Neal Amery  74   m         2023-01-03
+      14        Elias Schell          Luis Mejia  26   m         2023-01-09
+      15        Elias Schell       Awad el-Amara  33   m         2023-01-06
+      16        Elias Schell        Joseph Plutt   4   m         2023-01-02
+      17         Alison Pham    Cleevens Thrower  53   m         2023-01-08
+      18       Awad el-Amara      James Smith Jr  86   m         2023-01-09
+      19      James Smith Jr        Kalia Truong  89   f         2023-01-07
+      20      James Smith Jr         Mary Weaver  24   f         2023-01-09
+      21      James Smith Jr      Sydney Aguilar  37   f         2023-01-08
+      22      Sydney Aguilar       Mariah Garcia  15   f         2023-01-09
+      23       Mariah Garcia        Cade Gilbert  14   m         2023-01-07
+      24       Mariah Garcia          Travis Roy  81   m         2023-01-09
+      25          Travis Roy            Marc Xue  82   m         2023-01-09
+      26            Marc Xue     Mathew Mcintire  72   m         2023-01-12
+      27            Marc Xue        Steven Smith  53   m         2023-01-13
+      28            Marc Xue     Cleevens Taylor  56   m         2023-01-07
+      29     Mathew Mcintire    Saisuriya Wilson  71   m         2023-01-13
+      30     Mathew Mcintire     Alejandro Lopez  50   m         2023-01-09
+      31     Mathew Mcintire       Dakota Harvie  73   m         2023-01-08
+      32     Mathew Mcintire  Nabeela al-Rahmani  20   f         2023-01-10
+      33    Saisuriya Wilson      Jerry Williams  75   m         2023-01-17
+      34    Saisuriya Wilson Manaahil al-Ebrahim   2   f         2023-01-20
+      35     Alejandro Lopez   Kelsey Mcclintock   3   f         2023-01-14
          date_last_contact was_case           status
       1         2023-01-07        Y             case
       2         2023-01-10        N   under_followup
@@ -207,35 +207,35 @@
       4         2023-01-06        Y             case
       5         2023-01-05        Y             case
       6         2023-01-05        N   under_followup
-      7         2023-01-05        Y             case
-      8         2023-01-06        Y             case
-      9         2023-01-09        Y             case
-      10        2023-01-06        N   under_followup
-      11        2023-01-04        N lost_to_followup
-      12        2023-01-04        N   under_followup
-      13        2023-01-06        N lost_to_followup
-      14        2023-01-09        N   under_followup
-      15        2023-01-06        Y             case
-      16        2023-01-05        N lost_to_followup
-      17        2023-01-08        N   under_followup
-      18        2023-01-07        Y             case
-      19        2023-01-05        N   under_followup
-      20        2023-01-07        N lost_to_followup
-      21        2023-01-07        Y             case
-      22        2023-01-06        Y             case
-      23        2023-01-05        N   under_followup
-      24        2023-01-06        Y             case
-      25        2023-01-06        Y             case
-      26        2023-01-06        Y             case
-      27        2023-01-09        N   under_followup
-      28        2023-01-04        N   under_followup
-      29        2023-01-06        Y             case
-      30        2023-01-05        Y             case
-      31        2023-01-06        N   under_followup
-      32        2023-01-05        N   under_followup
-      33        2023-01-08        N   under_followup
-      34        2023-01-12        N   under_followup
-      35        2023-01-07        Y             case
+      7         2023-01-06        Y             case
+      8         2023-01-07        Y             case
+      9         2023-01-11        Y             case
+      10        2023-01-08        N   under_followup
+      11        2023-01-06        N lost_to_followup
+      12        2023-01-05        N   under_followup
+      13        2023-01-07        N lost_to_followup
+      14        2023-01-10        N   under_followup
+      15        2023-01-07        Y             case
+      16        2023-01-06        N lost_to_followup
+      17        2023-01-11        N   under_followup
+      18        2023-01-10        Y             case
+      19        2023-01-08        N   under_followup
+      20        2023-01-10        N lost_to_followup
+      21        2023-01-10        Y             case
+      22        2023-01-10        Y             case
+      23        2023-01-09        N   under_followup
+      24        2023-01-10        Y             case
+      25        2023-01-11        Y             case
+      26        2023-01-13        Y             case
+      27        2023-01-16        N   under_followup
+      28        2023-01-11        N   under_followup
+      29        2023-01-13        Y             case
+      30        2023-01-12        Y             case
+      31        2023-01-13        N   under_followup
+      32        2023-01-12        N   under_followup
+      33        2023-01-17        N   under_followup
+      34        2023-01-21        N   under_followup
+      35        2023-01-16        Y             case
 
 # sim_contacts works as expected with age structure
 
@@ -250,35 +250,35 @@
       4      Kathryn Lapitan          Derek Choi   9   m         2023-01-03
       5      Kathryn Lapitan Chloe Moreno-Ferrel  89   f         2023-01-02
       6      Kathryn Lapitan        Lisa Johnson  36   f         2022-12-31
-      7           Derek Choi         Jacob Begay  16   m         2023-01-01
-      8           Derek Choi  Mia Yokota-Stroman  82   f         2022-12-29
-      9  Chloe Moreno-Ferrel       Deja Elizondo  27   f         2023-01-04
-      10 Chloe Moreno-Ferrel         Jacob Glaub  35   m         2023-01-02
-      11 Chloe Moreno-Ferrel      Shandre Ostrom   2   f         2023-01-01
-      12         Jacob Begay         Kylie Hicar   6   f         2022-12-29
-      13         Jacob Begay        Woo Bin Park  23   m         2022-12-31
-      14         Jacob Begay       Jayson Brooks  90   m         2023-01-06
-      15         Jacob Begay         Mario Jones  47   m         2023-01-03
-      16         Jacob Begay             Tai Ali  64   m         2022-12-30
-      17       Deja Elizondo    Ronald Burgdorff  16   m         2023-01-03
-      18         Mario Jones        Rodrigo Leal  85   m         2023-01-03
-      19        Rodrigo Leal        Kelia Gentry  42   f         2023-01-02
-      20        Rodrigo Leal          Ana Romero  26   f         2023-01-04
-      21        Rodrigo Leal           Thao Pham  57   f         2023-01-03
-      22           Thao Pham    Nabeela al-Nazir  89   f         2023-01-03
-      23    Nabeela al-Nazir        David Nguyen  21   m         2023-01-02
-      24    Nabeela al-Nazir       Joshua Valeta  90   m         2023-01-03
-      25       Joshua Valeta         Evan Browne  48   m         2023-01-02
-      26         Evan Browne        Jordan Brown  62   m         2023-01-03
-      27         Evan Browne       Leighton Chun  20   m         2023-01-03
-      28         Evan Browne    Raymond Martinez   4   m         2022-12-29
-      29        Jordan Brown       Jalen Thrower   9   m         2023-01-04
-      30        Jordan Brown   Cleevens Smith Jr  29   m         2023-01-01
-      31        Jordan Brown      Saleel el-Dada  32   m         2022-12-31
-      32        Jordan Brown       Lashon Butler  82   f         2023-01-01
-      33       Jalen Thrower  Suhail al-Abdallah  75   m         2023-01-06
-      34       Jalen Thrower       Alison Truong   2   f         2023-01-08
-      35   Cleevens Smith Jr         Emma Weaver  79   f         2023-01-03
+      7           Derek Choi         Jacob Begay  16   m         2023-01-02
+      8           Derek Choi  Mia Yokota-Stroman  82   f         2022-12-30
+      9  Chloe Moreno-Ferrel       Deja Elizondo  27   f         2023-01-06
+      10 Chloe Moreno-Ferrel         Jacob Glaub  35   m         2023-01-04
+      11 Chloe Moreno-Ferrel      Shandre Ostrom   2   f         2023-01-03
+      12         Jacob Begay         Kylie Hicar   6   f         2022-12-30
+      13         Jacob Begay        Woo Bin Park  23   m         2023-01-01
+      14         Jacob Begay       Jayson Brooks  90   m         2023-01-07
+      15         Jacob Begay         Mario Jones  47   m         2023-01-04
+      16         Jacob Begay             Tai Ali  64   m         2022-12-31
+      17       Deja Elizondo    Ronald Burgdorff  16   m         2023-01-06
+      18         Mario Jones        Rodrigo Leal  85   m         2023-01-06
+      19        Rodrigo Leal        Kelia Gentry  42   f         2023-01-05
+      20        Rodrigo Leal          Ana Romero  26   f         2023-01-07
+      21        Rodrigo Leal           Thao Pham  57   f         2023-01-06
+      22           Thao Pham    Nabeela al-Nazir  89   f         2023-01-07
+      23    Nabeela al-Nazir        David Nguyen  21   m         2023-01-06
+      24    Nabeela al-Nazir       Joshua Valeta  90   m         2023-01-07
+      25       Joshua Valeta         Evan Browne  48   m         2023-01-07
+      26         Evan Browne        Jordan Brown  62   m         2023-01-10
+      27         Evan Browne       Leighton Chun  20   m         2023-01-10
+      28         Evan Browne    Raymond Martinez   4   m         2023-01-05
+      29        Jordan Brown       Jalen Thrower   9   m         2023-01-11
+      30        Jordan Brown   Cleevens Smith Jr  29   m         2023-01-08
+      31        Jordan Brown      Saleel el-Dada  32   m         2023-01-07
+      32        Jordan Brown       Lashon Butler  82   f         2023-01-08
+      33       Jalen Thrower  Suhail al-Abdallah  75   m         2023-01-15
+      34       Jalen Thrower       Alison Truong   2   f         2023-01-17
+      35   Cleevens Smith Jr         Emma Weaver  79   f         2023-01-12
          date_last_contact was_case           status
       1         2023-01-05        Y             case
       2         2023-01-07        N   under_followup
@@ -286,33 +286,33 @@
       4         2023-01-04        Y             case
       5         2023-01-04        Y             case
       6         2023-01-03        N   under_followup
-      7         2023-01-03        Y             case
-      8         2023-01-04        Y             case
-      9         2023-01-07        Y             case
-      10        2023-01-04        N   under_followup
-      11        2023-01-03        N lost_to_followup
-      12        2023-01-02        N   under_followup
-      13        2023-01-04        N   under_followup
-      14        2023-01-07        N          unknown
-      15        2023-01-04        Y             case
-      16        2023-01-03        N lost_to_followup
-      17        2023-01-06        N   under_followup
-      18        2023-01-04        Y             case
-      19        2023-01-03        N lost_to_followup
-      20        2023-01-05        N   under_followup
-      21        2023-01-05        Y             case
-      22        2023-01-04        Y             case
-      23        2023-01-04        N   under_followup
-      24        2023-01-04        Y             case
-      25        2023-01-04        Y             case
-      26        2023-01-04        Y             case
-      27        2023-01-06        N   under_followup
-      28        2023-01-02        N   under_followup
-      29        2023-01-04        Y             case
-      30        2023-01-04        Y             case
-      31        2023-01-05        N lost_to_followup
-      32        2023-01-03        N   under_followup
-      33        2023-01-06        N lost_to_followup
-      34        2023-01-09        N   under_followup
-      35        2023-01-05        Y             case
+      7         2023-01-04        Y             case
+      8         2023-01-05        Y             case
+      9         2023-01-09        Y             case
+      10        2023-01-06        N   under_followup
+      11        2023-01-05        N lost_to_followup
+      12        2023-01-03        N   under_followup
+      13        2023-01-05        N   under_followup
+      14        2023-01-08        N          unknown
+      15        2023-01-05        Y             case
+      16        2023-01-04        N lost_to_followup
+      17        2023-01-09        N   under_followup
+      18        2023-01-07        Y             case
+      19        2023-01-06        N lost_to_followup
+      20        2023-01-08        N   under_followup
+      21        2023-01-08        Y             case
+      22        2023-01-08        Y             case
+      23        2023-01-08        N   under_followup
+      24        2023-01-08        Y             case
+      25        2023-01-09        Y             case
+      26        2023-01-11        Y             case
+      27        2023-01-13        N   under_followup
+      28        2023-01-09        N   under_followup
+      29        2023-01-11        Y             case
+      30        2023-01-11        Y             case
+      31        2023-01-12        N lost_to_followup
+      32        2023-01-10        N   under_followup
+      33        2023-01-15        N lost_to_followup
+      34        2023-01-18        N   under_followup
+      35        2023-01-14        Y             case
 

--- a/tests/testthat/_snaps/sim_linelist.md
+++ b/tests/testthat/_snaps/sim_linelist.md
@@ -7,39 +7,39 @@
          id           case_name case_type sex age date_onset date_admission
       1   1    Macella Moreland confirmed   f  28 2023-01-01           <NA>
       2   2      Kayla Ellerman confirmed   f  62 2023-01-02     2023-01-02
-      3   5 Matthew Biggerstaff confirmed   m  42 2023-01-01           <NA>
-      4   6   Vanessa Sihombing  probable   f  60 2023-01-01           <NA>
-      5   8     Ross Mcclintock suspected   m  28 2023-01-02     2023-01-03
-      6   9     Danielle Medero confirmed   f  78 2023-01-01           <NA>
-      7  10      Suhaa el-Saidi suspected   f  31 2023-01-04     2023-01-17
-      8  16       Jakeob Wisham suspected   m  33 2023-01-01           <NA>
-      9  19   Shaahir el-Younis suspected   m  86 2023-01-01           <NA>
-      10 22     Arianna Bellomy confirmed   f  37 2023-01-01           <NA>
-      11 23     Angela Thompson  probable   f  15 2023-01-01           <NA>
-      12 25       Irvin Quezada suspected   m  81 2023-01-02     2023-01-03
-      13 26        Ronald Bliss  probable   m  82 2023-01-01           <NA>
-      14 27       Andrew Truong  probable   m  72 2023-01-02           <NA>
-      15 30       Dawson Wagner confirmed   m  71 2023-01-03           <NA>
-      16 31          Jacky Chen confirmed   m  50 2023-01-01           <NA>
-      17 36          Dewi Smith confirmed   f   3 2023-01-01           <NA>
+      3   5 Matthew Biggerstaff confirmed   m  42 2023-01-02           <NA>
+      4   6   Vanessa Sihombing  probable   f  60 2023-01-03           <NA>
+      5   8     Ross Mcclintock suspected   m  28 2023-01-03     2023-01-05
+      6   9     Danielle Medero confirmed   f  78 2023-01-03           <NA>
+      7  10      Suhaa el-Saidi suspected   f  31 2023-01-07     2023-01-19
+      8  16       Jakeob Wisham suspected   m  33 2023-01-04           <NA>
+      9  19   Shaahir el-Younis suspected   m  86 2023-01-04           <NA>
+      10 22     Arianna Bellomy confirmed   f  37 2023-01-05           <NA>
+      11 23     Angela Thompson  probable   f  15 2023-01-05           <NA>
+      12 25       Irvin Quezada suspected   m  81 2023-01-07     2023-01-08
+      13 26        Ronald Bliss  probable   m  82 2023-01-08           <NA>
+      14 27       Andrew Truong  probable   m  72 2023-01-09           <NA>
+      15 30       Dawson Wagner confirmed   m  71 2023-01-12           <NA>
+      16 31          Jacky Chen confirmed   m  50 2023-01-10           <NA>
+      17 36          Dewi Smith confirmed   f   3 2023-01-10           <NA>
          date_death date_first_contact date_last_contact ct_value
       1        <NA>               <NA>              <NA>     23.6
       2        <NA>         2023-01-02        2023-01-05     23.6
       3        <NA>         2023-01-03        2023-01-04     23.6
       4        <NA>         2023-01-02        2023-01-04       NA
-      5        <NA>         2023-01-01        2023-01-03       NA
-      6        <NA>         2022-12-29        2023-01-04     23.6
-      7        <NA>         2023-01-04        2023-01-07       NA
-      8        <NA>         2023-01-03        2023-01-04       NA
-      9        <NA>         2023-01-03        2023-01-04       NA
-      10 2023-01-19         2023-01-03        2023-01-05     23.6
-      11       <NA>         2023-01-03        2023-01-04       NA
-      12       <NA>         2023-01-03        2023-01-04       NA
-      13       <NA>         2023-01-02        2023-01-04       NA
-      14       <NA>         2023-01-03        2023-01-04       NA
-      15       <NA>         2023-01-04        2023-01-04     23.6
-      16       <NA>         2023-01-01        2023-01-04     23.6
-      17       <NA>         2023-01-03        2023-01-05     23.6
+      5        <NA>         2023-01-02        2023-01-04       NA
+      6        <NA>         2022-12-30        2023-01-05     23.6
+      7        <NA>         2023-01-06        2023-01-09       NA
+      8        <NA>         2023-01-04        2023-01-05       NA
+      9        <NA>         2023-01-06        2023-01-07       NA
+      10 2023-01-23         2023-01-06        2023-01-08     23.6
+      11       <NA>         2023-01-07        2023-01-08       NA
+      12       <NA>         2023-01-07        2023-01-08       NA
+      13       <NA>         2023-01-07        2023-01-09       NA
+      14       <NA>         2023-01-10        2023-01-11       NA
+      15       <NA>         2023-01-11        2023-01-11     23.6
+      16       <NA>         2023-01-08        2023-01-11     23.6
+      17       <NA>         2023-01-12        2023-01-14     23.6
 
 # sim_linelist works as expected with age-strat risks
 
@@ -52,39 +52,39 @@
          id        case_name case_type sex age date_onset date_admission date_death
       1   1  Rachael Sneesby confirmed   f  28 2023-01-01           <NA>       <NA>
       2   2       Nadia Hill confirmed   f  62 2023-01-02     2023-01-02 2023-01-07
-      3   5   Jonathan Huynh  probable   m  42 2023-01-01           <NA>       <NA>
-      4   6  Tharwa al-Amber  probable   f  60 2023-01-01           <NA>       <NA>
-      5   8      Ian Sanchez suspected   m  28 2023-01-02           <NA>       <NA>
-      6   9       Sadie Ross confirmed   f  78 2023-01-01           <NA>       <NA>
-      7  10 Jordan Marquardt suspected   f  31 2023-01-04           <NA>       <NA>
-      8  16       Joseph Sky suspected   m  33 2023-01-01           <NA>       <NA>
-      9  19    Geoffrey Boon confirmed   m  86 2023-01-01           <NA>       <NA>
-      10 22    Juyoung Sands suspected   f  37 2023-01-01           <NA>       <NA>
-      11 23         Mya Hunt suspected   f  15 2023-01-01           <NA>       <NA>
-      12 25     Josef Fortes  probable   m  81 2023-01-02     2023-01-03 2023-01-24
-      13 26   Badri el-Hoque confirmed   m  82 2023-01-01           <NA>       <NA>
-      14 27    William Jones  probable   m  72 2023-01-02           <NA>       <NA>
-      15 30     Luis Arreola confirmed   m  71 2023-01-03           <NA>       <NA>
-      16 31   Zachary Abeyta  probable   m  50 2023-01-01           <NA>       <NA>
-      17 36  Shawnesse Smith suspected   f   3 2023-01-01           <NA>       <NA>
+      3   5   Jonathan Huynh  probable   m  42 2023-01-02           <NA>       <NA>
+      4   6  Tharwa al-Amber  probable   f  60 2023-01-03           <NA>       <NA>
+      5   8      Ian Sanchez suspected   m  28 2023-01-03           <NA>       <NA>
+      6   9       Sadie Ross confirmed   f  78 2023-01-03           <NA>       <NA>
+      7  10 Jordan Marquardt suspected   f  31 2023-01-07           <NA>       <NA>
+      8  16       Joseph Sky suspected   m  33 2023-01-04           <NA>       <NA>
+      9  19    Geoffrey Boon confirmed   m  86 2023-01-04           <NA>       <NA>
+      10 22    Juyoung Sands suspected   f  37 2023-01-05           <NA>       <NA>
+      11 23         Mya Hunt suspected   f  15 2023-01-05           <NA>       <NA>
+      12 25     Josef Fortes  probable   m  81 2023-01-07     2023-01-08 2023-01-29
+      13 26   Badri el-Hoque confirmed   m  82 2023-01-08           <NA>       <NA>
+      14 27    William Jones  probable   m  72 2023-01-09           <NA>       <NA>
+      15 30     Luis Arreola confirmed   m  71 2023-01-12           <NA>       <NA>
+      16 31   Zachary Abeyta  probable   m  50 2023-01-10           <NA>       <NA>
+      17 36  Shawnesse Smith suspected   f   3 2023-01-10           <NA>       <NA>
          date_first_contact date_last_contact ct_value
       1                <NA>              <NA>     24.3
       2          2023-01-02        2023-01-05     24.3
       3          2023-01-03        2023-01-04       NA
       4          2023-01-02        2023-01-04       NA
-      5          2023-01-01        2023-01-03       NA
-      6          2022-12-29        2023-01-04     24.3
-      7          2023-01-04        2023-01-07       NA
-      8          2023-01-03        2023-01-04       NA
-      9          2023-01-03        2023-01-04     24.3
-      10         2023-01-03        2023-01-05       NA
-      11         2023-01-03        2023-01-04       NA
-      12         2023-01-03        2023-01-04       NA
-      13         2023-01-02        2023-01-04     24.3
-      14         2023-01-03        2023-01-04       NA
-      15         2023-01-04        2023-01-04     24.3
-      16         2023-01-01        2023-01-04       NA
-      17         2023-01-03        2023-01-05       NA
+      5          2023-01-02        2023-01-04       NA
+      6          2022-12-30        2023-01-05     24.3
+      7          2023-01-06        2023-01-09       NA
+      8          2023-01-04        2023-01-05       NA
+      9          2023-01-06        2023-01-07     24.3
+      10         2023-01-06        2023-01-08       NA
+      11         2023-01-07        2023-01-08       NA
+      12         2023-01-07        2023-01-08       NA
+      13         2023-01-07        2023-01-09     24.3
+      14         2023-01-10        2023-01-11       NA
+      15         2023-01-11        2023-01-11     24.3
+      16         2023-01-08        2023-01-11       NA
+      17         2023-01-12        2023-01-14       NA
 
 # sim_linelist works as expected without Ct
 
@@ -96,39 +96,39 @@
          id           case_name case_type sex age date_onset date_admission
       1   1    Macella Moreland confirmed   f  28 2023-01-01           <NA>
       2   2      Kayla Ellerman confirmed   f  62 2023-01-02     2023-01-02
-      3   5 Matthew Biggerstaff confirmed   m  42 2023-01-01           <NA>
-      4   6   Vanessa Sihombing  probable   f  60 2023-01-01           <NA>
-      5   8     Ross Mcclintock suspected   m  28 2023-01-02     2023-01-03
-      6   9     Danielle Medero confirmed   f  78 2023-01-01           <NA>
-      7  10      Suhaa el-Saidi suspected   f  31 2023-01-04     2023-01-17
-      8  16       Jakeob Wisham suspected   m  33 2023-01-01           <NA>
-      9  19   Shaahir el-Younis suspected   m  86 2023-01-01           <NA>
-      10 22     Arianna Bellomy confirmed   f  37 2023-01-01           <NA>
-      11 23     Angela Thompson  probable   f  15 2023-01-01           <NA>
-      12 25       Irvin Quezada suspected   m  81 2023-01-02     2023-01-03
-      13 26        Ronald Bliss  probable   m  82 2023-01-01           <NA>
-      14 27       Andrew Truong  probable   m  72 2023-01-02           <NA>
-      15 30       Dawson Wagner confirmed   m  71 2023-01-03           <NA>
-      16 31          Jacky Chen confirmed   m  50 2023-01-01           <NA>
-      17 36          Dewi Smith confirmed   f   3 2023-01-01           <NA>
+      3   5 Matthew Biggerstaff confirmed   m  42 2023-01-02           <NA>
+      4   6   Vanessa Sihombing  probable   f  60 2023-01-03           <NA>
+      5   8     Ross Mcclintock suspected   m  28 2023-01-03     2023-01-05
+      6   9     Danielle Medero confirmed   f  78 2023-01-03           <NA>
+      7  10      Suhaa el-Saidi suspected   f  31 2023-01-07     2023-01-19
+      8  16       Jakeob Wisham suspected   m  33 2023-01-04           <NA>
+      9  19   Shaahir el-Younis suspected   m  86 2023-01-04           <NA>
+      10 22     Arianna Bellomy confirmed   f  37 2023-01-05           <NA>
+      11 23     Angela Thompson  probable   f  15 2023-01-05           <NA>
+      12 25       Irvin Quezada suspected   m  81 2023-01-07     2023-01-08
+      13 26        Ronald Bliss  probable   m  82 2023-01-08           <NA>
+      14 27       Andrew Truong  probable   m  72 2023-01-09           <NA>
+      15 30       Dawson Wagner confirmed   m  71 2023-01-12           <NA>
+      16 31          Jacky Chen confirmed   m  50 2023-01-10           <NA>
+      17 36          Dewi Smith confirmed   f   3 2023-01-10           <NA>
          date_death date_first_contact date_last_contact
       1        <NA>               <NA>              <NA>
       2        <NA>         2023-01-02        2023-01-05
       3        <NA>         2023-01-03        2023-01-04
       4        <NA>         2023-01-02        2023-01-04
-      5        <NA>         2023-01-01        2023-01-03
-      6        <NA>         2022-12-29        2023-01-04
-      7        <NA>         2023-01-04        2023-01-07
-      8        <NA>         2023-01-03        2023-01-04
-      9        <NA>         2023-01-03        2023-01-04
-      10 2023-01-19         2023-01-03        2023-01-05
-      11       <NA>         2023-01-03        2023-01-04
-      12       <NA>         2023-01-03        2023-01-04
-      13       <NA>         2023-01-02        2023-01-04
-      14       <NA>         2023-01-03        2023-01-04
-      15       <NA>         2023-01-04        2023-01-04
-      16       <NA>         2023-01-01        2023-01-04
-      17       <NA>         2023-01-03        2023-01-05
+      5        <NA>         2023-01-02        2023-01-04
+      6        <NA>         2022-12-30        2023-01-05
+      7        <NA>         2023-01-06        2023-01-09
+      8        <NA>         2023-01-04        2023-01-05
+      9        <NA>         2023-01-06        2023-01-07
+      10 2023-01-23         2023-01-06        2023-01-08
+      11       <NA>         2023-01-07        2023-01-08
+      12       <NA>         2023-01-07        2023-01-08
+      13       <NA>         2023-01-07        2023-01-09
+      14       <NA>         2023-01-10        2023-01-11
+      15       <NA>         2023-01-11        2023-01-11
+      16       <NA>         2023-01-08        2023-01-11
+      17       <NA>         2023-01-12        2023-01-14
 
 # sim_linelist works as expected with anonymous
 
@@ -140,39 +140,39 @@
          id case_type sex age date_onset date_admission date_death date_first_contact
       1   1 confirmed   f  28 2023-01-01           <NA>       <NA>               <NA>
       2   2 confirmed   f  62 2023-01-02     2023-01-02       <NA>         2023-01-02
-      3   5  probable   m  42 2023-01-01           <NA>       <NA>         2023-01-03
-      4   6 confirmed   f  60 2023-01-01           <NA>       <NA>         2023-01-02
-      5   8 suspected   m  28 2023-01-02     2023-01-03       <NA>         2023-01-01
-      6   9  probable   f  78 2023-01-01           <NA>       <NA>         2022-12-29
-      7  10 confirmed   f  31 2023-01-04     2023-01-17       <NA>         2023-01-04
-      8  16 confirmed   m  33 2023-01-01           <NA>       <NA>         2023-01-03
-      9  19 confirmed   m  86 2023-01-01           <NA>       <NA>         2023-01-03
-      10 22 suspected   f  37 2023-01-01           <NA> 2023-01-19         2023-01-03
-      11 23 confirmed   f  15 2023-01-01           <NA>       <NA>         2023-01-03
-      12 25  probable   m  81 2023-01-02     2023-01-03       <NA>         2023-01-03
-      13 26  probable   m  82 2023-01-01           <NA>       <NA>         2023-01-02
-      14 27 suspected   m  72 2023-01-02           <NA>       <NA>         2023-01-03
-      15 30  probable   m  71 2023-01-03           <NA>       <NA>         2023-01-04
-      16 31 confirmed   m  50 2023-01-01           <NA>       <NA>         2023-01-01
-      17 36 suspected   f   3 2023-01-01           <NA>       <NA>         2023-01-03
+      3   5  probable   m  42 2023-01-02           <NA>       <NA>         2023-01-03
+      4   6 confirmed   f  60 2023-01-03           <NA>       <NA>         2023-01-02
+      5   8 suspected   m  28 2023-01-03     2023-01-05       <NA>         2023-01-02
+      6   9  probable   f  78 2023-01-03           <NA>       <NA>         2022-12-30
+      7  10 confirmed   f  31 2023-01-07     2023-01-19       <NA>         2023-01-06
+      8  16 confirmed   m  33 2023-01-04           <NA>       <NA>         2023-01-04
+      9  19 confirmed   m  86 2023-01-04           <NA>       <NA>         2023-01-06
+      10 22 suspected   f  37 2023-01-05           <NA> 2023-01-23         2023-01-06
+      11 23 confirmed   f  15 2023-01-05           <NA>       <NA>         2023-01-07
+      12 25  probable   m  81 2023-01-07     2023-01-08       <NA>         2023-01-07
+      13 26  probable   m  82 2023-01-08           <NA>       <NA>         2023-01-07
+      14 27 suspected   m  72 2023-01-09           <NA>       <NA>         2023-01-10
+      15 30  probable   m  71 2023-01-12           <NA>       <NA>         2023-01-11
+      16 31 confirmed   m  50 2023-01-10           <NA>       <NA>         2023-01-08
+      17 36 suspected   f   3 2023-01-10           <NA>       <NA>         2023-01-12
          date_last_contact ct_value
       1               <NA>     25.7
       2         2023-01-05     25.7
       3         2023-01-04       NA
       4         2023-01-04     25.7
-      5         2023-01-03       NA
-      6         2023-01-04       NA
-      7         2023-01-07     25.7
-      8         2023-01-04     25.7
-      9         2023-01-04     25.7
-      10        2023-01-05       NA
-      11        2023-01-04     25.7
-      12        2023-01-04       NA
-      13        2023-01-04       NA
-      14        2023-01-04       NA
-      15        2023-01-04       NA
-      16        2023-01-04     25.7
-      17        2023-01-05       NA
+      5         2023-01-04       NA
+      6         2023-01-05       NA
+      7         2023-01-09     25.7
+      8         2023-01-05     25.7
+      9         2023-01-07     25.7
+      10        2023-01-08       NA
+      11        2023-01-08     25.7
+      12        2023-01-08       NA
+      13        2023-01-09       NA
+      14        2023-01-11       NA
+      15        2023-01-11       NA
+      16        2023-01-11     25.7
+      17        2023-01-14       NA
 
 # sim_linelist works as expected with age structure
 
@@ -184,39 +184,39 @@
          id            case_name case_type sex age date_onset date_admission
       1   1      Molly Archuleta confirmed   f   8 2023-01-01           <NA>
       2   2        Gracie Lorenz confirmed   f  76 2023-01-02     2023-01-03
-      3   5         David Alexis confirmed   m   9 2023-01-01           <NA>
-      4   6 Jazmyn Trotter-Brown confirmed   f  89 2023-01-01     2023-01-04
-      5   8           Jack Byers confirmed   m  16 2023-01-02     2023-01-02
-      6   9         Janet Cortez confirmed   f  82 2023-01-01           <NA>
-      7  10         Angeling Das  probable   f  27 2023-01-04           <NA>
-      8  16         Paul Collier  probable   m  47 2023-01-01           <NA>
-      9  19  Shawn Bustos-Campos confirmed   m  85 2023-01-01     2023-01-07
-      10 22      Fuaada al-Kanan suspected   f  57 2023-01-01           <NA>
-      11 23       Caitlin Reeves  probable   f  89 2023-01-01           <NA>
-      12 25       Samuel Thacker confirmed   m  90 2023-01-02           <NA>
-      13 26      Kenneth Huggins suspected   m  48 2023-01-01           <NA>
-      14 27        Alonzo Foster confirmed   m  62 2023-01-02           <NA>
-      15 30      Wajeeb al-Jafri confirmed   m   9 2023-01-03           <NA>
-      16 31        Kyron Pollard confirmed   m  29 2023-01-01           <NA>
-      17 36       Quinasia Lewis  probable   f  79 2023-01-01           <NA>
+      3   5         David Alexis confirmed   m   9 2023-01-02           <NA>
+      4   6 Jazmyn Trotter-Brown confirmed   f  89 2023-01-03     2023-01-05
+      5   8           Jack Byers confirmed   m  16 2023-01-03     2023-01-04
+      6   9         Janet Cortez confirmed   f  82 2023-01-03           <NA>
+      7  10         Angeling Das  probable   f  27 2023-01-07           <NA>
+      8  16         Paul Collier  probable   m  47 2023-01-04           <NA>
+      9  19  Shawn Bustos-Campos confirmed   m  85 2023-01-04     2023-01-10
+      10 22      Fuaada al-Kanan suspected   f  57 2023-01-05           <NA>
+      11 23       Caitlin Reeves  probable   f  89 2023-01-05           <NA>
+      12 25       Samuel Thacker confirmed   m  90 2023-01-07           <NA>
+      13 26      Kenneth Huggins suspected   m  48 2023-01-08           <NA>
+      14 27        Alonzo Foster confirmed   m  62 2023-01-09           <NA>
+      15 30      Wajeeb al-Jafri confirmed   m   9 2023-01-12           <NA>
+      16 31        Kyron Pollard confirmed   m  29 2023-01-10           <NA>
+      17 36       Quinasia Lewis  probable   f  79 2023-01-10           <NA>
          date_death date_first_contact date_last_contact ct_value
       1        <NA>               <NA>              <NA>     24.3
       2        <NA>         2023-01-02        2023-01-05     24.3
       3        <NA>         2023-01-03        2023-01-04     24.3
       4        <NA>         2023-01-02        2023-01-04     24.3
-      5        <NA>         2023-01-01        2023-01-03     24.3
-      6        <NA>         2022-12-29        2023-01-04     24.3
-      7        <NA>         2023-01-04        2023-01-07       NA
-      8        <NA>         2023-01-03        2023-01-04       NA
-      9        <NA>         2023-01-03        2023-01-04     24.3
-      10       <NA>         2023-01-03        2023-01-05       NA
-      11       <NA>         2023-01-03        2023-01-04       NA
-      12       <NA>         2023-01-03        2023-01-04     24.3
-      13       <NA>         2023-01-02        2023-01-04       NA
-      14       <NA>         2023-01-03        2023-01-04     24.3
-      15       <NA>         2023-01-04        2023-01-04     24.3
-      16       <NA>         2023-01-01        2023-01-04     24.3
-      17       <NA>         2023-01-03        2023-01-05       NA
+      5        <NA>         2023-01-02        2023-01-04     24.3
+      6        <NA>         2022-12-30        2023-01-05     24.3
+      7        <NA>         2023-01-06        2023-01-09       NA
+      8        <NA>         2023-01-04        2023-01-05       NA
+      9        <NA>         2023-01-06        2023-01-07     24.3
+      10       <NA>         2023-01-06        2023-01-08       NA
+      11       <NA>         2023-01-07        2023-01-08       NA
+      12       <NA>         2023-01-07        2023-01-08     24.3
+      13       <NA>         2023-01-07        2023-01-09       NA
+      14       <NA>         2023-01-10        2023-01-11     24.3
+      15       <NA>         2023-01-11        2023-01-11     24.3
+      16       <NA>         2023-01-08        2023-01-11     24.3
+      17       <NA>         2023-01-12        2023-01-14       NA
 
 # sim_linelist works as expected with age-strat risks & age struct
 
@@ -228,39 +228,39 @@
          id          case_name case_type sex age date_onset date_admission date_death
       1   1  Elvia Ramos-Salas confirmed   f   8 2023-01-01           <NA>       <NA>
       2   2   Izza al-Muhammed confirmed   f  76 2023-01-02           <NA>       <NA>
-      3   5    Nicholas Oliver  probable   m   9 2023-01-01           <NA>       <NA>
-      4   6      Monique Payne  probable   f  89 2023-01-01           <NA>       <NA>
-      5   8       Nathan Yatsu confirmed   m  16 2023-01-02           <NA>       <NA>
-      6   9 Musheera al-Dajani confirmed   f  82 2023-01-01     2023-01-08       <NA>
-      7  10     Cassidy Wilson suspected   f  27 2023-01-04           <NA>       <NA>
-      8  16     Yinghan Sahani suspected   m  47 2023-01-01           <NA> 2023-01-13
-      9  19         Zane Vitry confirmed   m  85 2023-01-01           <NA>       <NA>
-      10 22      Sarah Fejeran confirmed   f  57 2023-01-01           <NA>       <NA>
-      11 23       Susan Watson confirmed   f  89 2023-01-01           <NA>       <NA>
-      12 25        Tyler Begay confirmed   m  90 2023-01-02           <NA>       <NA>
-      13 26   Jonathan Johnson confirmed   m  48 2023-01-01           <NA>       <NA>
-      14 27    Daif al-Ebrahim  probable   m  62 2023-01-02     2023-01-03       <NA>
-      15 30        David Simok suspected   m   9 2023-01-03           <NA>       <NA>
-      16 31        Khameron Vu confirmed   m  29 2023-01-01           <NA>       <NA>
-      17 36   Brittany Tillman suspected   f  79 2023-01-01           <NA>       <NA>
+      3   5    Nicholas Oliver  probable   m   9 2023-01-02           <NA>       <NA>
+      4   6      Monique Payne  probable   f  89 2023-01-03           <NA>       <NA>
+      5   8       Nathan Yatsu confirmed   m  16 2023-01-03           <NA>       <NA>
+      6   9 Musheera al-Dajani confirmed   f  82 2023-01-03     2023-01-10       <NA>
+      7  10     Cassidy Wilson suspected   f  27 2023-01-07           <NA>       <NA>
+      8  16     Yinghan Sahani suspected   m  47 2023-01-04           <NA> 2023-01-16
+      9  19         Zane Vitry confirmed   m  85 2023-01-04           <NA>       <NA>
+      10 22      Sarah Fejeran confirmed   f  57 2023-01-05           <NA>       <NA>
+      11 23       Susan Watson confirmed   f  89 2023-01-05           <NA>       <NA>
+      12 25        Tyler Begay confirmed   m  90 2023-01-07           <NA>       <NA>
+      13 26   Jonathan Johnson confirmed   m  48 2023-01-08           <NA>       <NA>
+      14 27    Daif al-Ebrahim  probable   m  62 2023-01-09     2023-01-10       <NA>
+      15 30        David Simok suspected   m   9 2023-01-12           <NA>       <NA>
+      16 31        Khameron Vu confirmed   m  29 2023-01-10           <NA>       <NA>
+      17 36   Brittany Tillman suspected   f  79 2023-01-10           <NA>       <NA>
          date_first_contact date_last_contact ct_value
       1                <NA>              <NA>     26.8
       2          2023-01-02        2023-01-05     26.8
       3          2023-01-03        2023-01-04       NA
       4          2023-01-02        2023-01-04       NA
-      5          2023-01-01        2023-01-03     26.8
-      6          2022-12-29        2023-01-04     26.8
-      7          2023-01-04        2023-01-07       NA
-      8          2023-01-03        2023-01-04       NA
-      9          2023-01-03        2023-01-04     26.8
-      10         2023-01-03        2023-01-05     26.8
-      11         2023-01-03        2023-01-04     26.8
-      12         2023-01-03        2023-01-04     26.8
-      13         2023-01-02        2023-01-04     26.8
-      14         2023-01-03        2023-01-04       NA
-      15         2023-01-04        2023-01-04       NA
-      16         2023-01-01        2023-01-04     26.8
-      17         2023-01-03        2023-01-05       NA
+      5          2023-01-02        2023-01-04     26.8
+      6          2022-12-30        2023-01-05     26.8
+      7          2023-01-06        2023-01-09       NA
+      8          2023-01-04        2023-01-05       NA
+      9          2023-01-06        2023-01-07     26.8
+      10         2023-01-06        2023-01-08     26.8
+      11         2023-01-07        2023-01-08     26.8
+      12         2023-01-07        2023-01-08     26.8
+      13         2023-01-07        2023-01-09     26.8
+      14         2023-01-10        2023-01-11       NA
+      15         2023-01-11        2023-01-11       NA
+      16         2023-01-08        2023-01-11     26.8
+      17         2023-01-12        2023-01-14       NA
 
 # sim_linelist works as expected with modified config
 
@@ -273,39 +273,39 @@
          id         case_name case_type sex age date_onset date_admission date_death
       1   1 Michelle Gonzales confirmed   f  75 2023-01-01           <NA>       <NA>
       2   2   Melanie Shaffer confirmed   f   2 2023-01-02           <NA>       <NA>
-      3   5    Artrielle Webb confirmed   f  15 2023-01-01     2023-01-02       <NA>
-      4   6      Casey Tucson suspected   f  28 2023-01-01     2023-01-16       <NA>
-      5   8   John Yanushonis suspected   m  69 2023-01-02           <NA>       <NA>
-      6   9    Carli Burciaga  probable   f  78 2023-01-01           <NA>       <NA>
-      7  10   Saalih al-Islam suspected   m  37 2023-01-04           <NA>       <NA>
-      8  16      Daif al-Awan  probable   m  83 2023-01-01           <NA>       <NA>
-      9  19 Chanise Armstrong confirmed   f  68 2023-01-01     2023-01-06 2023-01-08
-      10 22    Dalene Charlie suspected   f  52 2023-01-01           <NA>       <NA>
-      11 23    Trent Atkinson confirmed   m  80 2023-01-01           <NA>       <NA>
-      12 25    Shandel Shreve confirmed   f  35 2023-01-02     2023-01-02       <NA>
-      13 26  Antonio Spradley confirmed   m  74 2023-01-01           <NA>       <NA>
-      14 27     William Oster  probable   m  70 2023-01-02           <NA>       <NA>
-      15 30      Hannah Hicks  probable   f  49 2023-01-03           <NA>       <NA>
-      16 31     Sara Broomand suspected   f  87 2023-01-01           <NA>       <NA>
-      17 36  Keith Henningsen confirmed   m  13 2023-01-01           <NA>       <NA>
+      3   5    Artrielle Webb confirmed   f  15 2023-01-02     2023-01-03       <NA>
+      4   6      Casey Tucson suspected   f  28 2023-01-03     2023-01-17       <NA>
+      5   8   John Yanushonis suspected   m  69 2023-01-03           <NA>       <NA>
+      6   9    Carli Burciaga  probable   f  78 2023-01-03           <NA>       <NA>
+      7  10   Saalih al-Islam suspected   m  37 2023-01-07           <NA>       <NA>
+      8  16      Daif al-Awan  probable   m  83 2023-01-04           <NA>       <NA>
+      9  19 Chanise Armstrong confirmed   f  68 2023-01-04     2023-01-09 2023-01-12
+      10 22    Dalene Charlie suspected   f  52 2023-01-05           <NA>       <NA>
+      11 23    Trent Atkinson confirmed   m  80 2023-01-05           <NA>       <NA>
+      12 25    Shandel Shreve confirmed   f  35 2023-01-07     2023-01-07       <NA>
+      13 26  Antonio Spradley confirmed   m  74 2023-01-08           <NA>       <NA>
+      14 27     William Oster  probable   m  70 2023-01-09           <NA>       <NA>
+      15 30      Hannah Hicks  probable   f  49 2023-01-12           <NA>       <NA>
+      16 31     Sara Broomand suspected   f  87 2023-01-10           <NA>       <NA>
+      17 36  Keith Henningsen confirmed   m  13 2023-01-10           <NA>       <NA>
          date_first_contact date_last_contact ct_value
       1                <NA>              <NA>       24
       2          2022-12-31        2023-01-01       24
       3          2023-01-01        2023-01-02       24
       4          2022-12-31        2023-01-05       NA
-      5          2022-12-30        2023-01-01       NA
-      6          2022-12-30        2023-01-02       NA
-      7          2022-12-31        2023-01-01       NA
-      8          2022-12-31        2023-01-02       NA
-      9          2022-12-27        2023-01-02       24
-      10         2022-12-30        2023-01-01       NA
-      11         2022-12-29        2023-01-02       24
-      12         2023-01-01        2023-01-03       24
-      13         2022-12-31        2023-01-02       24
-      14         2022-12-28        2023-01-01       NA
-      15         2022-12-30        2023-01-02       NA
-      16         2023-01-05        2023-01-06       NA
-      17         2022-12-29        2023-01-01       24
+      5          2022-12-31        2023-01-02       NA
+      6          2022-12-31        2023-01-03       NA
+      7          2023-01-02        2023-01-03       NA
+      8          2023-01-01        2023-01-03       NA
+      9          2022-12-30        2023-01-05       24
+      10         2023-01-02        2023-01-04       NA
+      11         2023-01-02        2023-01-06       24
+      12         2023-01-05        2023-01-07       24
+      13         2023-01-05        2023-01-07       24
+      14         2023-01-04        2023-01-08       NA
+      15         2023-01-06        2023-01-09       NA
+      16         2023-01-12        2023-01-13       NA
+      17         2023-01-07        2023-01-10       24
 
 # sim_linelist works as expected with modified config parameters
 
@@ -317,37 +317,37 @@
          id           case_name case_type sex age date_onset date_admission
       1   1    Macella Moreland confirmed   f  28 2023-01-01           <NA>
       2   2      Kayla Ellerman confirmed   f  62 2023-01-02     2023-01-02
-      3   5 Matthew Biggerstaff confirmed   m  42 2023-01-01           <NA>
-      4   6   Vanessa Sihombing  probable   f  60 2023-01-01           <NA>
-      5   8     Ross Mcclintock suspected   m  28 2023-01-02     2023-01-03
-      6   9     Danielle Medero confirmed   f  78 2023-01-01           <NA>
-      7  10      Suhaa el-Saidi suspected   f  31 2023-01-04     2023-01-17
-      8  16       Jakeob Wisham suspected   m  33 2023-01-01           <NA>
-      9  19   Shaahir el-Younis suspected   m  86 2023-01-01           <NA>
-      10 22     Arianna Bellomy confirmed   f  37 2023-01-01           <NA>
-      11 23     Angela Thompson  probable   f  15 2023-01-01           <NA>
-      12 25       Irvin Quezada suspected   m  81 2023-01-02     2023-01-03
-      13 26        Ronald Bliss  probable   m  82 2023-01-01           <NA>
-      14 27       Andrew Truong  probable   m  72 2023-01-02           <NA>
-      15 30       Dawson Wagner confirmed   m  71 2023-01-03           <NA>
-      16 31          Jacky Chen confirmed   m  50 2023-01-01           <NA>
-      17 36          Dewi Smith confirmed   f   3 2023-01-01           <NA>
+      3   5 Matthew Biggerstaff confirmed   m  42 2023-01-02           <NA>
+      4   6   Vanessa Sihombing  probable   f  60 2023-01-03           <NA>
+      5   8     Ross Mcclintock suspected   m  28 2023-01-03     2023-01-05
+      6   9     Danielle Medero confirmed   f  78 2023-01-03           <NA>
+      7  10      Suhaa el-Saidi suspected   f  31 2023-01-07     2023-01-19
+      8  16       Jakeob Wisham suspected   m  33 2023-01-04           <NA>
+      9  19   Shaahir el-Younis suspected   m  86 2023-01-04           <NA>
+      10 22     Arianna Bellomy confirmed   f  37 2023-01-05           <NA>
+      11 23     Angela Thompson  probable   f  15 2023-01-05           <NA>
+      12 25       Irvin Quezada suspected   m  81 2023-01-07     2023-01-08
+      13 26        Ronald Bliss  probable   m  82 2023-01-08           <NA>
+      14 27       Andrew Truong  probable   m  72 2023-01-09           <NA>
+      15 30       Dawson Wagner confirmed   m  71 2023-01-12           <NA>
+      16 31          Jacky Chen confirmed   m  50 2023-01-10           <NA>
+      17 36          Dewi Smith confirmed   f   3 2023-01-10           <NA>
          date_death date_first_contact date_last_contact ct_value
       1        <NA>               <NA>              <NA>     23.6
       2        <NA>         2023-01-04        2023-01-07     23.6
       3        <NA>         2023-01-05        2023-01-06     23.6
       4        <NA>         2023-01-03        2023-01-05       NA
-      5        <NA>         2023-01-03        2023-01-05       NA
-      6        <NA>         2022-12-31        2023-01-06     23.6
-      7        <NA>         2023-01-06        2023-01-09       NA
-      8        <NA>         2023-01-05        2023-01-06       NA
-      9        <NA>         2023-01-06        2023-01-07       NA
-      10 2023-01-19         2023-01-05        2023-01-07     23.6
-      11       <NA>         2023-01-05        2023-01-06       NA
-      12       <NA>         2023-01-05        2023-01-06       NA
-      13       <NA>         2023-01-04        2023-01-06       NA
-      14       <NA>         2023-01-05        2023-01-06       NA
-      15       <NA>         2023-01-06        2023-01-06     23.6
-      16       <NA>         2023-01-02        2023-01-05     23.6
-      17       <NA>         2023-01-05        2023-01-07     23.6
+      5        <NA>         2023-01-04        2023-01-06       NA
+      6        <NA>         2023-01-01        2023-01-07     23.6
+      7        <NA>         2023-01-08        2023-01-11       NA
+      8        <NA>         2023-01-06        2023-01-07       NA
+      9        <NA>         2023-01-09        2023-01-10       NA
+      10 2023-01-23         2023-01-08        2023-01-10     23.6
+      11       <NA>         2023-01-09        2023-01-10       NA
+      12       <NA>         2023-01-09        2023-01-10       NA
+      13       <NA>         2023-01-09        2023-01-11       NA
+      14       <NA>         2023-01-12        2023-01-13       NA
+      15       <NA>         2023-01-13        2023-01-13     23.6
+      16       <NA>         2023-01-09        2023-01-12     23.6
+      17       <NA>         2023-01-14        2023-01-16     23.6
 

--- a/tests/testthat/_snaps/sim_network_bp.md
+++ b/tests/testthat/_snaps/sim_network_bp.md
@@ -4,17 +4,17 @@
       .sim_network_bp(contact_distribution = contact_distribution, contact_interval = contact_interval,
         prob_infect = 0.5, max_outbreak_size = 10000, config = create_config())
     Output
-         id ancestor generation infected       time
-      1   1       NA          1 infected 0.00000000
-      2   2        1          2  contact 1.88240160
-      3   3        1          2 infected 1.80451250
-      4   4        3          3 infected 0.05896314
-      5   5        3          3  contact 1.15835525
-      6   6        3          3  contact 0.99001994
-      7   7        4          4 infected 2.14036129
-      8   8        7          5  contact 0.46988251
-      9   9        7          5  contact 0.69425308
-      10 10        7          5  contact 0.06819735
+         id ancestor generation infected     time
+      1   1       NA          1 infected 0.000000
+      2   2        1          2  contact 1.882402
+      3   3        1          2 infected 1.804512
+      4   4        3          3 infected 1.863476
+      5   5        3          3  contact 2.962868
+      6   6        3          3  contact 2.794532
+      7   7        4          4 infected 4.003837
+      8   8        7          5  contact 4.473719
+      9   9        7          5  contact 4.698090
+      10 10        7          5  contact 4.072034
 
 # .sim_network_bp works as expected with no contacts
 
@@ -31,15 +31,15 @@
       .sim_network_bp(contact_distribution = contact_distribution, contact_interval = contact_interval,
         prob_infect = 0.5, max_outbreak_size = 10000, config = create_config(network = "unadjusted"))
     Output
-         id ancestor generation infected       time
-      1   1       NA          1 infected 0.00000000
-      2   2        1          2  contact 1.88240160
-      3   3        1          2 infected 1.80451250
-      4   4        3          3 infected 0.05896314
-      5   5        3          3  contact 1.15835525
-      6   6        3          3  contact 0.99001994
-      7   7        4          4 infected 2.14036129
-      8   8        7          5  contact 0.46988251
-      9   9        7          5  contact 0.69425308
-      10 10        7          5  contact 0.06819735
+         id ancestor generation infected     time
+      1   1       NA          1 infected 0.000000
+      2   2        1          2  contact 1.882402
+      3   3        1          2 infected 1.804512
+      4   4        3          3 infected 1.863476
+      5   5        3          3  contact 2.962868
+      6   6        3          3  contact 2.794532
+      7   7        4          4 infected 4.003837
+      8   8        7          5  contact 4.473719
+      9   9        7          5  contact 4.698090
+      10 10        7          5  contact 4.072034
 

--- a/tests/testthat/_snaps/sim_outbreak.md
+++ b/tests/testthat/_snaps/sim_outbreak.md
@@ -8,39 +8,39 @@
          id           case_name case_type sex age date_onset date_admission
       1   1    Macella Moreland confirmed   f  28 2023-01-01           <NA>
       2   2      Kayla Ellerman confirmed   f  62 2023-01-02     2023-01-02
-      3   5 Matthew Biggerstaff confirmed   m  42 2023-01-01           <NA>
-      4   6   Vanessa Sihombing  probable   f  60 2023-01-01           <NA>
-      5   8     Ross Mcclintock suspected   m  28 2023-01-02     2023-01-03
-      6   9     Danielle Medero confirmed   f  78 2023-01-01           <NA>
-      7  10      Suhaa el-Saidi suspected   f  31 2023-01-04     2023-01-17
-      8  16       Jakeob Wisham suspected   m  33 2023-01-01           <NA>
-      9  19   Shaahir el-Younis suspected   m  86 2023-01-01           <NA>
-      10 22     Arianna Bellomy confirmed   f  37 2023-01-01           <NA>
-      11 23     Angela Thompson  probable   f  15 2023-01-01           <NA>
-      12 25       Irvin Quezada suspected   m  81 2023-01-02     2023-01-03
-      13 26        Ronald Bliss  probable   m  82 2023-01-01           <NA>
-      14 27       Andrew Truong  probable   m  72 2023-01-02           <NA>
-      15 30       Dawson Wagner confirmed   m  71 2023-01-03           <NA>
-      16 31          Jacky Chen confirmed   m  50 2023-01-01           <NA>
-      17 36          Dewi Smith confirmed   f   3 2023-01-01           <NA>
+      3   5 Matthew Biggerstaff confirmed   m  42 2023-01-02           <NA>
+      4   6   Vanessa Sihombing  probable   f  60 2023-01-03           <NA>
+      5   8     Ross Mcclintock suspected   m  28 2023-01-03     2023-01-05
+      6   9     Danielle Medero confirmed   f  78 2023-01-03           <NA>
+      7  10      Suhaa el-Saidi suspected   f  31 2023-01-07     2023-01-19
+      8  16       Jakeob Wisham suspected   m  33 2023-01-04           <NA>
+      9  19   Shaahir el-Younis suspected   m  86 2023-01-04           <NA>
+      10 22     Arianna Bellomy confirmed   f  37 2023-01-05           <NA>
+      11 23     Angela Thompson  probable   f  15 2023-01-05           <NA>
+      12 25       Irvin Quezada suspected   m  81 2023-01-07     2023-01-08
+      13 26        Ronald Bliss  probable   m  82 2023-01-08           <NA>
+      14 27       Andrew Truong  probable   m  72 2023-01-09           <NA>
+      15 30       Dawson Wagner confirmed   m  71 2023-01-12           <NA>
+      16 31          Jacky Chen confirmed   m  50 2023-01-10           <NA>
+      17 36          Dewi Smith confirmed   f   3 2023-01-10           <NA>
          date_death date_first_contact date_last_contact ct_value
       1        <NA>               <NA>              <NA>     23.6
       2        <NA>         2023-01-02        2023-01-05     23.6
       3        <NA>         2023-01-03        2023-01-04     23.6
       4        <NA>         2023-01-02        2023-01-04       NA
-      5        <NA>         2023-01-01        2023-01-03       NA
-      6        <NA>         2022-12-29        2023-01-04     23.6
-      7        <NA>         2023-01-04        2023-01-07       NA
-      8        <NA>         2023-01-03        2023-01-04       NA
-      9        <NA>         2023-01-03        2023-01-04       NA
-      10 2023-01-19         2023-01-03        2023-01-05     23.6
-      11       <NA>         2023-01-03        2023-01-04       NA
-      12       <NA>         2023-01-03        2023-01-04       NA
-      13       <NA>         2023-01-02        2023-01-04       NA
-      14       <NA>         2023-01-03        2023-01-04       NA
-      15       <NA>         2023-01-04        2023-01-04     23.6
-      16       <NA>         2023-01-01        2023-01-04     23.6
-      17       <NA>         2023-01-03        2023-01-05     23.6
+      5        <NA>         2023-01-02        2023-01-04       NA
+      6        <NA>         2022-12-30        2023-01-05     23.6
+      7        <NA>         2023-01-06        2023-01-09       NA
+      8        <NA>         2023-01-04        2023-01-05       NA
+      9        <NA>         2023-01-06        2023-01-07       NA
+      10 2023-01-23         2023-01-06        2023-01-08     23.6
+      11       <NA>         2023-01-07        2023-01-08       NA
+      12       <NA>         2023-01-07        2023-01-08       NA
+      13       <NA>         2023-01-07        2023-01-09       NA
+      14       <NA>         2023-01-10        2023-01-11       NA
+      15       <NA>         2023-01-11        2023-01-11     23.6
+      16       <NA>         2023-01-08        2023-01-11     23.6
+      17       <NA>         2023-01-12        2023-01-14     23.6
       
       $contacts
                         from                      to age sex date_first_contact
@@ -50,35 +50,35 @@
       4       Kayla Ellerman     Matthew Biggerstaff  42   m         2023-01-03
       5       Kayla Ellerman       Vanessa Sihombing  60   f         2023-01-02
       6       Kayla Ellerman            Joslyn Smith  65   f         2022-12-31
-      7  Matthew Biggerstaff         Ross Mcclintock  28   m         2023-01-01
-      8  Matthew Biggerstaff         Danielle Medero  78   f         2022-12-29
-      9    Vanessa Sihombing          Suhaa el-Saidi  31   f         2023-01-04
-      10   Vanessa Sihombing           Ethan Lapitan  12   m         2023-01-02
-      11   Vanessa Sihombing              Amanda Day  80   f         2023-01-01
-      12     Ross Mcclintock         Breianna Colson  44   f         2022-12-29
-      13     Ross Mcclintock Benjamin Yokota-Stroman  74   m         2022-12-31
-      14     Ross Mcclintock           Austin Wilson  26   m         2023-01-06
-      15     Ross Mcclintock           Jakeob Wisham  33   m         2023-01-03
-      16     Ross Mcclintock         Victor Elizondo   4   m         2022-12-30
-      17      Suhaa el-Saidi       Gustavo Hernandez  53   m         2023-01-03
-      18       Jakeob Wisham       Shaahir el-Younis  86   m         2023-01-03
-      19   Shaahir el-Younis         Chelsea Phoenix  89   f         2023-01-02
-      20   Shaahir el-Younis         Kalina Siddiqui  24   f         2023-01-04
-      21   Shaahir el-Younis         Arianna Bellomy  37   f         2023-01-03
-      22     Arianna Bellomy         Angela Thompson  15   f         2023-01-03
-      23     Angela Thompson             Daniel Pham  14   m         2023-01-02
-      24     Angela Thompson           Irvin Quezada  81   m         2023-01-03
-      25       Irvin Quezada            Ronald Bliss  82   m         2023-01-02
-      26        Ronald Bliss           Andrew Truong  72   m         2023-01-03
-      27        Ronald Bliss          Dillan Aguilar  53   m         2023-01-03
-      28        Ronald Bliss            Andres Garza  56   m         2022-12-29
-      29       Andrew Truong           Dawson Wagner  71   m         2023-01-04
-      30       Andrew Truong              Jacky Chen  50   m         2023-01-01
-      31       Andrew Truong          Ignacio Gentry  73   m         2022-12-31
-      32       Andrew Truong              Tessa Yang  20   f         2023-01-01
-      33       Dawson Wagner             Jair Garcia  75   m         2023-01-06
-      34       Dawson Wagner             Monique Lau   2   f         2023-01-08
-      35          Jacky Chen              Dewi Smith   3   f         2023-01-03
+      7  Matthew Biggerstaff         Ross Mcclintock  28   m         2023-01-02
+      8  Matthew Biggerstaff         Danielle Medero  78   f         2022-12-30
+      9    Vanessa Sihombing          Suhaa el-Saidi  31   f         2023-01-06
+      10   Vanessa Sihombing           Ethan Lapitan  12   m         2023-01-04
+      11   Vanessa Sihombing              Amanda Day  80   f         2023-01-03
+      12     Ross Mcclintock         Breianna Colson  44   f         2022-12-30
+      13     Ross Mcclintock Benjamin Yokota-Stroman  74   m         2023-01-01
+      14     Ross Mcclintock           Austin Wilson  26   m         2023-01-07
+      15     Ross Mcclintock           Jakeob Wisham  33   m         2023-01-04
+      16     Ross Mcclintock         Victor Elizondo   4   m         2022-12-31
+      17      Suhaa el-Saidi       Gustavo Hernandez  53   m         2023-01-06
+      18       Jakeob Wisham       Shaahir el-Younis  86   m         2023-01-06
+      19   Shaahir el-Younis         Chelsea Phoenix  89   f         2023-01-05
+      20   Shaahir el-Younis         Kalina Siddiqui  24   f         2023-01-07
+      21   Shaahir el-Younis         Arianna Bellomy  37   f         2023-01-06
+      22     Arianna Bellomy         Angela Thompson  15   f         2023-01-07
+      23     Angela Thompson             Daniel Pham  14   m         2023-01-06
+      24     Angela Thompson           Irvin Quezada  81   m         2023-01-07
+      25       Irvin Quezada            Ronald Bliss  82   m         2023-01-07
+      26        Ronald Bliss           Andrew Truong  72   m         2023-01-10
+      27        Ronald Bliss          Dillan Aguilar  53   m         2023-01-10
+      28        Ronald Bliss            Andres Garza  56   m         2023-01-05
+      29       Andrew Truong           Dawson Wagner  71   m         2023-01-11
+      30       Andrew Truong              Jacky Chen  50   m         2023-01-08
+      31       Andrew Truong          Ignacio Gentry  73   m         2023-01-07
+      32       Andrew Truong              Tessa Yang  20   f         2023-01-08
+      33       Dawson Wagner             Jair Garcia  75   m         2023-01-15
+      34       Dawson Wagner             Monique Lau   2   f         2023-01-17
+      35          Jacky Chen              Dewi Smith   3   f         2023-01-12
          date_last_contact was_case           status
       1         2023-01-05        Y             case
       2         2023-01-07        N   under_followup
@@ -86,35 +86,35 @@
       4         2023-01-04        Y             case
       5         2023-01-04        Y             case
       6         2023-01-03        N   under_followup
-      7         2023-01-03        Y             case
-      8         2023-01-04        Y             case
-      9         2023-01-07        Y             case
-      10        2023-01-04        N   under_followup
-      11        2023-01-03        N   under_followup
-      12        2023-01-02        N   under_followup
-      13        2023-01-04        N lost_to_followup
-      14        2023-01-07        N lost_to_followup
-      15        2023-01-04        Y             case
-      16        2023-01-03        N   under_followup
-      17        2023-01-06        N   under_followup
-      18        2023-01-04        Y             case
-      19        2023-01-03        N   under_followup
-      20        2023-01-05        N   under_followup
-      21        2023-01-05        Y             case
-      22        2023-01-04        Y             case
-      23        2023-01-04        N   under_followup
-      24        2023-01-04        Y             case
-      25        2023-01-04        Y             case
-      26        2023-01-04        Y             case
-      27        2023-01-06        N   under_followup
-      28        2023-01-02        N   under_followup
-      29        2023-01-04        Y             case
-      30        2023-01-04        Y             case
-      31        2023-01-05        N   under_followup
-      32        2023-01-03        N   under_followup
-      33        2023-01-06        N lost_to_followup
-      34        2023-01-09        N   under_followup
-      35        2023-01-05        Y             case
+      7         2023-01-04        Y             case
+      8         2023-01-05        Y             case
+      9         2023-01-09        Y             case
+      10        2023-01-06        N   under_followup
+      11        2023-01-05        N   under_followup
+      12        2023-01-03        N   under_followup
+      13        2023-01-05        N lost_to_followup
+      14        2023-01-08        N lost_to_followup
+      15        2023-01-05        Y             case
+      16        2023-01-04        N   under_followup
+      17        2023-01-09        N   under_followup
+      18        2023-01-07        Y             case
+      19        2023-01-06        N   under_followup
+      20        2023-01-08        N   under_followup
+      21        2023-01-08        Y             case
+      22        2023-01-08        Y             case
+      23        2023-01-08        N   under_followup
+      24        2023-01-08        Y             case
+      25        2023-01-09        Y             case
+      26        2023-01-11        Y             case
+      27        2023-01-13        N   under_followup
+      28        2023-01-09        N   under_followup
+      29        2023-01-11        Y             case
+      30        2023-01-11        Y             case
+      31        2023-01-12        N   under_followup
+      32        2023-01-10        N   under_followup
+      33        2023-01-15        N lost_to_followup
+      34        2023-01-18        N   under_followup
+      35        2023-01-14        Y             case
       
 
 # sim_outbreak works as expected with add_names = FALSE
@@ -128,39 +128,39 @@
          id case_type sex age date_onset date_admission date_death date_first_contact
       1   1 confirmed   f  28 2023-01-01           <NA>       <NA>               <NA>
       2   2 confirmed   f  62 2023-01-02     2023-01-02       <NA>         2023-01-02
-      3   5  probable   m  42 2023-01-01           <NA>       <NA>         2023-01-03
-      4   6 confirmed   f  60 2023-01-01           <NA>       <NA>         2023-01-02
-      5   8 suspected   m  28 2023-01-02     2023-01-03       <NA>         2023-01-01
-      6   9  probable   f  78 2023-01-01           <NA>       <NA>         2022-12-29
-      7  10 confirmed   f  31 2023-01-04     2023-01-17       <NA>         2023-01-04
-      8  16 confirmed   m  33 2023-01-01           <NA>       <NA>         2023-01-03
-      9  19 confirmed   m  86 2023-01-01           <NA>       <NA>         2023-01-03
-      10 22 suspected   f  37 2023-01-01           <NA> 2023-01-19         2023-01-03
-      11 23 confirmed   f  15 2023-01-01           <NA>       <NA>         2023-01-03
-      12 25  probable   m  81 2023-01-02     2023-01-03       <NA>         2023-01-03
-      13 26  probable   m  82 2023-01-01           <NA>       <NA>         2023-01-02
-      14 27 suspected   m  72 2023-01-02           <NA>       <NA>         2023-01-03
-      15 30  probable   m  71 2023-01-03           <NA>       <NA>         2023-01-04
-      16 31 confirmed   m  50 2023-01-01           <NA>       <NA>         2023-01-01
-      17 36 suspected   f   3 2023-01-01           <NA>       <NA>         2023-01-03
+      3   5  probable   m  42 2023-01-02           <NA>       <NA>         2023-01-03
+      4   6 confirmed   f  60 2023-01-03           <NA>       <NA>         2023-01-02
+      5   8 suspected   m  28 2023-01-03     2023-01-05       <NA>         2023-01-02
+      6   9  probable   f  78 2023-01-03           <NA>       <NA>         2022-12-30
+      7  10 confirmed   f  31 2023-01-07     2023-01-19       <NA>         2023-01-06
+      8  16 confirmed   m  33 2023-01-04           <NA>       <NA>         2023-01-04
+      9  19 confirmed   m  86 2023-01-04           <NA>       <NA>         2023-01-06
+      10 22 suspected   f  37 2023-01-05           <NA> 2023-01-23         2023-01-06
+      11 23 confirmed   f  15 2023-01-05           <NA>       <NA>         2023-01-07
+      12 25  probable   m  81 2023-01-07     2023-01-08       <NA>         2023-01-07
+      13 26  probable   m  82 2023-01-08           <NA>       <NA>         2023-01-07
+      14 27 suspected   m  72 2023-01-09           <NA>       <NA>         2023-01-10
+      15 30  probable   m  71 2023-01-12           <NA>       <NA>         2023-01-11
+      16 31 confirmed   m  50 2023-01-10           <NA>       <NA>         2023-01-08
+      17 36 suspected   f   3 2023-01-10           <NA>       <NA>         2023-01-12
          date_last_contact ct_value
       1               <NA>     25.7
       2         2023-01-05     25.7
       3         2023-01-04       NA
       4         2023-01-04     25.7
-      5         2023-01-03       NA
-      6         2023-01-04       NA
-      7         2023-01-07     25.7
-      8         2023-01-04     25.7
-      9         2023-01-04     25.7
-      10        2023-01-05       NA
-      11        2023-01-04     25.7
-      12        2023-01-04       NA
-      13        2023-01-04       NA
-      14        2023-01-04       NA
-      15        2023-01-04       NA
-      16        2023-01-04     25.7
-      17        2023-01-05       NA
+      5         2023-01-04       NA
+      6         2023-01-05       NA
+      7         2023-01-09     25.7
+      8         2023-01-05     25.7
+      9         2023-01-07     25.7
+      10        2023-01-08       NA
+      11        2023-01-08     25.7
+      12        2023-01-08       NA
+      13        2023-01-09       NA
+      14        2023-01-11       NA
+      15        2023-01-11       NA
+      16        2023-01-11     25.7
+      17        2023-01-14       NA
       
       $contacts
                        from                 to age sex date_first_contact
@@ -170,35 +170,35 @@
       4  Fat'hiyaa al-Ishak  Jordan Mcclintock  42   m         2023-01-03
       5  Fat'hiyaa al-Ishak    Xeandra Watkins  60   f         2023-01-02
       6  Fat'hiyaa al-Ishak        Jenae Berhe  65   f         2022-12-31
-      7   Jordan Mcclintock        Ranny Bajwa  28   m         2023-01-01
-      8   Jordan Mcclintock         Ceara Pham  78   f         2022-12-29
-      9     Xeandra Watkins       Sara Baldwin  31   f         2023-01-04
-      10    Xeandra Watkins    Derek Pensoneau  12   m         2023-01-02
-      11    Xeandra Watkins        Nikki Begay  80   f         2023-01-01
-      12        Ranny Bajwa         Dewi Huynh  44   f         2022-12-29
-      13        Ranny Bajwa     Luis Gutierrez  74   m         2022-12-31
-      14        Ranny Bajwa       Kelvin Bliss  26   m         2023-01-06
-      15        Ranny Bajwa        Matthew Som  33   m         2023-01-03
-      16        Ranny Bajwa           Ian Hill   4   m         2022-12-30
-      17       Sara Baldwin      Dakota Wagner  53   m         2023-01-03
-      18        Matthew Som     Sean Kapushion  86   m         2023-01-03
-      19     Sean Kapushion  Saranya Wiedmaier  89   f         2023-01-02
-      20     Sean Kapushion         Han Mi Ngu  24   f         2023-01-04
-      21     Sean Kapushion   Tenazia Whitaker  37   f         2023-01-03
-      22   Tenazia Whitaker   Madeeha el-Nasir  15   f         2023-01-03
-      23   Madeeha el-Nasir        Joseph John  14   m         2023-01-02
-      24   Madeeha el-Nasir       Jacob Montez  81   m         2023-01-03
-      25       Jacob Montez        Jonathan Li  82   m         2023-01-02
-      26        Jonathan Li     Hamood el-Meer  72   m         2023-01-03
-      27        Jonathan Li     Giovanni Smith  53   m         2023-01-03
-      28        Jonathan Li         Atif Huynh  56   m         2022-12-29
-      29     Hamood el-Meer        Jonah Mahan  71   m         2023-01-04
-      30     Hamood el-Meer     Chandler Gasca  50   m         2023-01-01
-      31     Hamood el-Meer    Geoffrey Wisham  73   m         2022-12-31
-      32     Hamood el-Meer      Jazmyn Pillow  20   f         2023-01-01
-      33        Jonah Mahan   Rafeeq el-Younis  75   m         2023-01-06
-      34        Jonah Mahan      Savannah Hawk   2   f         2023-01-08
-      35     Chandler Gasca         Anna Chase   3   f         2023-01-03
+      7   Jordan Mcclintock        Ranny Bajwa  28   m         2023-01-02
+      8   Jordan Mcclintock         Ceara Pham  78   f         2022-12-30
+      9     Xeandra Watkins       Sara Baldwin  31   f         2023-01-06
+      10    Xeandra Watkins    Derek Pensoneau  12   m         2023-01-04
+      11    Xeandra Watkins        Nikki Begay  80   f         2023-01-03
+      12        Ranny Bajwa         Dewi Huynh  44   f         2022-12-30
+      13        Ranny Bajwa     Luis Gutierrez  74   m         2023-01-01
+      14        Ranny Bajwa       Kelvin Bliss  26   m         2023-01-07
+      15        Ranny Bajwa        Matthew Som  33   m         2023-01-04
+      16        Ranny Bajwa           Ian Hill   4   m         2022-12-31
+      17       Sara Baldwin      Dakota Wagner  53   m         2023-01-06
+      18        Matthew Som     Sean Kapushion  86   m         2023-01-06
+      19     Sean Kapushion  Saranya Wiedmaier  89   f         2023-01-05
+      20     Sean Kapushion         Han Mi Ngu  24   f         2023-01-07
+      21     Sean Kapushion   Tenazia Whitaker  37   f         2023-01-06
+      22   Tenazia Whitaker   Madeeha el-Nasir  15   f         2023-01-07
+      23   Madeeha el-Nasir        Joseph John  14   m         2023-01-06
+      24   Madeeha el-Nasir       Jacob Montez  81   m         2023-01-07
+      25       Jacob Montez        Jonathan Li  82   m         2023-01-07
+      26        Jonathan Li     Hamood el-Meer  72   m         2023-01-10
+      27        Jonathan Li     Giovanni Smith  53   m         2023-01-10
+      28        Jonathan Li         Atif Huynh  56   m         2023-01-05
+      29     Hamood el-Meer        Jonah Mahan  71   m         2023-01-11
+      30     Hamood el-Meer     Chandler Gasca  50   m         2023-01-08
+      31     Hamood el-Meer    Geoffrey Wisham  73   m         2023-01-07
+      32     Hamood el-Meer      Jazmyn Pillow  20   f         2023-01-08
+      33        Jonah Mahan   Rafeeq el-Younis  75   m         2023-01-15
+      34        Jonah Mahan      Savannah Hawk   2   f         2023-01-17
+      35     Chandler Gasca         Anna Chase   3   f         2023-01-12
          date_last_contact was_case           status
       1         2023-01-05        Y             case
       2         2023-01-07        N lost_to_followup
@@ -206,35 +206,35 @@
       4         2023-01-04        Y             case
       5         2023-01-04        Y             case
       6         2023-01-03        N   under_followup
-      7         2023-01-03        Y             case
-      8         2023-01-04        Y             case
-      9         2023-01-07        Y             case
-      10        2023-01-04        N   under_followup
-      11        2023-01-03        N   under_followup
-      12        2023-01-02        N   under_followup
-      13        2023-01-04        N   under_followup
-      14        2023-01-07        N   under_followup
-      15        2023-01-04        Y             case
-      16        2023-01-03        N   under_followup
-      17        2023-01-06        N   under_followup
-      18        2023-01-04        Y             case
-      19        2023-01-03        N lost_to_followup
-      20        2023-01-05        N   under_followup
-      21        2023-01-05        Y             case
-      22        2023-01-04        Y             case
-      23        2023-01-04        N   under_followup
-      24        2023-01-04        Y             case
-      25        2023-01-04        Y             case
-      26        2023-01-04        Y             case
-      27        2023-01-06        N   under_followup
-      28        2023-01-02        N   under_followup
-      29        2023-01-04        Y             case
-      30        2023-01-04        Y             case
-      31        2023-01-05        N   under_followup
-      32        2023-01-03        N lost_to_followup
-      33        2023-01-06        N lost_to_followup
-      34        2023-01-09        N lost_to_followup
-      35        2023-01-05        Y             case
+      7         2023-01-04        Y             case
+      8         2023-01-05        Y             case
+      9         2023-01-09        Y             case
+      10        2023-01-06        N   under_followup
+      11        2023-01-05        N   under_followup
+      12        2023-01-03        N   under_followup
+      13        2023-01-05        N   under_followup
+      14        2023-01-08        N   under_followup
+      15        2023-01-05        Y             case
+      16        2023-01-04        N   under_followup
+      17        2023-01-09        N   under_followup
+      18        2023-01-07        Y             case
+      19        2023-01-06        N lost_to_followup
+      20        2023-01-08        N   under_followup
+      21        2023-01-08        Y             case
+      22        2023-01-08        Y             case
+      23        2023-01-08        N   under_followup
+      24        2023-01-08        Y             case
+      25        2023-01-09        Y             case
+      26        2023-01-11        Y             case
+      27        2023-01-13        N   under_followup
+      28        2023-01-09        N   under_followup
+      29        2023-01-11        Y             case
+      30        2023-01-11        Y             case
+      31        2023-01-12        N   under_followup
+      32        2023-01-10        N lost_to_followup
+      33        2023-01-15        N lost_to_followup
+      34        2023-01-18        N lost_to_followup
+      35        2023-01-14        Y             case
       
 
 # sim_outbreak works as expected with age-strat risks
@@ -249,39 +249,39 @@
          id        case_name case_type sex age date_onset date_admission date_death
       1   1  Rachael Sneesby confirmed   f  28 2023-01-01           <NA>       <NA>
       2   2       Nadia Hill confirmed   f  62 2023-01-02     2023-01-02 2023-01-07
-      3   5   Jonathan Huynh  probable   m  42 2023-01-01           <NA>       <NA>
-      4   6  Tharwa al-Amber  probable   f  60 2023-01-01           <NA>       <NA>
-      5   8      Ian Sanchez suspected   m  28 2023-01-02           <NA>       <NA>
-      6   9       Sadie Ross confirmed   f  78 2023-01-01           <NA>       <NA>
-      7  10 Jordan Marquardt suspected   f  31 2023-01-04           <NA>       <NA>
-      8  16       Joseph Sky suspected   m  33 2023-01-01           <NA>       <NA>
-      9  19    Geoffrey Boon confirmed   m  86 2023-01-01           <NA>       <NA>
-      10 22    Juyoung Sands suspected   f  37 2023-01-01           <NA>       <NA>
-      11 23         Mya Hunt suspected   f  15 2023-01-01           <NA>       <NA>
-      12 25     Josef Fortes  probable   m  81 2023-01-02     2023-01-03 2023-01-24
-      13 26   Badri el-Hoque confirmed   m  82 2023-01-01           <NA>       <NA>
-      14 27    William Jones  probable   m  72 2023-01-02           <NA>       <NA>
-      15 30     Luis Arreola confirmed   m  71 2023-01-03           <NA>       <NA>
-      16 31   Zachary Abeyta  probable   m  50 2023-01-01           <NA>       <NA>
-      17 36  Shawnesse Smith suspected   f   3 2023-01-01           <NA>       <NA>
+      3   5   Jonathan Huynh  probable   m  42 2023-01-02           <NA>       <NA>
+      4   6  Tharwa al-Amber  probable   f  60 2023-01-03           <NA>       <NA>
+      5   8      Ian Sanchez suspected   m  28 2023-01-03           <NA>       <NA>
+      6   9       Sadie Ross confirmed   f  78 2023-01-03           <NA>       <NA>
+      7  10 Jordan Marquardt suspected   f  31 2023-01-07           <NA>       <NA>
+      8  16       Joseph Sky suspected   m  33 2023-01-04           <NA>       <NA>
+      9  19    Geoffrey Boon confirmed   m  86 2023-01-04           <NA>       <NA>
+      10 22    Juyoung Sands suspected   f  37 2023-01-05           <NA>       <NA>
+      11 23         Mya Hunt suspected   f  15 2023-01-05           <NA>       <NA>
+      12 25     Josef Fortes  probable   m  81 2023-01-07     2023-01-08 2023-01-29
+      13 26   Badri el-Hoque confirmed   m  82 2023-01-08           <NA>       <NA>
+      14 27    William Jones  probable   m  72 2023-01-09           <NA>       <NA>
+      15 30     Luis Arreola confirmed   m  71 2023-01-12           <NA>       <NA>
+      16 31   Zachary Abeyta  probable   m  50 2023-01-10           <NA>       <NA>
+      17 36  Shawnesse Smith suspected   f   3 2023-01-10           <NA>       <NA>
          date_first_contact date_last_contact ct_value
       1                <NA>              <NA>     24.3
       2          2023-01-02        2023-01-05     24.3
       3          2023-01-03        2023-01-04       NA
       4          2023-01-02        2023-01-04       NA
-      5          2023-01-01        2023-01-03       NA
-      6          2022-12-29        2023-01-04     24.3
-      7          2023-01-04        2023-01-07       NA
-      8          2023-01-03        2023-01-04       NA
-      9          2023-01-03        2023-01-04     24.3
-      10         2023-01-03        2023-01-05       NA
-      11         2023-01-03        2023-01-04       NA
-      12         2023-01-03        2023-01-04       NA
-      13         2023-01-02        2023-01-04     24.3
-      14         2023-01-03        2023-01-04       NA
-      15         2023-01-04        2023-01-04     24.3
-      16         2023-01-01        2023-01-04       NA
-      17         2023-01-03        2023-01-05       NA
+      5          2023-01-02        2023-01-04       NA
+      6          2022-12-30        2023-01-05     24.3
+      7          2023-01-06        2023-01-09       NA
+      8          2023-01-04        2023-01-05       NA
+      9          2023-01-06        2023-01-07     24.3
+      10         2023-01-06        2023-01-08       NA
+      11         2023-01-07        2023-01-08       NA
+      12         2023-01-07        2023-01-08       NA
+      13         2023-01-07        2023-01-09     24.3
+      14         2023-01-10        2023-01-11       NA
+      15         2023-01-11        2023-01-11     24.3
+      16         2023-01-08        2023-01-11       NA
+      17         2023-01-12        2023-01-14       NA
       
       $contacts
                      from                       to age sex date_first_contact
@@ -291,35 +291,35 @@
       4        Nadia Hill           Jonathan Huynh  42   m         2023-01-03
       5        Nadia Hill          Tharwa al-Amber  60   f         2023-01-02
       6        Nadia Hill        Taaliba el-Habibi  65   f         2022-12-31
-      7    Jonathan Huynh              Ian Sanchez  28   m         2023-01-01
-      8    Jonathan Huynh               Sadie Ross  78   f         2022-12-29
-      9   Tharwa al-Amber         Jordan Marquardt  31   f         2023-01-04
-      10  Tharwa al-Amber           Jacob Martinez  12   m         2023-01-02
-      11  Tharwa al-Amber          Melissa Salazar  80   f         2023-01-01
-      12      Ian Sanchez     Larissa Garcia Perez  44   f         2022-12-29
-      13      Ian Sanchez            Dakota Kremke  74   m         2022-12-31
-      14      Ian Sanchez                Atif Jung  26   m         2023-01-06
-      15      Ian Sanchez               Joseph Sky  33   m         2023-01-03
-      16      Ian Sanchez              Sean Powell   4   m         2022-12-30
-      17 Jordan Marquardt              Jonah Smith  53   m         2023-01-03
-      18       Joseph Sky            Geoffrey Boon  86   m         2023-01-03
-      19    Geoffrey Boon       Husniyya al-Zamani  89   f         2023-01-02
-      20    Geoffrey Boon             Leona Torres  24   f         2023-01-04
-      21    Geoffrey Boon            Juyoung Sands  37   f         2023-01-03
-      22    Juyoung Sands                 Mya Hunt  15   f         2023-01-03
-      23         Mya Hunt Chandler Saldana-Martine  14   m         2023-01-02
-      24         Mya Hunt             Josef Fortes  81   m         2023-01-03
-      25     Josef Fortes           Badri el-Hoque  82   m         2023-01-02
-      26   Badri el-Hoque            William Jones  72   m         2023-01-03
-      27   Badri el-Hoque                Ka Lok Le  53   m         2023-01-03
-      28   Badri el-Hoque           Bryan Goodwine  56   m         2022-12-29
-      29    William Jones             Luis Arreola  71   m         2023-01-04
-      30    William Jones           Zachary Abeyta  50   m         2023-01-01
-      31    William Jones           Naasif al-Sani  73   m         2022-12-31
-      32    William Jones          Danielle Morser  20   f         2023-01-01
-      33     Luis Arreola          Maahir al-Jamal  75   m         2023-01-06
-      34     Luis Arreola           Arielle Connor   2   f         2023-01-08
-      35   Zachary Abeyta          Shawnesse Smith   3   f         2023-01-03
+      7    Jonathan Huynh              Ian Sanchez  28   m         2023-01-02
+      8    Jonathan Huynh               Sadie Ross  78   f         2022-12-30
+      9   Tharwa al-Amber         Jordan Marquardt  31   f         2023-01-06
+      10  Tharwa al-Amber           Jacob Martinez  12   m         2023-01-04
+      11  Tharwa al-Amber          Melissa Salazar  80   f         2023-01-03
+      12      Ian Sanchez     Larissa Garcia Perez  44   f         2022-12-30
+      13      Ian Sanchez            Dakota Kremke  74   m         2023-01-01
+      14      Ian Sanchez                Atif Jung  26   m         2023-01-07
+      15      Ian Sanchez               Joseph Sky  33   m         2023-01-04
+      16      Ian Sanchez              Sean Powell   4   m         2022-12-31
+      17 Jordan Marquardt              Jonah Smith  53   m         2023-01-06
+      18       Joseph Sky            Geoffrey Boon  86   m         2023-01-06
+      19    Geoffrey Boon       Husniyya al-Zamani  89   f         2023-01-05
+      20    Geoffrey Boon             Leona Torres  24   f         2023-01-07
+      21    Geoffrey Boon            Juyoung Sands  37   f         2023-01-06
+      22    Juyoung Sands                 Mya Hunt  15   f         2023-01-07
+      23         Mya Hunt Chandler Saldana-Martine  14   m         2023-01-06
+      24         Mya Hunt             Josef Fortes  81   m         2023-01-07
+      25     Josef Fortes           Badri el-Hoque  82   m         2023-01-07
+      26   Badri el-Hoque            William Jones  72   m         2023-01-10
+      27   Badri el-Hoque                Ka Lok Le  53   m         2023-01-10
+      28   Badri el-Hoque           Bryan Goodwine  56   m         2023-01-05
+      29    William Jones             Luis Arreola  71   m         2023-01-11
+      30    William Jones           Zachary Abeyta  50   m         2023-01-08
+      31    William Jones           Naasif al-Sani  73   m         2023-01-07
+      32    William Jones          Danielle Morser  20   f         2023-01-08
+      33     Luis Arreola          Maahir al-Jamal  75   m         2023-01-15
+      34     Luis Arreola           Arielle Connor   2   f         2023-01-17
+      35   Zachary Abeyta          Shawnesse Smith   3   f         2023-01-12
          date_last_contact was_case           status
       1         2023-01-05        Y             case
       2         2023-01-07        N lost_to_followup
@@ -327,35 +327,35 @@
       4         2023-01-04        Y             case
       5         2023-01-04        Y             case
       6         2023-01-03        N          unknown
-      7         2023-01-03        Y             case
-      8         2023-01-04        Y             case
-      9         2023-01-07        Y             case
-      10        2023-01-04        N   under_followup
-      11        2023-01-03        N lost_to_followup
-      12        2023-01-02        N   under_followup
-      13        2023-01-04        N   under_followup
-      14        2023-01-07        N          unknown
-      15        2023-01-04        Y             case
-      16        2023-01-03        N   under_followup
-      17        2023-01-06        N   under_followup
-      18        2023-01-04        Y             case
-      19        2023-01-03        N   under_followup
-      20        2023-01-05        N   under_followup
-      21        2023-01-05        Y             case
-      22        2023-01-04        Y             case
-      23        2023-01-04        N   under_followup
-      24        2023-01-04        Y             case
-      25        2023-01-04        Y             case
-      26        2023-01-04        Y             case
-      27        2023-01-06        N lost_to_followup
-      28        2023-01-02        N          unknown
-      29        2023-01-04        Y             case
-      30        2023-01-04        Y             case
-      31        2023-01-05        N lost_to_followup
-      32        2023-01-03        N   under_followup
-      33        2023-01-06        N   under_followup
-      34        2023-01-09        N   under_followup
-      35        2023-01-05        Y             case
+      7         2023-01-04        Y             case
+      8         2023-01-05        Y             case
+      9         2023-01-09        Y             case
+      10        2023-01-06        N   under_followup
+      11        2023-01-05        N lost_to_followup
+      12        2023-01-03        N   under_followup
+      13        2023-01-05        N   under_followup
+      14        2023-01-08        N          unknown
+      15        2023-01-05        Y             case
+      16        2023-01-04        N   under_followup
+      17        2023-01-09        N   under_followup
+      18        2023-01-07        Y             case
+      19        2023-01-06        N   under_followup
+      20        2023-01-08        N   under_followup
+      21        2023-01-08        Y             case
+      22        2023-01-08        Y             case
+      23        2023-01-08        N   under_followup
+      24        2023-01-08        Y             case
+      25        2023-01-09        Y             case
+      26        2023-01-11        Y             case
+      27        2023-01-13        N lost_to_followup
+      28        2023-01-09        N          unknown
+      29        2023-01-11        Y             case
+      30        2023-01-11        Y             case
+      31        2023-01-12        N lost_to_followup
+      32        2023-01-10        N   under_followup
+      33        2023-01-15        N   under_followup
+      34        2023-01-18        N   under_followup
+      35        2023-01-14        Y             case
       
 
 # sim_outbreak works as expected with age structure
@@ -369,39 +369,39 @@
          id            case_name case_type sex age date_onset date_admission
       1   1      Molly Archuleta confirmed   f   8 2023-01-01           <NA>
       2   2        Gracie Lorenz confirmed   f  76 2023-01-02     2023-01-03
-      3   5         David Alexis confirmed   m   9 2023-01-01           <NA>
-      4   6 Jazmyn Trotter-Brown confirmed   f  89 2023-01-01     2023-01-04
-      5   8           Jack Byers confirmed   m  16 2023-01-02     2023-01-02
-      6   9         Janet Cortez confirmed   f  82 2023-01-01           <NA>
-      7  10         Angeling Das  probable   f  27 2023-01-04           <NA>
-      8  16         Paul Collier  probable   m  47 2023-01-01           <NA>
-      9  19  Shawn Bustos-Campos confirmed   m  85 2023-01-01     2023-01-07
-      10 22      Fuaada al-Kanan suspected   f  57 2023-01-01           <NA>
-      11 23       Caitlin Reeves  probable   f  89 2023-01-01           <NA>
-      12 25       Samuel Thacker confirmed   m  90 2023-01-02           <NA>
-      13 26      Kenneth Huggins suspected   m  48 2023-01-01           <NA>
-      14 27        Alonzo Foster confirmed   m  62 2023-01-02           <NA>
-      15 30      Wajeeb al-Jafri confirmed   m   9 2023-01-03           <NA>
-      16 31        Kyron Pollard confirmed   m  29 2023-01-01           <NA>
-      17 36       Quinasia Lewis  probable   f  79 2023-01-01           <NA>
+      3   5         David Alexis confirmed   m   9 2023-01-02           <NA>
+      4   6 Jazmyn Trotter-Brown confirmed   f  89 2023-01-03     2023-01-05
+      5   8           Jack Byers confirmed   m  16 2023-01-03     2023-01-04
+      6   9         Janet Cortez confirmed   f  82 2023-01-03           <NA>
+      7  10         Angeling Das  probable   f  27 2023-01-07           <NA>
+      8  16         Paul Collier  probable   m  47 2023-01-04           <NA>
+      9  19  Shawn Bustos-Campos confirmed   m  85 2023-01-04     2023-01-10
+      10 22      Fuaada al-Kanan suspected   f  57 2023-01-05           <NA>
+      11 23       Caitlin Reeves  probable   f  89 2023-01-05           <NA>
+      12 25       Samuel Thacker confirmed   m  90 2023-01-07           <NA>
+      13 26      Kenneth Huggins suspected   m  48 2023-01-08           <NA>
+      14 27        Alonzo Foster confirmed   m  62 2023-01-09           <NA>
+      15 30      Wajeeb al-Jafri confirmed   m   9 2023-01-12           <NA>
+      16 31        Kyron Pollard confirmed   m  29 2023-01-10           <NA>
+      17 36       Quinasia Lewis  probable   f  79 2023-01-10           <NA>
          date_death date_first_contact date_last_contact ct_value
       1        <NA>               <NA>              <NA>     24.3
       2        <NA>         2023-01-02        2023-01-05     24.3
       3        <NA>         2023-01-03        2023-01-04     24.3
       4        <NA>         2023-01-02        2023-01-04     24.3
-      5        <NA>         2023-01-01        2023-01-03     24.3
-      6        <NA>         2022-12-29        2023-01-04     24.3
-      7        <NA>         2023-01-04        2023-01-07       NA
-      8        <NA>         2023-01-03        2023-01-04       NA
-      9        <NA>         2023-01-03        2023-01-04     24.3
-      10       <NA>         2023-01-03        2023-01-05       NA
-      11       <NA>         2023-01-03        2023-01-04       NA
-      12       <NA>         2023-01-03        2023-01-04     24.3
-      13       <NA>         2023-01-02        2023-01-04       NA
-      14       <NA>         2023-01-03        2023-01-04     24.3
-      15       <NA>         2023-01-04        2023-01-04     24.3
-      16       <NA>         2023-01-01        2023-01-04     24.3
-      17       <NA>         2023-01-03        2023-01-05       NA
+      5        <NA>         2023-01-02        2023-01-04     24.3
+      6        <NA>         2022-12-30        2023-01-05     24.3
+      7        <NA>         2023-01-06        2023-01-09       NA
+      8        <NA>         2023-01-04        2023-01-05       NA
+      9        <NA>         2023-01-06        2023-01-07     24.3
+      10       <NA>         2023-01-06        2023-01-08       NA
+      11       <NA>         2023-01-07        2023-01-08       NA
+      12       <NA>         2023-01-07        2023-01-08     24.3
+      13       <NA>         2023-01-07        2023-01-09       NA
+      14       <NA>         2023-01-10        2023-01-11     24.3
+      15       <NA>         2023-01-11        2023-01-11     24.3
+      16       <NA>         2023-01-08        2023-01-11     24.3
+      17       <NA>         2023-01-12        2023-01-14       NA
       
       $contacts
                          from                   to age sex date_first_contact
@@ -411,35 +411,35 @@
       4         Gracie Lorenz         David Alexis   9   m         2023-01-03
       5         Gracie Lorenz Jazmyn Trotter-Brown  89   f         2023-01-02
       6         Gracie Lorenz      Jenifer Sanchez  36   f         2022-12-31
-      7          David Alexis           Jack Byers  16   m         2023-01-01
-      8          David Alexis         Janet Cortez  82   f         2022-12-29
-      9  Jazmyn Trotter-Brown         Angeling Das  27   f         2023-01-04
-      10 Jazmyn Trotter-Brown   Thewodros Martinez  35   m         2023-01-02
-      11 Jazmyn Trotter-Brown       Bianca Naranjo   2   f         2023-01-01
-      12           Jack Byers   Alexandra Brostrom   6   f         2022-12-29
-      13           Jack Byers   Timothy Rademacher  23   m         2022-12-31
-      14           Jack Byers        Kail Fanshier  90   m         2023-01-06
-      15           Jack Byers         Paul Collier  47   m         2023-01-03
-      16           Jack Byers         Timothy Diaz  64   m         2022-12-30
-      17         Angeling Das            Mark Soto  16   m         2023-01-03
-      18         Paul Collier  Shawn Bustos-Campos  85   m         2023-01-03
-      19  Shawn Bustos-Campos         Picabo Colin  42   f         2023-01-02
-      20  Shawn Bustos-Campos           Ana Rinard  26   f         2023-01-04
-      21  Shawn Bustos-Campos      Fuaada al-Kanan  57   f         2023-01-03
-      22      Fuaada al-Kanan       Caitlin Reeves  89   f         2023-01-03
-      23       Caitlin Reeves        Brendan Watts  21   m         2023-01-02
-      24       Caitlin Reeves       Samuel Thacker  90   m         2023-01-03
-      25       Samuel Thacker      Kenneth Huggins  48   m         2023-01-02
-      26      Kenneth Huggins        Alonzo Foster  62   m         2023-01-03
-      27      Kenneth Huggins        Hector Correa  20   m         2023-01-03
-      28      Kenneth Huggins      Samuel Classick   4   m         2022-12-29
-      29        Alonzo Foster      Wajeeb al-Jafri   9   m         2023-01-04
-      30        Alonzo Foster        Kyron Pollard  29   m         2023-01-01
-      31        Alonzo Foster          Lexie Meeks  32   m         2022-12-31
-      32        Alonzo Foster       Ahanabah Smith  82   f         2023-01-01
-      33      Wajeeb al-Jafri        Jordan Altman  75   m         2023-01-06
-      34      Wajeeb al-Jafri   Kebremeskel Gaines   2   f         2023-01-08
-      35        Kyron Pollard       Quinasia Lewis  79   f         2023-01-03
+      7          David Alexis           Jack Byers  16   m         2023-01-02
+      8          David Alexis         Janet Cortez  82   f         2022-12-30
+      9  Jazmyn Trotter-Brown         Angeling Das  27   f         2023-01-06
+      10 Jazmyn Trotter-Brown   Thewodros Martinez  35   m         2023-01-04
+      11 Jazmyn Trotter-Brown       Bianca Naranjo   2   f         2023-01-03
+      12           Jack Byers   Alexandra Brostrom   6   f         2022-12-30
+      13           Jack Byers   Timothy Rademacher  23   m         2023-01-01
+      14           Jack Byers        Kail Fanshier  90   m         2023-01-07
+      15           Jack Byers         Paul Collier  47   m         2023-01-04
+      16           Jack Byers         Timothy Diaz  64   m         2022-12-31
+      17         Angeling Das            Mark Soto  16   m         2023-01-06
+      18         Paul Collier  Shawn Bustos-Campos  85   m         2023-01-06
+      19  Shawn Bustos-Campos         Picabo Colin  42   f         2023-01-05
+      20  Shawn Bustos-Campos           Ana Rinard  26   f         2023-01-07
+      21  Shawn Bustos-Campos      Fuaada al-Kanan  57   f         2023-01-06
+      22      Fuaada al-Kanan       Caitlin Reeves  89   f         2023-01-07
+      23       Caitlin Reeves        Brendan Watts  21   m         2023-01-06
+      24       Caitlin Reeves       Samuel Thacker  90   m         2023-01-07
+      25       Samuel Thacker      Kenneth Huggins  48   m         2023-01-07
+      26      Kenneth Huggins        Alonzo Foster  62   m         2023-01-10
+      27      Kenneth Huggins        Hector Correa  20   m         2023-01-10
+      28      Kenneth Huggins      Samuel Classick   4   m         2023-01-05
+      29        Alonzo Foster      Wajeeb al-Jafri   9   m         2023-01-11
+      30        Alonzo Foster        Kyron Pollard  29   m         2023-01-08
+      31        Alonzo Foster          Lexie Meeks  32   m         2023-01-07
+      32        Alonzo Foster       Ahanabah Smith  82   f         2023-01-08
+      33      Wajeeb al-Jafri        Jordan Altman  75   m         2023-01-15
+      34      Wajeeb al-Jafri   Kebremeskel Gaines   2   f         2023-01-17
+      35        Kyron Pollard       Quinasia Lewis  79   f         2023-01-12
          date_last_contact was_case           status
       1         2023-01-05        Y             case
       2         2023-01-07        N   under_followup
@@ -447,34 +447,34 @@
       4         2023-01-04        Y             case
       5         2023-01-04        Y             case
       6         2023-01-03        N   under_followup
-      7         2023-01-03        Y             case
-      8         2023-01-04        Y             case
-      9         2023-01-07        Y             case
-      10        2023-01-04        N   under_followup
-      11        2023-01-03        N   under_followup
-      12        2023-01-02        N   under_followup
-      13        2023-01-04        N   under_followup
-      14        2023-01-07        N   under_followup
-      15        2023-01-04        Y             case
-      16        2023-01-03        N lost_to_followup
-      17        2023-01-06        N   under_followup
-      18        2023-01-04        Y             case
-      19        2023-01-03        N   under_followup
-      20        2023-01-05        N          unknown
-      21        2023-01-05        Y             case
-      22        2023-01-04        Y             case
-      23        2023-01-04        N lost_to_followup
-      24        2023-01-04        Y             case
-      25        2023-01-04        Y             case
-      26        2023-01-04        Y             case
-      27        2023-01-06        N   under_followup
-      28        2023-01-02        N   under_followup
-      29        2023-01-04        Y             case
-      30        2023-01-04        Y             case
-      31        2023-01-05        N   under_followup
-      32        2023-01-03        N   under_followup
-      33        2023-01-06        N   under_followup
-      34        2023-01-09        N lost_to_followup
-      35        2023-01-05        Y             case
+      7         2023-01-04        Y             case
+      8         2023-01-05        Y             case
+      9         2023-01-09        Y             case
+      10        2023-01-06        N   under_followup
+      11        2023-01-05        N   under_followup
+      12        2023-01-03        N   under_followup
+      13        2023-01-05        N   under_followup
+      14        2023-01-08        N   under_followup
+      15        2023-01-05        Y             case
+      16        2023-01-04        N lost_to_followup
+      17        2023-01-09        N   under_followup
+      18        2023-01-07        Y             case
+      19        2023-01-06        N   under_followup
+      20        2023-01-08        N          unknown
+      21        2023-01-08        Y             case
+      22        2023-01-08        Y             case
+      23        2023-01-08        N lost_to_followup
+      24        2023-01-08        Y             case
+      25        2023-01-09        Y             case
+      26        2023-01-11        Y             case
+      27        2023-01-13        N   under_followup
+      28        2023-01-09        N   under_followup
+      29        2023-01-11        Y             case
+      30        2023-01-11        Y             case
+      31        2023-01-12        N   under_followup
+      32        2023-01-10        N   under_followup
+      33        2023-01-15        N   under_followup
+      34        2023-01-18        N lost_to_followup
+      35        2023-01-14        Y             case
       
 


### PR DESCRIPTION
This PR addresses #92 by finding and fixing an error in the `.sim_network_bp()` function. Previously, the time delay between contacts (which also then influenced times of hospitalisation and death) were not being correctly added to the time of their ancestor due to a vector indexing bug. This PR attempts to fix this by correctly indexing the ancestors time of infection and adds the new time delay of the newly infected individual.

This should resolve the issue raised in #92 that the distribution of times of an outbreak is only a few days even when modifying the simulation parameters. 

Snapshots for tests of `sim_*()` function have been updated with the new dates from the fix.