### PR TITLE
Error when negative infectious period is sampled

### DIFF
--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -30,7 +30,7 @@
 #' become infectious immediately after being infected (the latency period is
 #' assumed to be zero). The time intervals between an infected individual and
 #' their contacts are assumed to be uniformly distributed within the
-#' infectious period.
+#' infectious period. Infectious periods must be strictly positive.
 #' @param prob_infect A single `numeric` for the probability of a secondary
 #' contact being infected by an infected primary contact.
 #' @param onset_to_hosp An `<epidist>` object, an anonymous function for

--- a/R/sim_network_bp.R
+++ b/R/sim_network_bp.R
@@ -94,7 +94,7 @@
           infected[vec_idx] <- as.numeric(infect)
 
           # compute infectious period for ancestor
-          contact_infect_period <- infect_period(1)
+          contact_infect_period <- .sample_infect_period(infect_period)
 
           # assume contacts are evenly distributed across the infectious period
           contact_times <- stats::runif(

--- a/R/utils.R
+++ b/R/utils.R
@@ -187,3 +187,22 @@ as_function <- function(x) {
     onset_to_recovery = onset_to_recovery
   )
 }
+
+#' Sample infectious period distribution and check value is positive
+#'
+#' @inheritParams sim_linelist
+#'
+#' @return A single `numeric`.
+#' @keywords internal
+#' @noRd
+.sample_infect_period <- function(infect_period) {
+  contact_infect_period <- infect_period(1)
+  if (contact_infect_period < 0) {
+    stop(
+      "Negative infectious period sampled. ",
+      "The infectious period must be strictly positive.",
+      call. = FALSE
+    )
+  }
+  contact_infect_period
+}

--- a/man/dot-check_sim_input.Rd
+++ b/man/dot-check_sim_input.Rd
@@ -38,7 +38,7 @@ to no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
 assumed to be zero). The time intervals between an infected individual and
 their contacts are assumed to be uniformly distributed within the
-infectious period.}
+infectious period. Infectious periods must be strictly positive.}
 
 \item{prob_infect}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}

--- a/man/dot-sim_internal.Rd
+++ b/man/dot-sim_internal.Rd
@@ -40,7 +40,7 @@ to no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
 assumed to be zero). The time intervals between an infected individual and
 their contacts are assumed to be uniformly distributed within the
-infectious period.}
+infectious period. Infectious periods must be strictly positive.}
 
 \item{prob_infect}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}

--- a/man/dot-sim_network_bp.Rd
+++ b/man/dot-sim_network_bp.Rd
@@ -25,7 +25,7 @@ to no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
 assumed to be zero). The time intervals between an infected individual and
 their contacts are assumed to be uniformly distributed within the
-infectious period.}
+infectious period. Infectious periods must be strictly positive.}
 
 \item{prob_infect}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}

--- a/man/sim_contacts.Rd
+++ b/man/sim_contacts.Rd
@@ -29,7 +29,7 @@ to no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
 assumed to be zero). The time intervals between an infected individual and
 their contacts are assumed to be uniformly distributed within the
-infectious period.}
+infectious period. Infectious periods must be strictly positive.}
 
 \item{prob_infect}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}

--- a/man/sim_linelist.Rd
+++ b/man/sim_linelist.Rd
@@ -34,7 +34,7 @@ to no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
 assumed to be zero). The time intervals between an infected individual and
 their contacts are assumed to be uniformly distributed within the
-infectious period.}
+infectious period. Infectious periods must be strictly positive.}
 
 \item{prob_infect}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}

--- a/man/sim_outbreak.Rd
+++ b/man/sim_outbreak.Rd
@@ -36,7 +36,7 @@ to no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
 assumed to be zero). The time intervals between an infected individual and
 their contacts are assumed to be uniformly distributed within the
-infectious period.}
+infectious period. Infectious periods must be strictly positive.}
 
 \item{prob_infect}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}

--- a/tests/testthat/test-sim_network_bp.R
+++ b/tests/testthat/test-sim_network_bp.R
@@ -80,3 +80,27 @@ test_that(".sim_network_bp warns as expected", {
     regexp = "(Number of cases exceeds maximum)*(Returning data early)"
   )
 })
+
+test_that(".sim_network_bp errors with negative infectious period", {
+  suppressMessages({
+    infect_period <- as.function(
+    epiparameter::epidist(
+      disease = "COVID-19",
+      epi_dist = "infectious period",
+      prob_distribution = "norm",
+      prob_distribution_params = c(mean = 10, sd = 5)
+    ), func_type = "generate"
+    )
+  })
+  set.seed(3)
+  expect_error(
+    .sim_network_bp(
+      contact_distribution = contact_distribution,
+      infect_period = infect_period,
+      prob_infect = 0.5,
+      max_outbreak_size = 1e4,
+      config = create_config()
+    ),
+    regexp = "(Negative infectious period sampled)"
+  )
+})


### PR DESCRIPTION
This PR addresses #141 by adding a check that the sampled infectious period is positive and if not then erroring. A new internal function is added, `.sample_infect_period()`, which samples from the user-supplied infectious period and checks if the value is positive. This is a new function to prevent the cyclomatic complexity of `.sim_network_bp()` from exceeding 15. 

A new unit test is added to ensure the `stop()` in `.sample_infect_period()` is correctly triggered when called by `.sim_network_bp()`. 

The `infect_period` argument documentation is updated to document that only positive values are valid.