### PR TITLE
Capitalise messages returned to user

### DIFF
--- a/R/checkers.R
+++ b/R/checkers.R
@@ -9,17 +9,17 @@
 .check_risk_df <- function(x, age_range) {
   # check input
   stopifnot(
-    "column names should be 'age_limit' & 'risk'" =
+    "Column names should be 'age_limit' & 'risk'" =
       setequal(c("age_limit", "risk"), colnames(x)),
-    "minimum age of lowest age group should match lower age range" =
+    "Minimum age of lowest age group should match lower age range" =
       age_range[["lower"]] == min(x$age_limit),
-    "lower bound of oldest age group must be lower than highest age range" =
+    "Lower bound of oldest age group must be lower than highest age range" =
       age_range[["upper"]] > max(x$age_limit),
-    "age limit or risk cannot be NA or NaN" =
+    "Age limit or risk cannot be NA or NaN" =
       !anyNA(x),
-    "risk should be between 0 and 1" =
+    "Risk should be between 0 and 1" =
       min(x$risk) >= 0 && max(x$risk) <= 1,
-    "age limit in risk data frame must be unique" =
+    "Age limit in risk data frame must be unique" =
       anyDuplicated(x$age_limit) == 0
   )
 
@@ -59,13 +59,13 @@
 .check_age_df <- function(x) {
   # check input
   stopifnot(
-    "column names should be 'age_range' & 'proportion'" =
+    "Column names should be 'age_range' & 'proportion'" =
       setequal(c("age_range", "proportion"), colnames(x)),
-    "age range or proportion cannot be NA or NaN" =
+    "Age range or proportion cannot be NA or NaN" =
       !anyNA(x),
-    "proportions of each age bracket should sum to 1" =
+    "Proportions of each age bracket should sum to 1" =
       all.equal(sum(x$proportion), 1),
-    "all age groups should be separated with a '-' (e.g. '1-5')" =
+    "All age groups should be separated with a '-' (e.g. '1-5')" =
       all(grepl(pattern = "^\\d+(-)\\d+$", x = x$age_range)) # nolint nonportable_path_linter
   )
 
@@ -76,11 +76,11 @@
 
   # check age input
   stopifnot(
-    "age groups should be non-overlapping" =
+    "Age groups should be non-overlapping" =
       anyDuplicated(age_groups) == 0,
-    "age groups should be contiguous" =
+    "Age groups should be contiguous" =
       all(min(age_groups):max(age_groups) %in% age_groups),
-    "age groups should include only positive integers" =
+    "Age groups should include only positive integers" =
       checkmate::test_integerish(unlist(age_bounds), lower = 0)
   )
 

--- a/tests/testthat/test-checkers.R
+++ b/tests/testthat/test-checkers.R
@@ -23,7 +23,7 @@ test_that(".check_risk_df fails as expected", {
   )
   expect_error(
     .check_risk_df(age_dep_hosp_risk, age_range = c(lower = 1, upper = 91)),
-    regexp = "column names should be 'age_limit' & 'risk'"
+    regexp = "Column names should be 'age_limit' & 'risk'"
   )
 
   age_dep_hosp_risk <- data.frame(
@@ -32,7 +32,7 @@ test_that(".check_risk_df fails as expected", {
   )
   expect_error(
     .check_risk_df(age_dep_hosp_risk, age_range = c(lower = 1, upper = 90)),
-    regexp = "minimum age of lowest age group should match lower age range"
+    regexp = "Minimum age of lowest age group should match lower age range"
   )
 
   age_dep_hosp_risk <- data.frame(
@@ -42,7 +42,7 @@ test_that(".check_risk_df fails as expected", {
   expect_error(
     .check_risk_df(age_dep_hosp_risk, age_range = c(lower = 1, upper = 90)),
     regexp =
-      "lower bound of oldest age group must be lower than highest age range"
+      "Lower bound of oldest age group must be lower than highest age range"
   )
 
   age_dep_hosp_risk <- data.frame(
@@ -51,7 +51,7 @@ test_that(".check_risk_df fails as expected", {
   )
   expect_error(
     .check_risk_df(age_dep_hosp_risk, age_range = c(lower = 1, upper = 90)),
-    regexp = "risk should be between 0 and 1"
+    regexp = "Risk should be between 0 and 1"
   )
 
   age_dep_hosp_risk <- data.frame(
@@ -60,7 +60,7 @@ test_that(".check_risk_df fails as expected", {
   )
   expect_error(
     .check_risk_df(age_dep_hosp_risk, age_range = c(lower = 1, upper = 90)),
-    regexp = "age limit in risk data frame must be unique"
+    regexp = "Age limit in risk data frame must be unique"
   )
 
   age_dep_hosp_risk <- data.frame(
@@ -69,7 +69,7 @@ test_that(".check_risk_df fails as expected", {
   )
   expect_error(
     .check_risk_df(age_dep_hosp_risk, age_range = c(lower = 1, upper = 90)),
-    regexp = "age limit or risk cannot be NA or NaN"
+    regexp = "Age limit or risk cannot be NA or NaN"
   )
 })
 
@@ -93,7 +93,7 @@ test_that(".check_age_df fails as expected", {
   )
   expect_error(
     .check_age_df(age_struct),
-    regexp = "column names should be 'age_range' & 'proportion'"
+    regexp = "Column names should be 'age_range' & 'proportion'"
   )
 
   age_struct <- data.frame(
@@ -103,7 +103,7 @@ test_that(".check_age_df fails as expected", {
   )
   expect_error(
     .check_age_df(age_struct),
-    regexp = "age range or proportion cannot be NA or NaN"
+    regexp = "Age range or proportion cannot be NA or NaN"
   )
 
   age_struct <- data.frame(
@@ -113,7 +113,7 @@ test_that(".check_age_df fails as expected", {
   )
   expect_error(
     .check_age_df(age_struct),
-    regexp = "proportions of each age bracket should sum to 1"
+    regexp = "Proportions of each age bracket should sum to 1"
   )
 
   age_struct <- data.frame(
@@ -123,7 +123,7 @@ test_that(".check_age_df fails as expected", {
   )
   expect_error(
     .check_age_df(age_struct),
-    regexp = "(all age groups should be separated with a)*(-)"
+    regexp = "(All age groups should be separated with a)*(-)"
   )
 
   age_struct <- data.frame(
@@ -133,7 +133,7 @@ test_that(".check_age_df fails as expected", {
   )
   expect_error(
     .check_age_df(age_struct),
-    regexp = "age groups should be contiguous"
+    regexp = "Age groups should be contiguous"
   )
 })
 


### PR DESCRIPTION
This PR updates any messages that are returned by condition or error handling functions (e.g. `stop()`, `stopifnot()`, `warning()`, `message()`) to start with a capital letter, unless the first word is the name of a function or argument that is lowercase. This changes comes from a suggestion in PR #117.