### PR TITLE
Update `sim_linelist()` and `sim_outbreak()` snapshots

### DIFF
--- a/tests/testthat/_snaps/sim_linelist.md
+++ b/tests/testthat/_snaps/sim_linelist.md
@@ -4,32 +4,32 @@
       sim_linelist(contact_distribution = contact_distribution, infect_period = infect_period,
         prob_infect = 0.5, onset_to_hosp = onset_to_hosp, onset_to_death = onset_to_death)
     Output
-         id              case_name case_type sex age date_onset date_admission
-      1   1        Dominic Sundara  probable   m  35 2023-01-01           <NA>
-      2   2     Preston Montgomery suspected   m  43 2023-01-01           <NA>
-      3   3          Reece Chittum  probable   m   1 2023-01-01           <NA>
-      4   5          Michael Cheek confirmed   m  78 2023-01-01           <NA>
-      5   6         Jennifer Smith confirmed   f  22 2023-01-01           <NA>
-      6   8         Erika Quintero confirmed   f  28 2023-01-01           <NA>
-      7  11       Isaiah Patterson suspected   m  46 2023-01-01     2023-01-13
-      8  12        Cicely Anderson suspected   f  67 2023-01-01           <NA>
-      9  13           Michael John  probable   m  86 2023-01-01     2023-01-01
-      10 18 Giovana Magana Aguirre suspected   f  60 2023-01-02           <NA>
-      11 20       Mudrik al-Hallal suspected   m  49 2023-01-02           <NA>
-      12 22          Tea Slaughter  probable   f   7 2023-01-02     2023-01-02
-           outcome date_outcome date_first_contact date_last_contact ct_value
-      1  recovered         <NA>               <NA>              <NA>       NA
-      2  recovered         <NA>         2022-12-30        2023-01-05       NA
-      3  recovered         <NA>         2022-12-30        2023-01-02       NA
-      4  recovered         <NA>         2022-12-29        2023-01-02     23.1
-      5  recovered         <NA>         2023-01-01        2023-01-03     23.1
-      6  recovered         <NA>         2023-01-03        2023-01-04     23.1
-      7  recovered         <NA>         2023-01-04        2023-01-05       NA
-      8  recovered         <NA>         2023-01-01        2023-01-04       NA
-      9       died   2023-01-12         2022-12-31        2023-01-03       NA
-      10 recovered         <NA>         2022-12-30        2023-01-03       NA
-      11 recovered         <NA>         2023-01-01        2023-01-04       NA
-      12 recovered         <NA>         2023-01-01        2023-01-03       NA
+         id          case_name case_type sex age date_onset date_admission   outcome
+      1   1    Rushdi al-Ishak  probable   m  35 2023-01-01           <NA> recovered
+      2   2         Jeffrey Le confirmed   m  43 2023-01-01           <NA> recovered
+      3   3  Dominic Barringer suspected   m   1 2023-01-01           <NA> recovered
+      4   5       Tyler Kelley  probable   m  78 2023-01-01           <NA> recovered
+      5   6      Carolyn Moore confirmed   f  22 2023-01-01           <NA> recovered
+      6   8  Cheyenne Sayavong confirmed   f  28 2023-01-01     2023-01-04      died
+      7  11   Bassaam el-Majid confirmed   m  46 2023-01-01     2023-01-14 recovered
+      8  12          Kendra To suspected   f  67 2023-01-01     2023-01-10      died
+      9  13    Qaaid al-Madani confirmed   m  86 2023-01-01           <NA> recovered
+      10 18  Dominique Raymond confirmed   f  60 2023-01-02           <NA> recovered
+      11 20 Abdul Noor el-Syed  probable   m  49 2023-01-02           <NA> recovered
+      12 22      Susana Varela  probable   f   7 2023-01-02           <NA> recovered
+         date_outcome date_first_contact date_last_contact ct_value
+      1          <NA>               <NA>              <NA>       NA
+      2          <NA>         2022-12-30        2023-01-05       24
+      3          <NA>         2022-12-30        2023-01-02       NA
+      4          <NA>         2022-12-29        2023-01-02       NA
+      5          <NA>         2023-01-01        2023-01-03       24
+      6    2023-01-16         2023-01-03        2023-01-04       24
+      7          <NA>         2023-01-04        2023-01-05       24
+      8    2023-01-17         2023-01-01        2023-01-04       NA
+      9          <NA>         2022-12-31        2023-01-03       24
+      10         <NA>         2022-12-30        2023-01-03       24
+      11         <NA>         2023-01-01        2023-01-04       NA
+      12         <NA>         2023-01-01        2023-01-03       NA
 
 # sim_linelist works as expected with age-strat risks
 
@@ -39,32 +39,32 @@
         hosp_risk = age_dep_hosp_risk, hosp_death_risk = age_dep_hosp_death_risk,
         non_hosp_death_risk = age_dep_non_hosp_death_risk)
     Output
-         id        case_name case_type sex age date_onset date_admission   outcome
-      1   1       Cass Duran  probable   m  35 2023-01-01           <NA> recovered
-      2   2 Mudrik al-Hallal suspected   m  43 2023-01-01           <NA> recovered
-      3   3  Jareer al-Safar  probable   m   1 2023-01-01     2023-01-11 recovered
-      4   5  Raashid el-Huda confirmed   m  78 2023-01-01           <NA> recovered
-      5   6     Erika Sierra confirmed   f  22 2023-01-01           <NA> recovered
-      6   8    Jennifer Hong confirmed   f  28 2023-01-01           <NA> recovered
-      7  11    Donald Childs suspected   m  46 2023-01-01           <NA> recovered
-      8  12    Kayla Johnson suspected   f  67 2023-01-01           <NA>      died
-      9  13   Avery Johnston  probable   m  86 2023-01-01     2023-01-01 recovered
-      10 18  Giovana Segarra suspected   f  60 2023-01-02           <NA> recovered
-      11 20      Donald Root suspected   m  49 2023-01-02     2023-01-09 recovered
-      12 22      Kiona Dalke  probable   f   7 2023-01-02           <NA> recovered
+         id          case_name case_type sex age date_onset date_admission   outcome
+      1   1 Ghaamid el-Ishmael suspected   m  35 2023-01-01           <NA> recovered
+      2   2   Faatih el-Kaiser confirmed   m  43 2023-01-01           <NA> recovered
+      3   3   Brandon Galligan confirmed   m   1 2023-01-01     2023-01-04 recovered
+      4   5      Aiman el-Riaz suspected   m  78 2023-01-01           <NA> recovered
+      5   6     Katelyn Catlin confirmed   f  22 2023-01-01           <NA> recovered
+      6   8       Lynsey Duron confirmed   f  28 2023-01-01           <NA> recovered
+      7  11      Travis Foster confirmed   m  46 2023-01-01           <NA> recovered
+      8  12       Jacy Cousins confirmed   f  67 2023-01-01           <NA> recovered
+      9  13        Khoa Murray confirmed   m  86 2023-01-01     2023-01-02 recovered
+      10 18     Maria Eberhart  probable   f  60 2023-01-02           <NA> recovered
+      11 20        John Flores suspected   m  49 2023-01-02           <NA> recovered
+      12 22        Erin Payson confirmed   f   7 2023-01-02           <NA> recovered
          date_outcome date_first_contact date_last_contact ct_value
       1          <NA>               <NA>              <NA>       NA
-      2          <NA>         2022-12-30        2023-01-05       NA
-      3          <NA>         2022-12-30        2023-01-02       NA
-      4          <NA>         2022-12-29        2023-01-02     23.1
-      5          <NA>         2023-01-01        2023-01-03     23.1
-      6          <NA>         2023-01-03        2023-01-04     23.1
-      7          <NA>         2023-01-04        2023-01-05       NA
-      8    2023-01-14         2023-01-01        2023-01-04       NA
-      9          <NA>         2022-12-31        2023-01-03       NA
+      2          <NA>         2022-12-30        2023-01-05     25.1
+      3          <NA>         2022-12-30        2023-01-02     25.1
+      4          <NA>         2022-12-29        2023-01-02       NA
+      5          <NA>         2023-01-01        2023-01-03     25.1
+      6          <NA>         2023-01-03        2023-01-04     25.1
+      7          <NA>         2023-01-04        2023-01-05     25.1
+      8          <NA>         2023-01-01        2023-01-04     25.1
+      9          <NA>         2022-12-31        2023-01-03     25.1
       10         <NA>         2022-12-30        2023-01-03       NA
       11         <NA>         2023-01-01        2023-01-04       NA
-      12         <NA>         2023-01-01        2023-01-03       NA
+      12         <NA>         2023-01-01        2023-01-03     25.1
 
 # sim_linelist works as expected with anonymous
 
@@ -74,31 +74,31 @@
         anonymise = TRUE)
     Output
          id  case_name case_type sex age date_onset date_admission   outcome
