### PR TITLE
Ensure `<Date>` in `CITATION`

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -11,7 +11,7 @@ if (length(author)) {
 if (is.null(meta$Date)) {
   date <- format(Sys.Date(), "%Y")
 } else {
-  date <- format(meta$Date, "%Y")
+  date <- format(as.Date(meta$Date), "%Y")
 }
 
 bibentry(
@@ -20,5 +20,5 @@ bibentry(
   author  = author,
   year    = date,
   doi     = "10.5281/zenodo.10471458",
-  url     = meta$URL
+  url     = "https://epiverse-trace.github.io/simulist/"
 )


### PR DESCRIPTION
This PR makes the same update as epiverse-trace/epiparameter#314 to ensure that the date used to produce the `CITATION` file is of the class `<Date>`. This resolves an issue that has been known to occur in other R package (see epiverse-trace/epiparameter#297).