### PR TITLE
Do not error when `hosp_death_risk` is `NA` without hospitalisation

### DIFF
--- a/R/checkers.R
+++ b/R/checkers.R
@@ -289,10 +289,10 @@
     ))
   }
   if (!rlang::is_lgl_na(onset_to_death_eval)) {
-    if (rlang::is_lgl_na(hosp_death_risk)) {
+    if (rlang::is_lgl_na(hosp_death_risk) && !rlang::is_lgl_na(hosp_risk)) {
       msg <- c(msg, paste(
-        "hosp_death_risk is set to NA but onset_to_death is specified \n",
-        "set hosp_death_risk to numeric value"
+        "hosp_death_risk is set to NA but hosp_risk and onset_to_death is",
+        "specified \n set hosp_death_risk to numeric value"
       ))
     }
     if (rlang::is_lgl_na(non_hosp_death_risk)) {

--- a/tests/testthat/test-sim_linelist.R
+++ b/tests/testthat/test-sim_linelist.R
@@ -332,7 +332,7 @@ test_that("sim_linelist fails when onset-to-event are given by risk is NA", {
       onset_to_death = onset_to_death,
       hosp_death_risk = NA
     ),
-    regexp = "(hosp_death_risk is set to NA but onset_to_death is specified)"
+    regexp = "(hosp_death_risk is set to NA but hosp_risk and onset_to_death)"
   )
   expect_error(
     sim_linelist(


### PR DESCRIPTION
This PR addresses an issue whereby the `sim_linelist()` function would error when `hosp_death_risk` is `NA` and `onset_to_death` is specified as a delay distribution by the user (i.e. not `NA`). See example `sim_linelist()` call that would produce this error.

```r
sim_linelist(
  contact_distribution = contact_distribution,
  infectious_period = infectious_period,
  onset_to_hosp = NA,
  onset_to_death = onset_to_death,
  onset_to_recovery = onset_to_recovery,
  hosp_risk = NA,
  hosp_death_risk = NA,
  non_hosp_death_risk = 0.3,
  prob_infection = 0.5
)
```

However, this is unwanted behaviour as in this parameterisation nobody in the simulation is hospitalised (`onset_to_hosp = NA` and `hosp_risk = NA`), so `hosp_death_risk` should be allowed to be `NA`. This PR resolves this by updating `.cross_check_sim_input()` to check whether `hosp_risk` is `NA` and if so not erroring.

Thanks to @CarmenTamayo for reporting this issue.