-      1   1 ng7AzDS6oX confirmed   m  35 2023-01-01           <NA> recovered
-      2   2 fHuaqm1SzN  probable   m  43 2023-01-01           <NA> recovered
-      3   3 bO5h4yEtT6 confirmed   m   1 2023-01-01           <NA> recovered
-      4   5 a8e6yKFNmy suspected   m  78 2023-01-01           <NA> recovered
-      5   6 dPL7XeZaLT  probable   f  22 2023-01-01           <NA> recovered
-      6   8 TLkhw9tYeb confirmed   f  28 2023-01-01           <NA> recovered
-      7  11 WQihvSfYVA confirmed   m  46 2023-01-01     2023-01-13 recovered
-      8  12 RDjDafq8m2 confirmed   f  67 2023-01-01           <NA> recovered
-      9  13 zbFUJRewLY confirmed   m  86 2023-01-01     2023-01-01      died
-      10 18 VV4dJ6ZKaU confirmed   f  60 2023-01-02           <NA> recovered
-      11 20 fVJ5ftN2GN suspected   m  49 2023-01-02           <NA> recovered
-      12 22 ERhwf5kY6K confirmed   f   7 2023-01-02     2023-01-02 recovered
+      1   1 1ePRI5wC1I suspected   m  35 2023-01-01           <NA> recovered
+      2   2 Ji3IItv5Ov suspected   m  43 2023-01-01           <NA> recovered
+      3   3 sRrRMCAJFE  probable   m   1 2023-01-01           <NA> recovered
+      4   5 uuoY8Kxng7  probable   m  78 2023-01-01           <NA> recovered
+      5   6 AzDS6oXfHu  probable   f  22 2023-01-01           <NA> recovered
+      6   8 h4yEtT6tej confirmed   f  28 2023-01-01     2023-01-04      died
+      7  11 7XeZaLTmhW confirmed   m  46 2023-01-01     2023-01-14 recovered
+      8  12 sVUBVWYTLk  probable   f  67 2023-01-01     2023-01-10      died
+      9  13 hw9tYeb1el suspected   m  86 2023-01-01           <NA> recovered
+      10 18 UJRewLYtBB  probable   f  60 2023-01-02           <NA> recovered
+      11 20 9HLY9VZdzu  probable   m  49 2023-01-02           <NA> recovered
+      12 22 wJ3WvUcVV4 confirmed   f   7 2023-01-02           <NA> recovered
          date_outcome date_first_contact date_last_contact ct_value
-      1          <NA>               <NA>              <NA>     25.8
+      1          <NA>               <NA>              <NA>       NA
       2          <NA>         2022-12-30        2023-01-05       NA
-      3          <NA>         2022-12-30        2023-01-02     25.8
+      3          <NA>         2022-12-30        2023-01-02       NA
       4          <NA>         2022-12-29        2023-01-02       NA
       5          <NA>         2023-01-01        2023-01-03       NA
-      6          <NA>         2023-01-03        2023-01-04     25.8
-      7          <NA>         2023-01-04        2023-01-05     25.8
-      8          <NA>         2023-01-01        2023-01-04     25.8
-      9    2023-01-12         2022-12-31        2023-01-03     25.8
-      10         <NA>         2022-12-30        2023-01-03     25.8
+      6    2023-01-16         2023-01-03        2023-01-04     23.8
+      7          <NA>         2023-01-04        2023-01-05     23.8
+      8    2023-01-17         2023-01-01        2023-01-04       NA
+      9          <NA>         2022-12-31        2023-01-03       NA
+      10         <NA>         2022-12-30        2023-01-03       NA
       11         <NA>         2023-01-01        2023-01-04       NA
-      12         <NA>         2023-01-01        2023-01-03     25.8
+      12         <NA>         2023-01-01        2023-01-03     23.8
 
 # sim_linelist works as expected with age structure
 
@@ -107,32 +107,32 @@
         prob_infect = 0.5, onset_to_hosp = onset_to_hosp, onset_to_death = onset_to_death,
         population_age = age_struct)
     Output
-         id          case_name case_type sex age date_onset date_admission   outcome
-      1   1         Kyle Crane suspected   m  44 2023-01-01           <NA> recovered
-      2   2 Ghaamid el-Ishmael confirmed   m  13 2023-01-01           <NA> recovered
-      3   3   Faatih el-Kaiser confirmed   m  22 2023-01-01     2023-01-09 recovered
-      4   5   Va'Aahi Galligan suspected   m  85 2023-01-01           <NA> recovered
-      5   6     Katelyn Catlin confirmed   f  41 2023-01-01           <NA> recovered
-      6   8       Lynsey Duron confirmed   f  89 2023-01-01     2023-01-02      died
-      7  11    Wajdi al-Demian confirmed   m  69 2023-01-01           <NA> recovered
-      8  12       Jacy Cousins confirmed   f  23 2023-01-01           <NA> recovered
-      9  13      Travis Foster confirmed   m   9 2023-01-01           <NA> recovered
-      10 18     Maria Eberhart  probable   f  62 2023-01-02           <NA> recovered
-      11 20  Mubarak el-Vaziri suspected   m  52 2023-01-02     2023-01-15 recovered
-      12 22        Erin Payson confirmed   f  76 2023-01-02           <NA> recovered
-         date_outcome date_first_contact date_last_contact ct_value
-      1          <NA>               <NA>              <NA>       NA
-      2          <NA>         2022-12-30        2023-01-05     25.1
-      3          <NA>         2022-12-30        2023-01-02     25.1
-      4          <NA>         2022-12-29        2023-01-02       NA
-      5          <NA>         2023-01-01        2023-01-03     25.1
-      6    2023-01-26         2023-01-03        2023-01-04     25.1
-      7          <NA>         2023-01-04        2023-01-05     25.1
-      8          <NA>         2023-01-01        2023-01-04     25.1
-      9          <NA>         2022-12-31        2023-01-03     25.1
-      10         <NA>         2022-12-30        2023-01-03       NA
-      11         <NA>         2023-01-01        2023-01-04       NA
-      12         <NA>         2023-01-01        2023-01-03     25.1
+         id            case_name case_type sex age date_onset date_admission
+      1   1        Bryce Cunniff  probable   m  44 2023-01-01           <NA>
+      2   2 Ignacio Garcia Mayen confirmed   m  13 2023-01-01           <NA>
+      3   3     Dominic Martinez suspected   m  22 2023-01-01           <NA>
+      4   5   Sheldon Kacprowicz  probable   m  85 2023-01-01     2023-01-22
+      5   6 Caroline Hergenreter confirmed   f  41 2023-01-01     2023-01-01
+      6   8  Cassandra Whitworth confirmed   f  89 2023-01-01     2023-01-03
+      7  11        Tyler Carlson confirmed   m  69 2023-01-01           <NA>
+      8  12    Harleigh Sayavong suspected   f  23 2023-01-01           <NA>
+      9  13        Cleatus Black confirmed   m   9 2023-01-01           <NA>
+      10 18            Kendra To confirmed   f  62 2023-01-02           <NA>
+      11 20            Jelani Le  probable   m  52 2023-01-02           <NA>
+      12 22        Amanda Kaiser  probable   f  76 2023-01-02           <NA>
+           outcome date_outcome date_first_contact date_last_contact ct_value
+      1  recovered         <NA>               <NA>              <NA>       NA
+      2  recovered         <NA>         2022-12-30        2023-01-05       24
+      3  recovered         <NA>         2022-12-30        2023-01-02       NA
+      4       died   2023-01-16         2022-12-29        2023-01-02       NA
+      5  recovered         <NA>         2023-01-01        2023-01-03       24
+      6       died   2023-01-16         2023-01-03        2023-01-04       24
+      7  recovered         <NA>         2023-01-04        2023-01-05       24
+      8  recovered         <NA>         2023-01-01        2023-01-04       NA
+      9  recovered         <NA>         2022-12-31        2023-01-03       24
+      10 recovered         <NA>         2022-12-30        2023-01-03       24
+      11 recovered         <NA>         2023-01-01        2023-01-04       NA
+      12 recovered         <NA>         2023-01-01        2023-01-03       NA
 
 # sim_linelist works as expected with age-strat risks & age struct
 
@@ -141,30 +141,30 @@
         prob_infect = 0.5, onset_to_hosp = onset_to_hosp, onset_to_death = onset_to_death,
         hosp_risk = age_dep_hosp_risk, population_age = age_struct)
     Output
-         id        case_name case_type sex age date_onset date_admission   outcome
-      1   1 Maazin el-Othman  probable   m  44 2023-01-01           <NA> recovered
-      2   2 Faisal el-Vaziri confirmed   m  13 2023-01-01           <NA> recovered
-      3   3     Jorge Marten suspected   m  22 2023-01-01           <NA> recovered
-      4   5  Kaleb Natarelli confirmed   m  85 2023-01-01     2023-01-01 recovered
-      5   6      Hope Arshad suspected   f  41 2023-01-01           <NA> recovered
-      6   8   Shanta Holiday  probable   f  89 2023-01-01           <NA> recovered
-      7  11  Nicholas Orgill  probable   m  69 2023-01-01           <NA> recovered
-      8  12   Chandra Kilian suspected   f  23 2023-01-01           <NA> recovered
-      9  13     Corey Alcala confirmed   m   9 2023-01-01           <NA> recovered
-      10 18    Kanani Nguyen confirmed   f  62 2023-01-02           <NA> recovered
-      11 20    Sean Shrestha  probable   m  52 2023-01-02           <NA> recovered
-      12 22     Annie Carter  probable   f  76 2023-01-02           <NA> recovered
+         id           case_name case_type sex age date_onset date_admission   outcome
+      1   1  Sheldon Kacprowicz  probable   m  44 2023-01-01           <NA> recovered
+      2   2        Bryce Kelley confirmed   m  13 2023-01-01           <NA> recovered
+      3   3 Khristopher Carlson suspected   m  22 2023-01-01           <NA> recovered
+      4   5       Cleatus Black  probable   m  85 2023-01-01           <NA> recovered
+      5   6       Carolyn Moore confirmed   f  41 2023-01-01           <NA> recovered
+      6   8   Cheyenne Sayavong confirmed   f  89 2023-01-01           <NA> recovered
+      7  11         David Grano confirmed   m  69 2023-01-01           <NA> recovered
+      8  12           Kendra To suspected   f  23 2023-01-01           <NA> recovered
+      9  13           Jelani Le confirmed   m   9 2023-01-01           <NA> recovered
+      10 18   Dominique Raymond confirmed   f  62 2023-01-02           <NA> recovered
+      11 20   Gabriel Barringer  probable   m  52 2023-01-02           <NA> recovered
+      12 22       Susana Varela  probable   f  76 2023-01-02           <NA> recovered
          date_outcome date_first_contact date_last_contact ct_value
       1          <NA>               <NA>              <NA>       NA
