### PR TITLE
Update `LICENSE` copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-YEAR: 2022
+YEAR: 2024
 COPYRIGHT HOLDER: simulist authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2022 simulist authors
+Copyright (c) 2024 simulist authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR updates the copyright year in both the `LICENSE.md` and `LICENSE` files to the current year. This was raised in PR #117.