### PR TITLE
Turn partial argument matching check to `TRUE`

### DIFF
--- a/tests/testthat/setup-options.R
+++ b/tests/testthat/setup-options.R
@@ -3,6 +3,5 @@
 options(
   warnPartialMatchAttr = TRUE,
   warnPartialMatchDollar = TRUE,
-  # https://github.com/CenterForAssessment/randomNames/pull/82
-  warnPartialMatchArgs = FALSE # temp FALSE due to PartialMatchArgs in import
+  warnPartialMatchArgs = TRUE
 )

--- a/tests/testthat/test-add_cols.R
+++ b/tests/testthat/test-add_cols.R
@@ -230,7 +230,7 @@ test_that(".add_outcome works as expected with age-strat risks", {
   linelist <- .add_outcome(
     .data = ll,
     onset_to_death = onset_to_death,
-    onset_to_recover = onset_to_recovery,
+    onset_to_recovery = onset_to_recovery,
     hosp_death_risk = age_dep_hosp_death_risk,
     non_hosp_death_risk = age_dep_non_hosp_death_risk,
     config = create_config()


### PR DESCRIPTION
This PR addresses #1 by turning the `warnPartialMatchArgs` to `TRUE` in `setup-options.R`. This has been resolved thanks to a PR to {randomNames} resolving the issue (CenterForAssessment/randomNames#82) being merged and a new version of the package being uploaded to CRAN. 