-      2          <NA>         2022-12-30        2023-01-05     24.1
+      2          <NA>         2022-12-30        2023-01-05       24
       3          <NA>         2022-12-30        2023-01-02       NA
-      4          <NA>         2022-12-29        2023-01-02     24.1
-      5          <NA>         2023-01-01        2023-01-03       NA
-      6          <NA>         2023-01-03        2023-01-04       NA
-      7          <NA>         2023-01-04        2023-01-05       NA
+      4          <NA>         2022-12-29        2023-01-02       NA
+      5          <NA>         2023-01-01        2023-01-03       24
+      6          <NA>         2023-01-03        2023-01-04       24
+      7          <NA>         2023-01-04        2023-01-05       24
       8          <NA>         2023-01-01        2023-01-04       NA
-      9          <NA>         2022-12-31        2023-01-03     24.1
-      10         <NA>         2022-12-30        2023-01-03     24.1
+      9          <NA>         2022-12-31        2023-01-03       24
+      10         <NA>         2022-12-30        2023-01-03       24
       11         <NA>         2023-01-01        2023-01-04       NA
       12         <NA>         2023-01-01        2023-01-03       NA
 
@@ -176,32 +176,32 @@
         config = create_config(last_contact_distribution = "geom",
           last_contact_distribution_params = c(prob = 0.5)))
     Output
-         id          case_name case_type sex age date_onset date_admission   outcome
-      1   1       Lily Camacho confirmed   f  20 2023-01-01           <NA> recovered
-      2   2       Sad el-Irani suspected   m  24 2023-01-01           <NA> recovered
-      3   3   Tristan Benjamin suspected   m  51 2023-01-01     2023-01-07 recovered
-      4   5     Treven Cornejo  probable   m  16 2023-01-01           <NA> recovered
-      5   6    Kevin Contreras suspected   m  83 2023-01-01           <NA> recovered
-      6   8       Tyler Garcia suspected   m  48 2023-01-01           <NA> recovered
-      7  11      Royse Beltran  probable   m  77 2023-01-01     2023-01-01 recovered
-      8  12     Clayton Falcon confirmed   m  90 2023-01-01           <NA> recovered
-      9  13   Halle Batchelder confirmed   f  66 2023-01-01           <NA> recovered
-      10 18 Morgan Grant-Perry confirmed   f  31 2023-01-02     2023-01-02 recovered
-      11 20      Bowen Apodaca confirmed   m  46 2023-01-02           <NA> recovered
-      12 22  Haaroon el-Firman confirmed   m  75 2023-01-02           <NA> recovered
-         date_outcome date_first_contact date_last_contact ct_value
-      1          <NA>               <NA>              <NA>     24.7
-      2          <NA>         2022-12-30        2023-01-01       NA
-      3          <NA>         2022-12-31        2023-01-02       NA
-      4          <NA>         2022-12-30        2023-01-02       NA
-      5          <NA>         2022-12-31        2023-01-01       NA
-      6          <NA>         2022-12-31        2023-01-01       NA
-      7          <NA>         2022-12-30        2023-01-02       NA
-      8          <NA>         2022-12-30        2023-01-01     24.7
-      9          <NA>         2022-12-29        2023-01-01     24.7
-      10         <NA>         2022-12-30        2023-01-01     24.7
-      11         <NA>         2022-12-30        2023-01-01     24.7
-      12         <NA>         2022-12-30        2023-01-02     24.7
+         id                 case_name case_type sex age date_onset date_admission
+      1   1      Ashly Magana Aguirre confirmed   f  20 2023-01-01           <NA>
+      2   2 Jose Martinez Villalpando confirmed   m  24 2023-01-01           <NA>
+      3   3            Michael Cooper  probable   m  51 2023-01-01           <NA>
+      4   5           Cass Loughridge  probable   m  16 2023-01-01           <NA>
+      5   6             Vincent White confirmed   m  83 2023-01-01     2023-01-03
+      6   8              Donald Jumbo  probable   m  48 2023-01-01           <NA>
+      7  11          Khaleel al-Amini  probable   m  77 2023-01-01     2023-01-15
+      8  12         Zayyaan al-Masood confirmed   m  90 2023-01-01           <NA>
+      9  13            Maricela Perez  probable   f  66 2023-01-01           <NA>
+      10 18          Aiyana Burgdorff suspected   f  31 2023-01-02           <NA>
+      11 20              Dante Burden  probable   m  46 2023-01-02           <NA>
+      12 22            Jonah Orlowske confirmed   m  75 2023-01-02     2023-01-04
+           outcome date_outcome date_first_contact date_last_contact ct_value
+      1  recovered         <NA>               <NA>              <NA>     23.9
+      2  recovered         <NA>         2022-12-30        2023-01-01     23.9
+      3  recovered         <NA>         2022-12-31        2023-01-02       NA
+      4  recovered         <NA>         2022-12-30        2023-01-02       NA
+      5  recovered         <NA>         2022-12-31        2023-01-01     23.9
+      6  recovered         <NA>         2022-12-31        2023-01-01       NA
+      7       died   2023-01-12         2022-12-30        2023-01-02       NA
+      8  recovered         <NA>         2022-12-30        2023-01-01     23.9
+      9  recovered         <NA>         2022-12-29        2023-01-01       NA
+      10 recovered         <NA>         2022-12-30        2023-01-01       NA
+      11 recovered         <NA>         2022-12-30        2023-01-01       NA
+      12 recovered         <NA>         2022-12-30        2023-01-02     23.9
 
 # sim_linelist works as expected with modified config parameters
 
@@ -210,32 +210,32 @@
         prob_infect = 0.5, onset_to_hosp = onset_to_hosp, onset_to_death = onset_to_death,
         config = create_config(last_contact_distribution_params = c(lambda = 5)))
     Output
-         id              case_name case_type sex age date_onset date_admission
-      1   1        Dominic Sundara  probable   m  35 2023-01-01           <NA>
-      2   2     Preston Montgomery suspected   m  43 2023-01-01           <NA>
-      3   3          Reece Chittum  probable   m   1 2023-01-01           <NA>
-      4   5          Michael Cheek confirmed   m  78 2023-01-01           <NA>
-      5   6         Jennifer Smith confirmed   f  22 2023-01-01           <NA>
-      6   8         Erika Quintero confirmed   f  28 2023-01-01           <NA>
-      7  11       Isaiah Patterson suspected   m  46 2023-01-01     2023-01-13
-      8  12        Cicely Anderson suspected   f  67 2023-01-01           <NA>
-      9  13           Michael John  probable   m  86 2023-01-01     2023-01-01
-      10 18 Giovana Magana Aguirre suspected   f  60 2023-01-02           <NA>
-      11 20       Mudrik al-Hallal suspected   m  49 2023-01-02           <NA>
-      12 22          Tea Slaughter  probable   f   7 2023-01-02     2023-01-02
-           outcome date_outcome date_first_contact date_last_contact ct_value
-      1  recovered         <NA>               <NA>              <NA>       NA
-      2  recovered         <NA>         2023-01-01        2023-01-07       NA
-      3  recovered         <NA>         2022-12-31        2023-01-03       NA
-      4  recovered         <NA>         2022-12-31        2023-01-04     23.1
-      5  recovered         <NA>         2023-01-02        2023-01-04     23.1
-      6  recovered         <NA>         2023-01-06        2023-01-07     23.1
-      7  recovered         <NA>         2023-01-07        2023-01-08       NA
-      8  recovered         <NA>         2023-01-03        2023-01-06       NA
-      9       died   2023-01-12         2023-01-02        2023-01-05       NA
-      10 recovered         <NA>         2023-01-01        2023-01-05       NA
-      11 recovered         <NA>         2023-01-04        2023-01-07       NA
-      12 recovered         <NA>         2023-01-03        2023-01-05       NA
+         id          case_name case_type sex age date_onset date_admission   outcome
+      1   1    Rushdi al-Ishak  probable   m  35 2023-01-01           <NA> recovered
+      2   2         Jeffrey Le confirmed   m  43 2023-01-01           <NA> recovered
+      3   3  Dominic Barringer suspected   m   1 2023-01-01           <NA> recovered
+      4   5       Tyler Kelley  probable   m  78 2023-01-01           <NA> recovered
+      5   6      Carolyn Moore confirmed   f  22 2023-01-01           <NA> recovered
+      6   8  Cheyenne Sayavong confirmed   f  28 2023-01-01     2023-01-04      died
+      7  11   Bassaam el-Majid confirmed   m  46 2023-01-01     2023-01-14 recovered
+      8  12          Kendra To suspected   f  67 2023-01-01     2023-01-10      died
+      9  13    Qaaid al-Madani confirmed   m  86 2023-01-01           <NA> recovered
+      10 18  Dominique Raymond confirmed   f  60 2023-01-02           <NA> recovered
+      11 20 Abdul Noor el-Syed  probable   m  49 2023-01-02           <NA> recovered
+      12 22      Susana Varela  probable   f   7 2023-01-02           <NA> recovered
+         date_outcome date_first_contact date_last_contact ct_value
+      1          <NA>               <NA>              <NA>       NA
+      2          <NA>         2023-01-01        2023-01-07       24
+      3          <NA>         2022-12-31        2023-01-03       NA
+      4          <NA>         2022-12-31        2023-01-04       NA
+      5          <NA>         2023-01-02        2023-01-04       24
+      6    2023-01-16         2023-01-06        2023-01-07       24
+      7          <NA>         2023-01-07        2023-01-08       24
+      8    2023-01-17         2023-01-03        2023-01-06       NA
+      9          <NA>         2023-01-02        2023-01-05       24
+      10         <NA>         2023-01-01        2023-01-05       24
+      11         <NA>         2023-01-04        2023-01-07       NA
+      12         <NA>         2023-01-03        2023-01-05       NA
 
 # sim_linelist works as expected with time-varying cfr
 
