### PR TITLE
Use `*_idx` and `*_lgl_idx` naming convention

### DIFF
--- a/R/add_cols.R
+++ b/R/add_cols.R
@@ -81,10 +81,10 @@ NULL
 .add_hospitalisation <- function(.data,
                                  onset_to_hosp,
                                  hosp_risk) {
-  infected_idx <- .data$infected == "infected"
-  num_infected <- sum(infected_idx)
+  infected_lgl_idx <- .data$infected == "infected"
+  num_infected <- sum(infected_lgl_idx)
   .data$hospitalisation <- NA_real_
-  .data$hospitalisation[infected_idx] <- .data$time[infected_idx] +
+  .data$hospitalisation[infected_lgl_idx] <- .data$time[infected_lgl_idx] +
     onset_to_hosp(num_infected)
 
   # hosp_risk is either numeric or <data.frame> or NA
@@ -92,7 +92,7 @@ NULL
     if (is.numeric(hosp_risk)) {
       # size is converted to an integer internally in sample()
       pop_sample <- sample(
-        which(infected_idx),
+        which(infected_lgl_idx),
         replace = FALSE,
         size = (1 - hosp_risk) * num_infected
       )
@@ -124,15 +124,15 @@ NULL
                          hosp_death_risk,
                          non_hosp_death_risk,
                          config) {
-  infected_idx <- .data$infected == "infected"
-  num_infected <- sum(infected_idx)
+  infected_lgl_idx <- .data$infected == "infected"
+  num_infected <- sum(infected_lgl_idx)
   .data$outcome <- "contact"
   .data$outcome_time <- NA_real_
-  .data$outcome[infected_idx] <- "recovered"
-  .data$outcome_time[infected_idx] <- .data$time[infected_idx] +
+  .data$outcome[infected_lgl_idx] <- "recovered"
+  .data$outcome_time[infected_lgl_idx] <- .data$time[infected_lgl_idx] +
     onset_to_recovery(num_infected)
-  hosp_idx <- !is.na(.data$hospitalisation) & infected_idx
-  non_hosp_idx <- is.na(.data$hospitalisation) & infected_idx
+  hosp_lgl_idx <- !is.na(.data$hospitalisation) & infected_lgl_idx
+  non_hosp_lgl_idx <- is.na(.data$hospitalisation) & infected_lgl_idx
 
   # internal function only called in .add_outcome()
   # assign deaths using population or age-stratified death risk
@@ -186,19 +186,19 @@ NULL
       # sample individuals to die given risk group
       died_idx <- stats::rbinom(n = length(risk_), size = 1, prob = risk_)
       # died index requires individuals to be in idx group (e.g. hosp)
-      died_idx <- as.logical(died_idx) & idx
-      .data$outcome[died_idx] <- "died"
-      .data$outcome_time[died_idx] <- .data$time[died_idx] +
-        onset_to_death(sum(died_idx))
+      died_lgl_idx <- as.logical(died_idx) & idx
+      .data$outcome[died_lgl_idx] <- "died"
+      .data$outcome_time[died_lgl_idx] <- .data$time[died_lgl_idx] +
+        onset_to_death(sum(died_lgl_idx))
     }
     .data
   }
 
   .data <- apply_death_risk(
-    .data, risk = hosp_death_risk, idx = hosp_idx, config = config
+    .data, risk = hosp_death_risk, idx = hosp_lgl_idx, config = config
   )
   .data <- apply_death_risk(
-    .data, risk = non_hosp_death_risk, idx = non_hosp_idx, config = config
+    .data, risk = non_hosp_death_risk, idx = non_hosp_lgl_idx, config = config
   )
 
   # return data

--- a/R/utils.R
+++ b/R/utils.R
@@ -21,10 +21,10 @@
 #' @keywords internal
 .sample_names <- function(.data,
                           buffer_factor = 1.5) {
-  m_idx <- .data$sex == "m"
-  f_idx <- .data$sex == "f"
-  num_m <- sum(m_idx)
-  num_f <- sum(f_idx)
+  m_lgl_idx <- .data$sex == "m"
+  f_lgl_idx <- .data$sex == "f"
+  num_m <- sum(m_lgl_idx)
+  num_f <- sum(f_lgl_idx)
   num_sample_m <- ceiling(num_m * buffer_factor)
   num_sample_f <- ceiling(num_f * buffer_factor)
 
@@ -61,8 +61,8 @@
 
   # order names with sex codes from .data
   names_mf <- vector(mode = "character", length = nrow(.data))
-  names_mf[m_idx] <- names_m
-  names_mf[f_idx] <- names_f
+  names_mf[m_lgl_idx] <- names_m
+  names_mf[f_lgl_idx] <- names_f
 
   # return vector of names
   names_mf

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -55,6 +55,7 @@ Poisson
 Pratik
 prob
 qPCR
+R's
 randomNames
 RECON
 redocumented

--- a/vignettes/design-principles.Rmd
+++ b/vignettes/design-principles.Rmd
@@ -50,6 +50,8 @@ The simulation functions either return a `<data.frame>` or a `list` of `<data.fr
 
 - The `sim_linelist()`, `sim_contacts()` and `sim_outbreak()` do not have arguments that change the dimensions of the `<data.frame>` returned by the functions (or in the case of `sim_outbreak()` a list of two `<data.frame>`s). Instead, we recommend modifying the line list or contact tracing data after the simulation, and provide a vignette to guide users on common data wrangling tasks in `wrangling-linelist.Rmd`. Not including arguments that can remove or add columns to the output `<data.frame>`s reduces the complexity of the functions; and by limiting the simulation function arguments to only parameterise, and not change the dimensionality of, the simulated data, the package is more robust to being used in pipelines or other automated approaches, where the data needs to be predictably formatted.
 
+- Several parts of the {simulist} codebase use indices for determining which individual are infected, allocation to vectors, and other uses. R's subsetting (`[`) can use logical vectors or numeric vectors, but in {simulist} these are differentiated by the names `*_idx` for variables holding a `numeric` vector of indices, and `*_lgl_idx` for a `logical` vector of indices. This makes it safer and more readable to call functions like `sum()` or `which()` on index vectors.
+
 ## Dependencies
 
 The aim is to restrict the number of dependencies to a minimal required set for ease of maintenance. The current hard dependencies are:


### PR DESCRIPTION
This PR addresses a comment made in PR #101, that the use of the `*_idx` suffix for index vectors was applied to both `numeric` and `logical` vectors (as R's subsetting works similarly for `numeric` and `logical` subsetting). This PR changes the suffix for `logical` index vectors from `*_idx` to `*_lgl_idx`. 

The follows the same abbreviation of `logical` to `lgl` as `rlang::is_lgl_na()` (used in the {simulist} package since PR #111).

A new bullet point has been added to the `design-principles.Rmd` vignette to explain this naming convention and make it easier for contributors to correctly name index vectors.