### PR TITLE
Add URL to `_pkgdown.yml`

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: ~
+url: https://epiverse-trace.github.io/simulist/
 template:
   package: epiversetheme
   bslib:


### PR DESCRIPTION
This PR explicitly states the pkgdown URL for {simulist} in the `_pkgdown.yml` file to ensure the searchbar functionality works when browsing the website.