@@ -245,32 +245,32 @@
         config = create_config(time_varying_death_risk = function(risk, time) risk *
           exp(-time)))
     Output
-         id         case_name case_type sex age date_onset date_admission   outcome
-      1   1   Anthony Raigoza suspected   m  35 2023-01-01           <NA> recovered
-      2   2      Joseph Begay  probable   m  43 2023-01-01           <NA> recovered
-      3   3          Andi Lee  probable   m   1 2023-01-01           <NA> recovered
-      4   5      Robert Duran suspected   m  78 2023-01-01           <NA> recovered
-      5   6    Mikhaila Guyon confirmed   f  22 2023-01-01           <NA> recovered
-      6   8        Kanani Ahn confirmed   f  28 2023-01-01           <NA> recovered
-      7  11   Michael Chittum  probable   m  46 2023-01-01     2023-01-13 recovered
-      8  12         Hope Cobb  probable   f  67 2023-01-01           <NA> recovered
-      9  13        Eric Lopez confirmed   m  86 2023-01-01     2023-01-01 recovered
-      10 18      Kelly Carter  probable   f  60 2023-01-02           <NA> recovered
-      11 20   Turki el-Vaziri  probable   m  49 2023-01-02           <NA> recovered
-      12 22 Cicely Shangreaux confirmed   f   7 2023-01-02     2023-01-02 recovered
+         id          case_name case_type sex age date_onset date_admission   outcome
+      1   1       Cody Morales confirmed   m  35 2023-01-01           <NA> recovered
+      2   2          Joewid Le suspected   m  43 2023-01-01           <NA> recovered
+      3   3    Rushdi el-Laham confirmed   m   1 2023-01-01           <NA> recovered
+      4   5 Pierce Khanthavong confirmed   m  78 2023-01-01           <NA> recovered
+      5   6   Kendra Domingues suspected   f  22 2023-01-01           <NA> recovered
+      6   8       Amanda Hayes confirmed   f  28 2023-01-01     2023-01-04      died
+      7  11      Jackson Duffy confirmed   m  46 2023-01-01     2023-01-14 recovered
+      8  12     Natalie Nguyen confirmed   f  67 2023-01-01     2023-01-10 recovered
+      9  13       Sam Pluskett confirmed   m  86 2023-01-01           <NA> recovered
+      10 18    Dominique Suggs confirmed   f  60 2023-01-02           <NA> recovered
+      11 20         Ryan Hirro  probable   m  49 2023-01-02           <NA> recovered
+      12 22   Najlaa al-Rahimi suspected   f   7 2023-01-02           <NA> recovered
          date_outcome date_first_contact date_last_contact ct_value
-      1          <NA>               <NA>              <NA>       NA
+      1          <NA>               <NA>              <NA>     23.4
       2          <NA>         2022-12-30        2023-01-05       NA
-      3          <NA>         2022-12-30        2023-01-02       NA
-      4          <NA>         2022-12-29        2023-01-02       NA
-      5          <NA>         2023-01-01        2023-01-03     25.4
-      6          <NA>         2023-01-03        2023-01-04     25.4
-      7          <NA>         2023-01-04        2023-01-05       NA
-      8          <NA>         2023-01-01        2023-01-04       NA
-      9          <NA>         2022-12-31        2023-01-03     25.4
-      10         <NA>         2022-12-30        2023-01-03       NA
+      3          <NA>         2022-12-30        2023-01-02     23.4
+      4          <NA>         2022-12-29        2023-01-02     23.4
+      5          <NA>         2023-01-01        2023-01-03       NA
+      6    2023-01-16         2023-01-03        2023-01-04     23.4
+      7          <NA>         2023-01-04        2023-01-05     23.4
+      8          <NA>         2023-01-01        2023-01-04     23.4
+      9          <NA>         2022-12-31        2023-01-03     23.4
+      10         <NA>         2022-12-30        2023-01-03     23.4
       11         <NA>         2023-01-01        2023-01-04       NA
-      12         <NA>         2023-01-01        2023-01-03     25.4
+      12         <NA>         2023-01-01        2023-01-03       NA
 
 # sim_linelist works as expected with time-varying cfr & age-strat
 
@@ -280,30 +280,30 @@
         hosp_death_risk = age_dep_hosp_death_risk, config = create_config(
           time_varying_death_risk = function(risk, time) risk * exp(-time)))
     Output
-         id         case_name case_type sex age date_onset date_admission   outcome
-      1   1   Anthony Raigoza suspected   m  35 2023-01-01           <NA> recovered
-      2   2      Joseph Begay  probable   m  43 2023-01-01           <NA> recovered
-      3   3          Andi Lee  probable   m   1 2023-01-01           <NA> recovered
-      4   5      Robert Duran suspected   m  78 2023-01-01           <NA> recovered
-      5   6    Mikhaila Guyon confirmed   f  22 2023-01-01           <NA> recovered
-      6   8        Kanani Ahn confirmed   f  28 2023-01-01           <NA> recovered
-      7  11   Michael Chittum  probable   m  46 2023-01-01     2023-01-13 recovered
-      8  12         Hope Cobb  probable   f  67 2023-01-01           <NA> recovered
-      9  13        Eric Lopez confirmed   m  86 2023-01-01     2023-01-01 recovered
-      10 18      Kelly Carter  probable   f  60 2023-01-02           <NA> recovered
-      11 20   Turki el-Vaziri  probable   m  49 2023-01-02           <NA> recovered
-      12 22 Cicely Shangreaux confirmed   f   7 2023-01-02     2023-01-02 recovered
+         id          case_name case_type sex age date_onset date_admission   outcome
+      1   1      Gabriel Black  probable   m  35 2023-01-01           <NA> recovered
+      2   2       Tyler Kelley confirmed   m  43 2023-01-01           <NA> recovered
+      3   3       Cody Morales suspected   m   1 2023-01-01           <NA> recovered
+      4   5          Joewid Le  probable   m  78 2023-01-01           <NA> recovered
+      5   6      Carolyn Moore confirmed   f  22 2023-01-01           <NA> recovered
+      6   8  Cheyenne Sayavong confirmed   f  28 2023-01-01     2023-01-04 recovered
+      7  11 Pierce Khanthavong confirmed   m  46 2023-01-01     2023-01-14 recovered
+      8  12          Kendra To suspected   f  67 2023-01-01     2023-01-10 recovered
+      9  13  Preston Barringer confirmed   m  86 2023-01-01           <NA> recovered
+      10 18  Dominique Raymond confirmed   f  60 2023-01-02           <NA> recovered
+      11 20   Bassaam el-Majid  probable   m  49 2023-01-02           <NA> recovered
+      12 22      Susana Varela  probable   f   7 2023-01-02           <NA> recovered
          date_outcome date_first_contact date_last_contact ct_value
       1          <NA>               <NA>              <NA>       NA
-      2          <NA>         2022-12-30        2023-01-05       NA
+      2          <NA>         2022-12-30        2023-01-05       24
       3          <NA>         2022-12-30        2023-01-02       NA
       4          <NA>         2022-12-29        2023-01-02       NA
-      5          <NA>         2023-01-01        2023-01-03     25.4
-      6          <NA>         2023-01-03        2023-01-04     25.4
-      7          <NA>         2023-01-04        2023-01-05       NA
+      5          <NA>         2023-01-01        2023-01-03       24
+      6          <NA>         2023-01-03        2023-01-04       24
+      7          <NA>         2023-01-04        2023-01-05       24
       8          <NA>         2023-01-01        2023-01-04       NA
-      9          <NA>         2022-12-31        2023-01-03     25.4
-      10         <NA>         2022-12-30        2023-01-03       NA
+      9          <NA>         2022-12-31        2023-01-03       24
+      10         <NA>         2022-12-30        2023-01-03       24
       11         <NA>         2023-01-01        2023-01-04       NA
-      12         <NA>         2023-01-01        2023-01-03     25.4
+      12         <NA>         2023-01-01        2023-01-03       NA
 

--- a/tests/testthat/_snaps/sim_outbreak.md
+++ b/tests/testthat/_snaps/sim_outbreak.md
@@ -5,78 +5,78 @@
         prob_infect = 0.5, onset_to_hosp = onset_to_hosp, onset_to_death = onset_to_death)
     Output
       $linelist
-         id              case_name case_type sex age date_onset date_admission
-      1   1        Dominic Sundara  probable   m  35 2023-01-01           <NA>
-      2   2     Preston Montgomery suspected   m  43 2023-01-01           <NA>
-      3   3          Reece Chittum  probable   m   1 2023-01-01           <NA>
-      4   5          Michael Cheek confirmed   m  78 2023-01-01           <NA>
-      5   6         Jennifer Smith confirmed   f  22 2023-01-01           <NA>
-      6   8         Erika Quintero confirmed   f  28 2023-01-01           <NA>
-      7  11       Isaiah Patterson suspected   m  46 2023-01-01     2023-01-13
-      8  12        Cicely Anderson suspected   f  67 2023-01-01           <NA>
-      9  13           Michael John  probable   m  86 2023-01-01     2023-01-01
-      10 18 Giovana Magana Aguirre suspected   f  60 2023-01-02           <NA>
-      11 20       Mudrik al-Hallal suspected   m  49 2023-01-02           <NA>
-      12 22          Tea Slaughter  probable   f   7 2023-01-02     2023-01-02
-           outcome date_outcome date_first_contact date_last_contact ct_value
-      1  recovered         <NA>               <NA>              <NA>       NA
-      2  recovered         <NA>         2022-12-30        2023-01-05       NA
-      3  recovered         <NA>         2022-12-30        2023-01-02       NA
-      4  recovered         <NA>         2022-12-29        2023-01-02     23.1
-      5  recovered         <NA>         2023-01-01        2023-01-03     23.1
-      6  recovered         <NA>         2023-01-03        2023-01-04     23.1
-      7  recovered         <NA>         2023-01-04        2023-01-05       NA
-      8  recovered         <NA>         2023-01-01        2023-01-04       NA
-      9       died   2023-01-12         2022-12-31        2023-01-03       NA
-      10 recovered         <NA>         2022-12-30        2023-01-03       NA
-      11 recovered         <NA>         2023-01-01        2023-01-04       NA
-      12 recovered         <NA>         2023-01-01        2023-01-03       NA
+         id          case_name case_type sex age date_onset date_admission   outcome
+      1   1    Rushdi al-Ishak  probable   m  35 2023-01-01           <NA> recovered
+      2   2         Jeffrey Le confirmed   m  43 2023-01-01           <NA> recovered
+      3   3  Dominic Barringer suspected   m   1 2023-01-01           <NA> recovered
+      4   5       Tyler Kelley  probable   m  78 2023-01-01           <NA> recovered
+      5   6      Carolyn Moore confirmed   f  22 2023-01-01           <NA> recovered
+      6   8  Cheyenne Sayavong confirmed   f  28 2023-01-01     2023-01-04      died
+      7  11   Bassaam el-Majid confirmed   m  46 2023-01-01     2023-01-14 recovered
+      8  12          Kendra To suspected   f  67 2023-01-01     2023-01-10      died
+      9  13    Qaaid al-Madani confirmed   m  86 2023-01-01           <NA> recovered
+      10 18  Dominique Raymond confirmed   f  60 2023-01-02           <NA> recovered
+      11 20 Abdul Noor el-Syed  probable   m  49 2023-01-02           <NA> recovered
+      12 22      Susana Varela  probable   f   7 2023-01-02           <NA> recovered
+         date_outcome date_first_contact date_last_contact ct_value
+      1          <NA>               <NA>              <NA>       NA
+      2          <NA>         2022-12-30        2023-01-05       24
+      3          <NA>         2022-12-30        2023-01-02       NA
+      4          <NA>         2022-12-29        2023-01-02       NA
+      5          <NA>         2023-01-01        2023-01-03       24
+      6    2023-01-16         2023-01-03        2023-01-04       24
+      7          <NA>         2023-01-04        2023-01-05       24
+      8    2023-01-17         2023-01-01        2023-01-04       NA
+      9          <NA>         2022-12-31        2023-01-03       24
+      10         <NA>         2022-12-30        2023-01-03       24
+      11         <NA>         2023-01-01        2023-01-04       NA
+      12         <NA>         2023-01-01        2023-01-03       NA
       
       $contacts
-                           from                       to age sex date_first_contact
-      1         Dominic Sundara       Preston Montgomery  43   m         2022-12-30
-      2         Dominic Sundara            Reece Chittum   1   m         2022-12-30
-      3      Preston Montgomery               Kayla Hill  29   f         2022-12-27
-      4      Preston Montgomery            Michael Cheek  78   m         2022-12-29
-      5           Reece Chittum           Jennifer Smith  22   f         2023-01-01
-      6           Reece Chittum            Jaylyn Childs  70   m         2022-12-30
-      7           Reece Chittum           Erika Quintero  28   f         2023-01-03
-      8           Michael Cheek        Kelly Fitzsimmons  37   f         2023-01-06
-      9          Jennifer Smith          Audreon Starkey  61   f         2023-01-01
-      10         Erika Quintero         Isaiah Patterson  46   m         2023-01-04
-      11         Erika Quintero          Cicely Anderson  67   f         2023-01-01
-      12         Erika Quintero             Michael John  86   m         2022-12-31
-      13       Isaiah Patterson          Muneeb al-Jamil  71   m         2022-12-28
-      14       Isaiah Patterson Juwairiya el-Abdelrahman  51   f         2023-01-01
-      15       Isaiah Patterson         Bishr al-Youssef  44   m         2023-01-02
-      16        Cicely Anderson        Samantha Gonzalez  49   f         2023-01-02
-      17           Michael John   Giovana Magana Aguirre  60   f         2022-12-30
-      18           Michael John           Michiyo Batara  56   f         2023-01-06
-      19           Michael John         Mudrik al-Hallal  49   m         2023-01-01
-      20           Michael John         Dominic Gonzales  50   m         2023-01-01
-      21 Giovana Magana Aguirre            Tea Slaughter   7   f         2023-01-01
-         date_last_contact was_case         status
-      1         2023-01-05        Y           case
-      2         2023-01-02        Y           case
-      3         2023-01-03        N under_followup
-      4         2023-01-02        Y           case
-      5         2023-01-03        Y           case
-      6         2023-01-02        N under_followup
-      7         2023-01-04        Y           case
-      8         2023-01-06        N under_followup
-      9         2023-01-05        N under_followup
-      10        2023-01-05        Y           case
-      11        2023-01-04        Y           case
-      12        2023-01-03        Y           case
-      13        2023-01-05        N under_followup
-      14        2023-01-04        N under_followup
-      15        2023-01-05        N under_followup
-      16        2023-01-03        N under_followup
-      17        2023-01-03        Y           case
-      18        2023-01-09        N        unknown
-      19        2023-01-04        Y           case
-      20        2023-01-03        N under_followup
-      21        2023-01-03        Y           case
+                      from                        to age sex date_first_contact
+      1    Rushdi al-Ishak                Jeffrey Le  43   m         2022-12-30
+      2    Rushdi al-Ishak         Dominic Barringer   1   m         2022-12-30
+      3         Jeffrey Le             Taylor Graves  29   f         2022-12-27
+      4         Jeffrey Le              Tyler Kelley  78   m         2022-12-29
+      5  Dominic Barringer             Carolyn Moore  22   f         2023-01-01
+      6  Dominic Barringer           Jackson Carlson  70   m         2022-12-30
+      7  Dominic Barringer         Cheyenne Sayavong  28   f         2023-01-03
+      8       Tyler Kelley         Mercedes Lovelace  37   f         2023-01-06
+      9      Carolyn Moore Chantelle Vazquez-Luevano  61   f         2023-01-01
+      10 Cheyenne Sayavong          Bassaam el-Majid  46   m         2023-01-04
+      11 Cheyenne Sayavong                 Kendra To  67   f         2023-01-01
+      12 Cheyenne Sayavong           Qaaid al-Madani  86   m         2022-12-31
+      13  Bassaam el-Majid          John Khanthavong  71   m         2022-12-28
+      14  Bassaam el-Majid               Megan Hayes  51   f         2023-01-01
+      15  Bassaam el-Majid     Abdul Kader el-Jabour  44   m         2023-01-02
+      16         Kendra To         Amanda Larochelle  49   f         2023-01-02
+      17   Qaaid al-Madani         Dominique Raymond  60   f         2022-12-30
+      18   Qaaid al-Madani            Natalie Newton  56   f         2023-01-06
+      19   Qaaid al-Madani        Abdul Noor el-Syed  49   m         2023-01-01
+      20   Qaaid al-Madani               Sam Spencer  50   m         2023-01-01
+      21 Dominique Raymond             Susana Varela   7   f         2023-01-01
+         date_last_contact was_case           status
+      1         2023-01-05        Y             case
+      2         2023-01-02        Y             case
+      3         2023-01-03        N          unknown
+      4         2023-01-02        Y             case
+      5         2023-01-03        Y             case
+      6         2023-01-02        N   under_followup
+      7         2023-01-04        Y             case
+      8         2023-01-06        N   under_followup
+      9         2023-01-05        N   under_followup
+      10        2023-01-05        Y             case
+      11        2023-01-04        Y             case
+      12        2023-01-03        Y             case
+      13        2023-01-05        N   under_followup
+      14        2023-01-04        N lost_to_followup
+      15        2023-01-05        N   under_followup
+      16        2023-01-03        N   under_followup
+      17        2023-01-03        Y             case
+      18        2023-01-09        N          unknown
+      19        2023-01-04        Y             case
+      20        2023-01-03        N   under_followup
+      21        2023-01-03        Y             case
       
 
 # sim_outbreak works as expected with anonymised
@@ -88,59 +88,59 @@
     Output
       $linelist
          id  case_name case_type sex age date_onset date_admission   outcome
-      1   1 ng7AzDS6oX confirmed   m  35 2023-01-01           <NA> recovered
-      2   2 fHuaqm1SzN  probable   m  43 2023-01-01           <NA> recovered
-      3   3 bO5h4yEtT6 confirmed   m   1 2023-01-01           <NA> recovered
-      4   5 a8e6yKFNmy suspected   m  78 2023-01-01           <NA> recovered
-      5   6 dPL7XeZaLT  probable   f  22 2023-01-01           <NA> recovered
-      6   8 TLkhw9tYeb confirmed   f  28 2023-01-01           <NA> recovered
-      7  11 WQihvSfYVA confirmed   m  46 2023-01-01     2023-01-13 recovered
-      8  12 RDjDafq8m2 confirmed   f  67 2023-01-01           <NA> recovered
-      9  13 zbFUJRewLY confirmed   m  86 2023-01-01     2023-01-01      died
-      10 18 VV4dJ6ZKaU confirmed   f  60 2023-01-02           <NA> recovered
-      11 20 fVJ5ftN2GN suspected   m  49 2023-01-02           <NA> recovered
-      12 22 ERhwf5kY6K confirmed   f   7 2023-01-02     2023-01-02 recovered
+      1   1 1ePRI5wC1I suspected   m  35 2023-01-01           <NA> recovered
+      2   2 Ji3IItv5Ov suspected   m  43 2023-01-01           <NA> recovered
+      3   3 sRrRMCAJFE  probable   m   1 2023-01-01           <NA> recovered
+      4   5 uuoY8Kxng7  probable   m  78 2023-01-01           <NA> recovered
+      5   6 AzDS6oXfHu  probable   f  22 2023-01-01           <NA> recovered
+      6   8 h4yEtT6tej confirmed   f  28 2023-01-01     2023-01-04      died
+      7  11 7XeZaLTmhW confirmed   m  46 2023-01-01     2023-01-14 recovered
+      8  12 sVUBVWYTLk  probable   f  67 2023-01-01     2023-01-10      died
+      9  13 hw9tYeb1el suspected   m  86 2023-01-01           <NA> recovered
+      10 18 UJRewLYtBB  probable   f  60 2023-01-02           <NA> recovered
+      11 20 9HLY9VZdzu  probable   m  49 2023-01-02           <NA> recovered
+      12 22 wJ3WvUcVV4 confirmed   f   7 2023-01-02           <NA> recovered
          date_outcome date_first_contact date_last_contact ct_value
-      1          <NA>               <NA>              <NA>     25.8
+      1          <NA>               <NA>              <NA>       NA
       2          <NA>         2022-12-30        2023-01-05       NA
-      3          <NA>         2022-12-30        2023-01-02     25.8
+      3          <NA>         2022-12-30        2023-01-02       NA
       4          <NA>         2022-12-29        2023-01-02       NA
       5          <NA>         2023-01-01        2023-01-03       NA
-      6          <NA>         2023-01-03        2023-01-04     25.8
-      7          <NA>         2023-01-04        2023-01-05     25.8
-      8          <NA>         2023-01-01        2023-01-04     25.8
-      9    2023-01-12         2022-12-31        2023-01-03     25.8
-      10         <NA>         2022-12-30        2023-01-03     25.8
+      6    2023-01-16         2023-01-03        2023-01-04     23.8
+      7          <NA>         2023-01-04        2023-01-05     23.8
+      8    2023-01-17         2023-01-01        2023-01-04       NA
+      9          <NA>         2022-12-31        2023-01-03       NA
+      10         <NA>         2022-12-30        2023-01-03       NA
       11         <NA>         2023-01-01        2023-01-04       NA
-      12         <NA>         2023-01-01        2023-01-03     25.8
+      12         <NA>         2023-01-01        2023-01-03     23.8
       
       $contacts
                from         to age sex date_first_contact date_last_contact was_case
-      1  ng7AzDS6oX fHuaqm1SzN  43   m         2022-12-30        2023-01-05        Y
-      2  ng7AzDS6oX bO5h4yEtT6   1   m         2022-12-30        2023-01-02        Y
-      3  fHuaqm1SzN tejRt34oCb  29   f         2022-12-27        2023-01-03        N
-      4  fHuaqm1SzN a8e6yKFNmy  78   m         2022-12-29        2023-01-02        Y
-      5  bO5h4yEtT6 dPL7XeZaLT  22   f         2023-01-01        2023-01-03        Y
-      6  bO5h4yEtT6 mhWsVUBVWY  70   m         2022-12-30        2023-01-02        N
-      7  bO5h4yEtT6 TLkhw9tYeb  28   f         2023-01-03        2023-01-04        Y
-      8  a8e6yKFNmy 1elczXnmE3  37   f         2023-01-06        2023-01-06        N
-      9  dPL7XeZaLT U4HDzSVgVA  61   f         2023-01-01        2023-01-05        N
-      10 TLkhw9tYeb WQihvSfYVA  46   m         2023-01-04        2023-01-05        Y
-      11 TLkhw9tYeb RDjDafq8m2  67   f         2023-01-01        2023-01-04        Y
-      12 TLkhw9tYeb zbFUJRewLY  86   m         2022-12-31        2023-01-03        Y
-      13 WQihvSfYVA tBBlIdUTzm  71   m         2022-12-28        2023-01-05        N
-      14 WQihvSfYVA cTo9HLY9VZ  51   f         2023-01-01        2023-01-04        N
-      15 WQihvSfYVA dzuuT3p6Kx  44   m         2023-01-02        2023-01-05        N
-      16 RDjDafq8m2 uczwJ3WvUc  49   f         2023-01-02        2023-01-03        N
-      17 zbFUJRewLY VV4dJ6ZKaU  60   f         2022-12-30        2023-01-03        Y
-      18 zbFUJRewLY Kvu5Ak6RZk  56   f         2023-01-06        2023-01-09        N
-      19 zbFUJRewLY fVJ5ftN2GN  49   m         2023-01-01        2023-01-04        Y
-      20 zbFUJRewLY kk2uuqi2rY  50   m         2023-01-01        2023-01-03        N
-      21 VV4dJ6ZKaU ERhwf5kY6K   7   f         2023-01-01        2023-01-03        Y
+      1  1ePRI5wC1I Ji3IItv5Ov  43   m         2022-12-30        2023-01-05        Y
+      2  1ePRI5wC1I sRrRMCAJFE   1   m         2022-12-30        2023-01-02        Y
+      3  Ji3IItv5Ov Y3qKY39Zyi  29   f         2022-12-27        2023-01-03        N
+      4  Ji3IItv5Ov uuoY8Kxng7  78   m         2022-12-29        2023-01-02        Y
+      5  sRrRMCAJFE AzDS6oXfHu  22   f         2023-01-01        2023-01-03        Y
+      6  sRrRMCAJFE aqm1SzNbO5  70   m         2022-12-30        2023-01-02        N
+      7  sRrRMCAJFE h4yEtT6tej  28   f         2023-01-03        2023-01-04        Y
+      8  uuoY8Kxng7 Rt34oCba8e  37   f         2023-01-06        2023-01-06        N
+      9  AzDS6oXfHu 6yKFNmydPL  61   f         2023-01-01        2023-01-05        N
+      10 h4yEtT6tej 7XeZaLTmhW  46   m         2023-01-04        2023-01-05        Y
+      11 h4yEtT6tej sVUBVWYTLk  67   f         2023-01-01        2023-01-04        Y
+      12 h4yEtT6tej hw9tYeb1el  86   m         2022-12-31        2023-01-03        Y
+      13 7XeZaLTmhW czXnmE3U4H  71   m         2022-12-28        2023-01-05        N
+      14 7XeZaLTmhW DzSVgVAWQi  51   f         2023-01-01        2023-01-04        N
+      15 7XeZaLTmhW hvSfYVARDj  44   m         2023-01-02        2023-01-05        N
+      16 sVUBVWYTLk Dafq8m2zbF  49   f         2023-01-02        2023-01-03        N
+      17 hw9tYeb1el UJRewLYtBB  60   f         2022-12-30        2023-01-03        Y
+      18 hw9tYeb1el lIdUTzmcTo  56   f         2023-01-06        2023-01-09        N
+      19 hw9tYeb1el 9HLY9VZdzu  49   m         2023-01-01        2023-01-04        Y
+      20 hw9tYeb1el uT3p6Kxucz  50   m         2023-01-01        2023-01-03        N
+      21 UJRewLYtBB wJ3WvUcVV4   7   f         2023-01-01        2023-01-03        Y
                    status
       1              case
       2              case
-      3  lost_to_followup
+      3    under_followup
       4              case
       5              case
       6    under_followup
@@ -152,10 +152,10 @@
       12             case
       13   under_followup
       14 lost_to_followup
-      15 lost_to_followup
-      16 lost_to_followup
+      15   under_followup
+      16   under_followup
       17             case
-      18   under_followup
+      18          unknown
       19             case
       20 lost_to_followup
       21             case
@@ -170,108 +170,26 @@
         non_hosp_death_risk = age_dep_non_hosp_death_risk)
     Output
       $linelist
-         id        case_name case_type sex age date_onset date_admission   outcome
-      1   1       Cass Duran  probable   m  35 2023-01-01           <NA> recovered
-      2   2 Mudrik al-Hallal suspected   m  43 2023-01-01           <NA> recovered
-      3   3  Jareer al-Safar  probable   m   1 2023-01-01     2023-01-11 recovered
-      4   5  Raashid el-Huda confirmed   m  78 2023-01-01           <NA> recovered
-      5   6     Erika Sierra confirmed   f  22 2023-01-01           <NA> recovered
-      6   8    Jennifer Hong confirmed   f  28 2023-01-01           <NA> recovered
-      7  11    Donald Childs suspected   m  46 2023-01-01           <NA> recovered
-      8  12    Kayla Johnson suspected   f  67 2023-01-01           <NA>      died
-      9  13   Avery Johnston  probable   m  86 2023-01-01     2023-01-01 recovered
-      10 18  Giovana Segarra suspected   f  60 2023-01-02           <NA> recovered
-      11 20      Donald Root suspected   m  49 2023-01-02     2023-01-09 recovered
-      12 22      Kiona Dalke  probable   f   7 2023-01-02           <NA> recovered
-         date_outcome date_first_contact date_last_contact ct_value
-      1          <NA>               <NA>              <NA>       NA
-      2          <NA>         2022-12-30        2023-01-05       NA
-      3          <NA>         2022-12-30        2023-01-02       NA
-      4          <NA>         2022-12-29        2023-01-02     23.1
-      5          <NA>         2023-01-01        2023-01-03     23.1
-      6          <NA>         2023-01-03        2023-01-04     23.1
-      7          <NA>         2023-01-04        2023-01-05       NA
-      8    2023-01-14         2023-01-01        2023-01-04       NA
-      9          <NA>         2022-12-31        2023-01-03       NA
-      10         <NA>         2022-12-30        2023-01-03       NA
-      11         <NA>         2023-01-01        2023-01-04       NA
-      12         <NA>         2023-01-01        2023-01-03       NA
-      
-      $contacts
-                     from                      to age sex date_first_contact
-      1        Cass Duran        Mudrik al-Hallal  43   m         2022-12-30
-      2        Cass Duran         Jareer al-Safar   1   m         2022-12-30
-      3  Mudrik al-Hallal        Kaitlynne Rieger  29   f         2022-12-27
-      4  Mudrik al-Hallal         Raashid el-Huda  78   m         2022-12-29
-      5   Jareer al-Safar            Erika Sierra  22   f         2023-01-01
-      6   Jareer al-Safar          Preston Huerta  70   m         2022-12-30
-      7   Jareer al-Safar           Jennifer Hong  28   f         2023-01-03
-      8   Raashid el-Huda        Kaitlin Gonzalez  37   f         2023-01-06
-      9      Erika Sierra       Marissa Slaughter  61   f         2023-01-01
-      10    Jennifer Hong           Donald Childs  46   m         2023-01-04
-      11    Jennifer Hong           Kayla Johnson  67   f         2023-01-01
-      12    Jennifer Hong          Avery Johnston  86   m         2022-12-31
-      13    Donald Childs          Lorenzo Gaynor  71   m         2022-12-28
-      14    Donald Childs            Michiyo Tran  51   f         2023-01-01
-      15    Donald Childs             Ethan Black  44   m         2023-01-02
-      16    Kayla Johnson Marzooqa el-Abdelrahman  49   f         2023-01-02
-      17   Avery Johnston         Giovana Segarra  60   f         2022-12-30
-      18   Avery Johnston       Kaylie Shangreaux  56   f         2023-01-06
-      19   Avery Johnston             Donald Root  49   m         2023-01-01
-      20   Avery Johnston          Hunter Simmons  50   m         2023-01-01
-      21  Giovana Segarra             Kiona Dalke   7   f         2023-01-01
-         date_last_contact was_case         status
-      1         2023-01-05        Y           case
-      2         2023-01-02        Y           case
-      3         2023-01-03        N under_followup
-      4         2023-01-02        Y           case
-      5         2023-01-03        Y           case
-      6         2023-01-02        N under_followup
-      7         2023-01-04        Y           case
-      8         2023-01-06        N under_followup
-      9         2023-01-05        N under_followup
-      10        2023-01-05        Y           case
-      11        2023-01-04        Y           case
-      12        2023-01-03        Y           case
-      13        2023-01-05        N under_followup
-      14        2023-01-04        N under_followup
-      15        2023-01-05        N under_followup
-      16        2023-01-03        N under_followup
-      17        2023-01-03        Y           case
-      18        2023-01-09        N        unknown
-      19        2023-01-04        Y           case
-      20        2023-01-03        N under_followup
-      21        2023-01-03        Y           case
-      
-
-# sim_outbreak works as expected with age structure
-
-    Code
-      sim_outbreak(contact_distribution = contact_distribution, infect_period = infect_period,
-        prob_infect = 0.5, onset_to_hosp = onset_to_hosp, onset_to_death = onset_to_death,
-        population_age = age_struct)
-    Output
-      $linelist
          id          case_name case_type sex age date_onset date_admission   outcome
-      1   1         Kyle Crane suspected   m  44 2023-01-01           <NA> recovered
-      2   2 Ghaamid el-Ishmael confirmed   m  13 2023-01-01           <NA> recovered
-      3   3   Faatih el-Kaiser confirmed   m  22 2023-01-01     2023-01-09 recovered
-      4   5   Va'Aahi Galligan suspected   m  85 2023-01-01           <NA> recovered
-      5   6     Katelyn Catlin confirmed   f  41 2023-01-01           <NA> recovered
-      6   8       Lynsey Duron confirmed   f  89 2023-01-01     2023-01-02      died
-      7  11    Wajdi al-Demian confirmed   m  69 2023-01-01           <NA> recovered
-      8  12       Jacy Cousins confirmed   f  23 2023-01-01           <NA> recovered
-      9  13      Travis Foster confirmed   m   9 2023-01-01           <NA> recovered
-      10 18     Maria Eberhart  probable   f  62 2023-01-02           <NA> recovered
-      11 20  Mubarak el-Vaziri suspected   m  52 2023-01-02     2023-01-15 recovered
-      12 22        Erin Payson confirmed   f  76 2023-01-02           <NA> recovered
+      1   1 Ghaamid el-Ishmael suspected   m  35 2023-01-01           <NA> recovered
+      2   2   Faatih el-Kaiser confirmed   m  43 2023-01-01           <NA> recovered
+      3   3   Brandon Galligan confirmed   m   1 2023-01-01     2023-01-04 recovered
+      4   5      Aiman el-Riaz suspected   m  78 2023-01-01           <NA> recovered
+      5   6     Katelyn Catlin confirmed   f  22 2023-01-01           <NA> recovered
+      6   8       Lynsey Duron confirmed   f  28 2023-01-01           <NA> recovered
+      7  11      Travis Foster confirmed   m  46 2023-01-01           <NA> recovered
+      8  12       Jacy Cousins confirmed   f  67 2023-01-01           <NA> recovered
+      9  13        Khoa Murray confirmed   m  86 2023-01-01     2023-01-02 recovered
+      10 18     Maria Eberhart  probable   f  60 2023-01-02           <NA> recovered
+      11 20        John Flores suspected   m  49 2023-01-02           <NA> recovered
+      12 22        Erin Payson confirmed   f   7 2023-01-02           <NA> recovered
          date_outcome date_first_contact date_last_contact ct_value
       1          <NA>               <NA>              <NA>       NA
       2          <NA>         2022-12-30        2023-01-05     25.1
       3          <NA>         2022-12-30        2023-01-02     25.1
       4          <NA>         2022-12-29        2023-01-02       NA
       5          <NA>         2023-01-01        2023-01-03     25.1
-      6    2023-01-26         2023-01-03        2023-01-04     25.1
+      6          <NA>         2023-01-03        2023-01-04     25.1
       7          <NA>         2023-01-04        2023-01-05     25.1
       8          <NA>         2023-01-01        2023-01-04     25.1
       9          <NA>         2022-12-31        2023-01-03     25.1
@@ -281,27 +199,27 @@
       
       $contacts
                        from                     to age sex date_first_contact
-      1          Kyle Crane     Ghaamid el-Ishmael  13   m         2022-12-30
-      2          Kyle Crane       Faatih el-Kaiser  22   m         2022-12-30
-      3  Ghaamid el-Ishmael Carisa Flores-Gonzalez   5   f         2022-12-27
-      4  Ghaamid el-Ishmael       Va'Aahi Galligan  85   m         2022-12-29
-      5    Faatih el-Kaiser         Katelyn Catlin  41   f         2023-01-01
-      6    Faatih el-Kaiser          Aiman el-Riaz   2   m         2022-12-30
-      7    Faatih el-Kaiser           Lynsey Duron  89   f         2023-01-03
-      8    Va'Aahi Galligan        Amaani al-Gaber  86   f         2023-01-06
-      9      Katelyn Catlin         Lilibeth Black  82   f         2023-01-01
-      10       Lynsey Duron        Wajdi al-Demian  69   m         2023-01-04
-      11       Lynsey Duron           Jacy Cousins  23   f         2023-01-01
-      12       Lynsey Duron          Travis Foster   9   m         2022-12-31
-      13    Wajdi al-Demian         Raymond Murray  79   m         2022-12-28
-      14    Wajdi al-Demian       Marquaja Johnson  29   f         2023-01-01
-      15    Wajdi al-Demian          Raaid el-Diab   4   m         2023-01-02
-      16       Jacy Cousins            Kayla Tudor  13   f         2023-01-02
-      17      Travis Foster         Maria Eberhart  62   f         2022-12-30
-      18      Travis Foster            Katja Muetz  24   f         2023-01-06
-      19      Travis Foster      Mubarak el-Vaziri  52   m         2023-01-01
-      20      Travis Foster     Alexandre Guerrero  74   m         2023-01-01
-      21     Maria Eberhart            Erin Payson  76   f         2023-01-01
+      1  Ghaamid el-Ishmael       Faatih el-Kaiser  43   m         2022-12-30
+      2  Ghaamid el-Ishmael       Brandon Galligan   1   m         2022-12-30
+      3    Faatih el-Kaiser Carisa Flores-Gonzalez  29   f         2022-12-27
+      4    Faatih el-Kaiser          Aiman el-Riaz  78   m         2022-12-29
+      5    Brandon Galligan         Katelyn Catlin  22   f         2023-01-01
+      6    Brandon Galligan        Wajdi al-Demian  70   m         2022-12-30
+      7    Brandon Galligan           Lynsey Duron  28   f         2023-01-03
+      8       Aiman el-Riaz        Amaani al-Gaber  37   f         2023-01-06
+      9      Katelyn Catlin         Lilibeth Black  61   f         2023-01-01
+      10       Lynsey Duron          Travis Foster  46   m         2023-01-04
+      11       Lynsey Duron           Jacy Cousins  67   f         2023-01-01
+      12       Lynsey Duron            Khoa Murray  86   m         2022-12-31
+      13      Travis Foster          Raaid el-Diab  71   m         2022-12-28
+      14      Travis Foster       Marquaja Johnson  51   f         2023-01-01
+      15      Travis Foster      Mubarak el-Vaziri  44   m         2023-01-02
+      16       Jacy Cousins            Kayla Tudor  49   f         2023-01-02
+      17        Khoa Murray         Maria Eberhart  60   f         2022-12-30
+      18        Khoa Murray            Katja Muetz  56   f         2023-01-06
+      19        Khoa Murray            John Flores  49   m         2023-01-01
+      20        Khoa Murray             Bryce Sena  50   m         2023-01-01
+      21     Maria Eberhart            Erin Payson   7   f         2023-01-01
          date_last_contact was_case           status
       1         2023-01-05        Y             case
       2         2023-01-02        Y             case
@@ -321,6 +239,88 @@
       16        2023-01-03        N   under_followup
       17        2023-01-03        Y             case
       18        2023-01-09        N lost_to_followup
+      19        2023-01-04        Y             case
+      20        2023-01-03        N   under_followup
+      21        2023-01-03        Y             case
+      
+
+# sim_outbreak works as expected with age structure
+
+    Code
+      sim_outbreak(contact_distribution = contact_distribution, infect_period = infect_period,
+        prob_infect = 0.5, onset_to_hosp = onset_to_hosp, onset_to_death = onset_to_death,
+        population_age = age_struct)
+    Output
+      $linelist
+         id            case_name case_type sex age date_onset date_admission
+      1   1        Bryce Cunniff  probable   m  44 2023-01-01           <NA>
+      2   2 Ignacio Garcia Mayen confirmed   m  13 2023-01-01           <NA>
+      3   3     Dominic Martinez suspected   m  22 2023-01-01           <NA>
+      4   5   Sheldon Kacprowicz  probable   m  85 2023-01-01     2023-01-22
+      5   6 Caroline Hergenreter confirmed   f  41 2023-01-01     2023-01-01
+      6   8  Cassandra Whitworth confirmed   f  89 2023-01-01     2023-01-03
+      7  11        Tyler Carlson confirmed   m  69 2023-01-01           <NA>
+      8  12    Harleigh Sayavong suspected   f  23 2023-01-01           <NA>
+      9  13        Cleatus Black confirmed   m   9 2023-01-01           <NA>
+      10 18            Kendra To confirmed   f  62 2023-01-02           <NA>
+      11 20            Jelani Le  probable   m  52 2023-01-02           <NA>
+      12 22        Amanda Kaiser  probable   f  76 2023-01-02           <NA>
+           outcome date_outcome date_first_contact date_last_contact ct_value
+      1  recovered         <NA>               <NA>              <NA>       NA
+      2  recovered         <NA>         2022-12-30        2023-01-05       24
+      3  recovered         <NA>         2022-12-30        2023-01-02       NA
+      4       died   2023-01-16         2022-12-29        2023-01-02       NA
+      5  recovered         <NA>         2023-01-01        2023-01-03       24
+      6       died   2023-01-16         2023-01-03        2023-01-04       24
+      7  recovered         <NA>         2023-01-04        2023-01-05       24
+      8  recovered         <NA>         2023-01-01        2023-01-04       NA
+      9  recovered         <NA>         2022-12-31        2023-01-03       24
+      10 recovered         <NA>         2022-12-30        2023-01-03       24
+      11 recovered         <NA>         2023-01-01        2023-01-04       NA
+      12 recovered         <NA>         2023-01-01        2023-01-03       NA
+      
+      $contacts
+                         from                        to age sex date_first_contact
+      1         Bryce Cunniff      Ignacio Garcia Mayen  13   m         2022-12-30
+      2         Bryce Cunniff          Dominic Martinez  22   m         2022-12-30
+      3  Ignacio Garcia Mayen          Grayson Anderson   5   f         2022-12-27
+      4  Ignacio Garcia Mayen        Sheldon Kacprowicz  85   m         2022-12-29
+      5      Dominic Martinez      Caroline Hergenreter  41   f         2023-01-01
+      6      Dominic Martinez        Khristopher Kelley   2   m         2022-12-30
+      7      Dominic Martinez       Cassandra Whitworth  89   f         2023-01-03
+      8    Sheldon Kacprowicz             Taylor Graves  86   f         2023-01-06
+      9  Caroline Hergenreter             Carolyn Moore  82   f         2023-01-01
+      10  Cassandra Whitworth             Tyler Carlson  69   m         2023-01-04
+      11  Cassandra Whitworth         Harleigh Sayavong  23   f         2023-01-01
+      12  Cassandra Whitworth             Cleatus Black   9   m         2022-12-31
+      13        Tyler Carlson           Jackson Spencer  79   m         2022-12-28
+      14        Tyler Carlson          Candace Lovelace  29   f         2023-01-01
+      15        Tyler Carlson              David Abeyta   4   m         2023-01-02
+      16    Harleigh Sayavong Chantelle Vazquez-Luevano  13   f         2023-01-02
+      17        Cleatus Black                 Kendra To  62   f         2022-12-30
+      18        Cleatus Black          Megan Riggenbach  24   f         2023-01-06
+      19        Cleatus Black                 Jelani Le  52   m         2023-01-01
+      20        Cleatus Black         Rushdi al-Chahine  74   m         2023-01-01
+      21            Kendra To             Amanda Kaiser  76   f         2023-01-01
+         date_last_contact was_case           status
+      1         2023-01-05        Y             case
+      2         2023-01-02        Y             case
+      3         2023-01-03        N          unknown
+      4         2023-01-02        Y             case
+      5         2023-01-03        Y             case
+      6         2023-01-02        N   under_followup
+      7         2023-01-04        Y             case
+      8         2023-01-06        N   under_followup
+      9         2023-01-05        N   under_followup
+      10        2023-01-05        Y             case
+      11        2023-01-04        Y             case
+      12        2023-01-03        Y             case
+      13        2023-01-05        N   under_followup
+      14        2023-01-04        N lost_to_followup
+      15        2023-01-05        N   under_followup
+      16        2023-01-03        N   under_followup
+      17        2023-01-03        Y             case
+      18        2023-01-09        N          unknown
       19        2023-01-04        Y             case
       20        2023-01-03        N   under_followup
       21        2023-01-03        Y             case


### PR DESCRIPTION
This PR updates the snapshots for the regression unit tests (`testthat::expect_snapsnot()`) that had started to fail because of an update to {epiparameter}. 

This PR makes no functional changes to the {simulist} package.

Since epiverse-trace/epiparameter#323 the `epidist_db()` function preferentially selects database entries that account for right truncation when specifying `single_epidist = TRUE`. This impacts the unit tests of `sim_linelist()` and `sim_outbreak()` which call `epiparameter::epidist_db()` to load an onset-to-hospitalisation and an onset-to-death delay distribution. Since the change to {epiparameter} different delay distributions are being returned and as a result the simulated line lists and outbreak datasets are different to the previous snapshots.

