### PR TITLE
Add defaults to all exported function arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,4 +52,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-GB
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -288,13 +288,16 @@
       "set hosp_risk to numeric value"
     ))
   }
-  if (!rlang::is_lgl_na(onset_to_death_eval)) {
-    if (is.null(hosp_death_risk) && !is.null(hosp_risk)) {
+  if (!rlang::is_lgl_na(onset_to_hosp_eval) &&
+      !rlang::is_lgl_na(onset_to_death_eval)) {
+    if (is.null(hosp_death_risk)) {
       msg <- c(msg, paste(
-        "hosp_death_risk is set to NULL but hosp_risk and onset_to_death is",
-        "specified \n set hosp_death_risk to numeric value"
+        "hosp_death_risk is set to NULL but onset_to_hosp and onset_to_death",
+        "is specified \n set hosp_death_risk to numeric value"
       ))
     }
+  }
+  if (!rlang::is_lgl_na(onset_to_death_eval)) {
     if (is.null(non_hosp_death_risk)) {
       msg <- c(msg, paste(
         "non_hosp_death_risk is set to NULL but onset_to_death is specified \n",

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -289,21 +289,17 @@
     ))
   }
   if (!rlang::is_lgl_na(onset_to_hosp_eval) &&
-      !rlang::is_lgl_na(onset_to_death_eval)) {
-    if (is.null(hosp_death_risk)) {
-      msg <- c(msg, paste(
-        "hosp_death_risk is set to NULL but onset_to_hosp and onset_to_death",
-        "is specified \n set hosp_death_risk to numeric value"
-      ))
-    }
+      !rlang::is_lgl_na(onset_to_death_eval) && is.null(hosp_death_risk)) {
+    msg <- c(msg, paste(
+      "hosp_death_risk is set to NULL but onset_to_hosp and onset_to_death",
+      "is specified \n set hosp_death_risk to numeric value"
+    ))
   }
-  if (!rlang::is_lgl_na(onset_to_death_eval)) {
-    if (is.null(non_hosp_death_risk)) {
-      msg <- c(msg, paste(
-        "non_hosp_death_risk is set to NULL but onset_to_death is specified \n",
-        "set non_hosp_death_risk to numeric value"
-      ))
-    }
+  if (!rlang::is_lgl_na(onset_to_death_eval) && is.null(non_hosp_death_risk)) {
+    msg <- c(msg, paste(
+      "non_hosp_death_risk is set to NULL but onset_to_death is specified \n",
+      "set non_hosp_death_risk to numeric value"
+    ))
   }
   if (length(msg) > 0) {
     stop(

--- a/R/sim_contacts.R
+++ b/R/sim_contacts.R
@@ -12,7 +12,12 @@
 #' @author Joshua W. Lambert, Carmen Tamayo
 #'
 #' @examples
-#' # load data required to simulate contacts
+#' # quickly simulate contact tracing data using the function defaults
+#' contacts <- sim_contacts()
+#' head(contacts)
+#'
+#' # to simulate more realistic contact tracing data load epiparameters from
+#' # {epiparameter}
 #' contact_distribution <- epiparameter::epidist(
 #'   disease = "COVID-19",
 #'   epi_dist = "contact distribution",

--- a/R/sim_contacts.R
+++ b/R/sim_contacts.R
@@ -32,9 +32,9 @@
 #'   infectious_period = infectious_period,
 #'   prob_infection = 0.5
 #' )
-sim_contacts <- function(contact_distribution,
-                         infectious_period,
-                         prob_infection,
+sim_contacts <- function(contact_distribution = function(x) stats::dpois(x = x, lambda = 2),
+                         infectious_period = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5),
+                         prob_infection = 0.5,
                          outbreak_start_date = as.Date("2023-01-01"),
                          anonymise = FALSE,
                          outbreak_size = c(10, 1e4),

--- a/R/sim_contacts.R
+++ b/R/sim_contacts.R
@@ -32,8 +32,8 @@
 #'   infectious_period = infectious_period,
 #'   prob_infection = 0.5
 #' )
-sim_contacts <- function(contact_distribution = function(x) stats::dpois(x = x, lambda = 2),
-                         infectious_period = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5),
+sim_contacts <- function(contact_distribution = function(x) stats::dpois(x = x, lambda = 2), # nolint line_lenght_linter
+                         infectious_period = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5), # nolint line_lenght_linter
                          prob_infection = 0.5,
                          outbreak_start_date = as.Date("2023-01-01"),
                          anonymise = FALSE,

--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -152,11 +152,11 @@
 #'   hosp_risk = age_dep_hosp_risk
 #' )
 #' head(linelist)
-sim_linelist <- function(contact_distribution = function(x) stats::dpois(x = x, lambda = 2),
+sim_linelist <- function(contact_distribution = function(x) stats::dpois(x = x, lambda = 2), # nolint start line_lenght_linter
                          infectious_period = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5),
                          prob_infection = 0.5,
                          onset_to_hosp = function(x) stats::rlnorm(n = x, meanlog = 1.5, sdlog = 0.5),
-                         onset_to_death = function(x) stats::rlnorm(n = x, meanlog = 2.5, sdlog = 0.5),
+                         onset_to_death = function(x) stats::rlnorm(n = x, meanlog = 2.5, sdlog = 0.5), # nolint end line_lenght_linter
                          onset_to_recovery = NULL,
                          hosp_risk = 0.2,
                          hosp_death_risk = 0.5,

--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -48,8 +48,9 @@
 #' infectious period. Infectious periods must be strictly positive.
 #'
 #' The function can be defined or anonymous. The function must return a vector
-#' of randomly generated real numbers representing sampled infectious periods. The function must
-#' have a single argument, the number of random infectious periods to generate.
+#' of randomly generated real numbers representing sampled infectious periods.
+#' The function must have a single argument, the number of random infectious
+#' periods to generate.
 #'
 #' An `<epidist>` can be provided. This will be converted into random number
 #' generator internally.

--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -239,6 +239,27 @@ sim_linelist <- function(contact_distribution = function(x) stats::dpois(x = x, 
                            confirmed = 0.5
                          ),
                          config = create_config()) {
+  # if hosp_risk or hosp_death_risk is supplied but onset_to_hosp is NULL
+  # set risks to NULL without warning in .cross_check_sim_input()
+  # this needs to happen in the current function frame and not within
+  # .cross_check_sim_input() due to the behaviour of missing()
+  if (is.null(onset_to_hosp)) {
+    if (missing(hosp_risk)) {
+      hosp_risk <- NULL
+    }
+    if (missing(hosp_death_risk)) {
+      hosp_death_risk <- NULL
+    }
+  }
+  if (is.null(onset_to_death)) {
+    if (missing(non_hosp_death_risk)) {
+      non_hosp_death_risk <- NULL
+    }
+    if (missing(hosp_death_risk)) {
+      hosp_death_risk <- NULL
+    }
+  }
+
   # check and convert distribution to func if needed before .check_sim_input()
   funcs <- as_function(
     list(

--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -96,7 +96,12 @@
 #' @author Joshua W. Lambert, Carmen Tamayo
 #'
 #' @examples
-#' # load data required to simulate line list
+#' # quickly simulate a line list using the function defaults
+#' linelist <- sim_linelist()
+#' head(linelist)
+#'
+#' # to simulate a more realistic line list load epiparameters from
+#' # {epiparameter}
 #' contact_distribution <- epiparameter::epidist(
 #'   disease = "COVID-19",
 #'   epi_dist = "contact distribution",

--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -23,11 +23,15 @@
 #' @param contact_distribution A `function` or an `<epidist>` object to generate
 #' the number of contacts per infection.
 #'
-#' The function can be defined or anonymous. The function must return a vector
-#' of `numerics`. The vector is the probability mass of sampling a certain
-#' number of contacts, i.e. the first element in the vector is the weight of
-#' sampling zero contacts, the second element is the weight of sampling a single
-#' contact, etc. The function must have a single argument.
+#' The function can be defined or anonymous. The function must have a single
+#' argument in the form of an `integer` vector with elements representing the
+#' number of contacts, and return a `numeric` vector where each element
+#' corresponds to the probability of observing the number of contacts in the
+#' vector passed to the function. The index of the `numeric` vector returned
+#' is offset by one to the corresponding probability of observing the number
+#' of contacts, i.e. the first element of the output vector is the probability
+#' of observing zero contacts, the second element is the probability of
+#' observing one contact, etc.
 #'
 #' An `<epidist>` can be provided. This will be converted into a probability
 #' mass function internally.

--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -152,11 +152,11 @@
 #'   hosp_risk = age_dep_hosp_risk
 #' )
 #' head(linelist)
-sim_linelist <- function(contact_distribution,
-                         infectious_period,
-                         prob_infection,
-                         onset_to_hosp,
-                         onset_to_death,
+sim_linelist <- function(contact_distribution = function(x) stats::dpois(x = x, lambda = 2),
+                         infectious_period = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5),
+                         prob_infection = 0.5,
+                         onset_to_hosp = function(x) stats::rlnorm(n = x, meanlog = 1.5, sdlog = 0.5),
+                         onset_to_death = function(x) stats::rlnorm(n = x, meanlog = 2.5, sdlog = 0.5),
                          onset_to_recovery = NULL,
                          hosp_risk = 0.2,
                          hosp_death_risk = 0.5,

--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -44,8 +44,8 @@
 #' infectious period. Infectious periods must be strictly positive.
 #'
 #' The function can be defined or anonymous. The function must return a vector
-#' of `numeric`s for the length of the infectious period. The function must
-#' have a single argument.
+#' of randomly generated real numbers representing sampled infectious periods. The function must
+#' have a single argument, the number of random infectious periods to generate.
 #'
 #' An `<epidist>` can be provided. This will be converted into random number
 #' generator internally.

--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -70,6 +70,9 @@
 #' The default is an anonymous function with a lognormal distribution random
 #' number generator ([rlnorm()]) with `meanlog = 1.5` and `sdlog = 0.5`.
 #'
+#' If `onset_to_hosp` is set to `NULL` then `hosp_risk` and `hosp_death_risk`
+#' will be automatically set to `NULL` if not manually specified.
+#'
 #' @param onset_to_death A `function` or an `<epidist>` object for the
 #' onset-to-death delay distribution. `onset_to_death` can also be set to
 #' `NULL` to not simulate dates for individuals that died.
@@ -83,6 +86,10 @@
 #'
 #' The default is an anonymous function with a lognormal distribution random
 #' number generator ([rlnorm()]) with `meanlog = 2.5` and `sdlog = 0.5`.
+#'
+#' If `onset_to_death` is set to `NULL` then `non_hosp_death_risk` and
+#' `hosp_death_risk` will be automatically set to `NULL` if not manually
+#' specified.
 #'
 #' @param onset_to_recovery A `function` or an `<epidist>` object for the
 #' onset-to-recovery delay distribution. `onset_to_recovery` can also be `NULL`
@@ -100,27 +107,30 @@
 #'
 #' @param hosp_risk Either a single `numeric` for the hospitalisation risk of
 #' everyone in the population, or a `<data.frame>` with age specific
-#' hospitalisation risks Default is 20% hospitalisation (`0.2`) for the entire
+#' hospitalisation risks. Default is 20% hospitalisation (`0.2`) for the entire
 #' population. If the `onset_to_hosp` argument is set to `NULL` this argument
-#' should also be set to `NULL`. See details and examples for more information.
+#' will automatically be set to `NULL` if not specified or can be manually
+#' set to `NULL`. See details and examples for more information.
 #'
 #' @param hosp_death_risk Either a single `numeric` for the death risk for
 #' hospitalised individuals across the population, or a `<data.frame>` with age
 #' specific hospitalised death risks Default is 50% death risk in hospitals
 #' (`0.5`) for the entire population. If the `onset_to_death` argument is set
-#' to `NULL` this argument should also be set to `NULL`. See details and
-#' examples for more information. If a time-varying death risk is specified in
-#' the `config` the `hosp_death_risk` is interpreted as the maximum risk across
-#' the epidemic.
+#' to `NULL` this argument will automatically be set to `NULL` if not specified
+#' or can be manually set to `NULL`. See details and examples for more
+#' information. The `hosp_death_risk` can vary through time if specified in
+#' the `time_varying_death_risk` element of `config`, see
+#' `vignette("time-varying-cfr", package = "simulist")` for more information.
 #'
 #' @param non_hosp_death_risk Either a single `numeric` for the death risk for
 #' outside of hospitals across the population, or a `<data.frame>` with age
 #' specific death risks outside of hospitals. Default is 5% death risk outside
 #' of hospitals  (`0.05`) for the entire population. If the `onset_to_death`
-#' argument is set to `NULL` this argument should also be set to `NULL`. See
-#' details and examples for more information. If a time-varying death risk is
-#' specified in the `config` the `non_hosp_death_risk` is interpreted as the
-#' maximum risk across the epidemic.
+#' argument is set to `NULL` this argument will automatically be set to `NULL`
+#' if not specified or can be manually set to `NULL`. See details and examples
+#' for more information. The `non_hosp_death_risk` can vary through time if
+#' specified in the `time_varying_death_risk` element of `config`, see
+#' `vignette("time-varying-cfr", package = "simulist")` for more information.
 #'
 #' @param outbreak_start_date A `date` for the start of the outbreak.
 #'

--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -35,7 +35,7 @@
 #' The default is an anonymous function with a Poisson probability mass function
 #' ([dpois()]) with a mean (\eqn{\lambda}) of 2 contacts per infection.
 #'
-#' @param infectious_period A function or an `<epidist>` object for the
+#' @param infectious_period A `function` or an `<epidist>` object for the
 #' infectious period. This defines the duration from becoming infectious to
 #' no longer infectious. In the simulation, individuals are assumed to
 #' become infectious immediately after being infected (the latency period is
@@ -56,7 +56,7 @@
 #' @param prob_infection A single `numeric` for the probability of a secondary
 #' contact being infected by an infected primary contact.
 #'
-#' @param onset_to_hosp A function or an `<epidist>` object for the
+#' @param onset_to_hosp A `function` or an `<epidist>` object for the
 #' onset-to-hospitalisation delay distribution. `onset_to_hosp` can also be
 #' set to `NULL` to not simulate hospitalisation (admission) dates.
 #'
@@ -70,7 +70,7 @@
 #' The default is an anonymous function with a lognormal distribution random
 #' number generator ([rlnorm()]) with `meanlog = 1.5` and `sdlog = 0.5`.
 #'
-#' @param onset_to_death A function or an `<epidist>` object for the
+#' @param onset_to_death A `function` or an `<epidist>` object for the
 #' onset-to-death delay distribution. `onset_to_death` can also be set to
 #' `NULL` to not simulate dates for individuals that died.
 #'
@@ -84,7 +84,7 @@
 #' The default is an anonymous function with a lognormal distribution random
 #' number generator ([rlnorm()]) with `meanlog = 2.5` and `sdlog = 0.5`.
 #'
-#' @param onset_to_recovery A function or an `<epidist>` object for the
+#' @param onset_to_recovery A `function` or an `<epidist>` object for the
 #' onset-to-recovery delay distribution. `onset_to_recovery` can also be `NULL`
 #' to not simulate dates for individuals that recovered.
 #'

--- a/R/sim_outbreak.R
+++ b/R/sim_outbreak.R
@@ -53,11 +53,11 @@
 #'   onset_to_hosp = onset_to_hosp,
 #'   onset_to_death = onset_to_death
 #' )
-sim_outbreak <- function(contact_distribution,
-                         infectious_period,
-                         prob_infection,
-                         onset_to_hosp,
-                         onset_to_death,
+sim_outbreak <- function(contact_distribution = function(x) stats::dpois(x = x, lambda = 2),
+                         infectious_period = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5),
+                         prob_infection = 0.5,
+                         onset_to_hosp = function(x) stats::rlnorm(n = x, meanlog = 1.5, sdlog = 0.5),
+                         onset_to_death = function(x) stats::rlnorm(n = x, meanlog = 2.5, sdlog = 0.5),
                          onset_to_recovery = NULL,
                          hosp_risk = 0.2,
                          hosp_death_risk = 0.5,

--- a/R/sim_outbreak.R
+++ b/R/sim_outbreak.R
@@ -17,7 +17,13 @@
 #' @author Joshua W. Lambert
 #'
 #' @examples
-#' # load data required to simulate outbreak data
+#' # quickly simulate an outbreak using the function defaults
+#' outbreak <- sim_outbreak()
+#' head(outbreak$linelist)
+#' head(outbreak$contacts)
+#'
+#' # to simulate a more realistic outbreak load epiparameters from
+#' # {epiparameter}
 #' contact_distribution <- epiparameter::epidist(
 #'   disease = "COVID-19",
 #'   epi_dist = "contact distribution",

--- a/R/sim_outbreak.R
+++ b/R/sim_outbreak.R
@@ -53,11 +53,11 @@
 #'   onset_to_hosp = onset_to_hosp,
 #'   onset_to_death = onset_to_death
 #' )
-sim_outbreak <- function(contact_distribution = function(x) stats::dpois(x = x, lambda = 2),
+sim_outbreak <- function(contact_distribution = function(x) stats::dpois(x = x, lambda = 2), # nolint start line_length_linter
                          infectious_period = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5),
                          prob_infection = 0.5,
                          onset_to_hosp = function(x) stats::rlnorm(n = x, meanlog = 1.5, sdlog = 0.5),
-                         onset_to_death = function(x) stats::rlnorm(n = x, meanlog = 2.5, sdlog = 0.5),
+                         onset_to_death = function(x) stats::rlnorm(n = x, meanlog = 2.5, sdlog = 0.5), # nolint end line_length_linter
                          onset_to_recovery = NULL,
                          hosp_risk = 0.2,
                          hosp_death_risk = 0.5,

--- a/R/sim_outbreak.R
+++ b/R/sim_outbreak.R
@@ -1,8 +1,7 @@
 #' Simulate a line list and a contacts table
 #'
 #' @description The line list and contacts are simulated using a branching
-#' process and parameterised with previously published epidemiological
-#' parameters.
+#' process and parameterised with epidemiological parameters.
 #'
 #' @inherit sim_linelist details
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -57,10 +57,21 @@ pak::pak("epiverse-trace/simulist")
 
 ```{r load-simulist}
 library(simulist)
-library(epiparameter)
 ```
 
-The line list simulation requires that we define a contact distribution, period of infectiousness, onset-to-hospitalisation delay, and onset-to-death delay. We can load these from the library of epidemiological parameters in the `{epiparameter}` R package if available, or if these are not in the database yet (such as the contact distribution for COVID-19) we can define them ourselves.
+A line list can be simulated by calling `sim_linelist()`. The function provides sensible defaults to quickly generate a epidemiologically valid data set.
+
+```{r, sim-linelist-defaults}
+set.seed(1)
+linelist <- sim_linelist()
+head(linelist)
+```
+
+However, to simulate a more realistic line list using epidemiological parameters estimated for a infectious disease we can use previously estimated epidemiological parameters. These can be from the `{epiparameter}` R package if available, or if these are not in the `{epiparameter}` database yet (such as the contact distribution for COVID-19) we can define them ourselves. Here we define a contact distribution, period of infectiousness, onset-to-hospitalisation delay, and onset-to-death delay. 
+
+```{r load-epiparameter}
+library(epiparameter)
+```
 
 ```{r create-epidists}
 # create COVID-19 contact distribution

--- a/README.md
+++ b/README.md
@@ -59,15 +59,44 @@ pak::pak("epiverse-trace/simulist")
 
 ``` r
 library(simulist)
-library(epiparameter)
 ```
 
-The line list simulation requires that we define a contact distribution,
-period of infectiousness, onset-to-hospitalisation delay, and
-onset-to-death delay. We can load these from the library of
-epidemiological parameters in the `{epiparameter}` R package if
-available, or if these are not in the database yet (such as the contact
-distribution for COVID-19) we can define them ourselves.
+A line list can be simulated by calling `sim_linelist()`. The function
+provides sensible defaults to quickly generate a epidemiologically valid
+data set.
+
+``` r
+set.seed(1)
+linelist <- sim_linelist()
+head(linelist)
+#>   id        case_name case_type sex age date_onset date_admission   outcome
+#> 1  1   Dylan Quintana confirmed   m  59 2023-01-01           <NA> recovered
+#> 2  2     Briana Owens confirmed   f  90 2023-01-01     2023-01-06      died
+#> 3  3  Elaine Phillips  probable   f   4 2023-01-02     2023-01-08      died
+#> 4  5    Justin Farley  probable   m  29 2023-01-04           <NA> recovered
+#> 5  6 Sadeeda el-Obeid suspected   f  14 2023-01-05           <NA> recovered
+#> 6  7   Mouneek Israel  probable   f  85 2023-01-06           <NA>      died
+#>   date_outcome date_first_contact date_last_contact ct_value
+#> 1         <NA>               <NA>              <NA>     26.3
+#> 2   2023-01-19         2022-12-31        2023-01-05     26.3
+#> 3   2023-01-08         2022-12-30        2023-01-01       NA
+#> 4         <NA>         2023-01-05        2023-01-05       NA
+#> 5         <NA>         2023-01-07        2023-01-08       NA
+#> 6   2023-01-15         2023-01-03        2023-01-06       NA
+```
+
+However, to simulate a more realistic line list using epidemiological
+parameters estimated for a infectious disease we can use previously
+estimated epidemiological parameters. These can be from the
+`{epiparameter}` R package if available, or if these are not in the
+`{epiparameter}` database yet (such as the contact distribution for
+COVID-19) we can define them ourselves. Here we define a contact
+distribution, period of infectiousness, onset-to-hospitalisation delay,
+and onset-to-death delay.
+
+``` r
+library(epiparameter)
+```
 
 ``` r
 # create COVID-19 contact distribution

--- a/README.md
+++ b/README.md
@@ -69,20 +69,20 @@ data set.
 set.seed(1)
 linelist <- sim_linelist()
 head(linelist)
-#>   id        case_name case_type sex age date_onset date_admission   outcome
-#> 1  1   Dylan Quintana confirmed   m  59 2023-01-01           <NA> recovered
-#> 2  2     Briana Owens confirmed   f  90 2023-01-01     2023-01-06      died
-#> 3  3  Elaine Phillips  probable   f   4 2023-01-02     2023-01-08      died
-#> 4  5    Justin Farley  probable   m  29 2023-01-04           <NA> recovered
-#> 5  6 Sadeeda el-Obeid suspected   f  14 2023-01-05           <NA> recovered
-#> 6  7   Mouneek Israel  probable   f  85 2023-01-06           <NA>      died
-#>   date_outcome date_first_contact date_last_contact ct_value
-#> 1         <NA>               <NA>              <NA>     26.3
-#> 2   2023-01-19         2022-12-31        2023-01-05     26.3
-#> 3   2023-01-08         2022-12-30        2023-01-01       NA
-#> 4         <NA>         2023-01-05        2023-01-05       NA
-#> 5         <NA>         2023-01-07        2023-01-08       NA
-#> 6   2023-01-15         2023-01-03        2023-01-06       NA
+#>   id               case_name case_type sex age date_onset date_admission
+#> 1  1    Marquione Currington suspected   m  59 2023-01-01     2023-01-09
+#> 2  2      Ghaaliba el-Hassen  probable   f  90 2023-01-01           <NA>
+#> 3  3 Leslie Morales-Gonzalez  probable   f   4 2023-01-02           <NA>
+#> 4  5        Labeeb el-Hariri confirmed   m  29 2023-01-04           <NA>
+#> 5  6             Carla Moore confirmed   f  14 2023-01-05     2023-01-09
+#> 6  7      Saabiqa al-Hammoud  probable   f  85 2023-01-06     2023-01-08
+#>     outcome date_outcome date_first_contact date_last_contact ct_value
+#> 1      died   2023-01-13               <NA>              <NA>       NA
+#> 2 recovered         <NA>         2022-12-31        2023-01-05       NA
+#> 3 recovered         <NA>         2022-12-30        2023-01-01       NA
+#> 4 recovered         <NA>         2023-01-05        2023-01-05     24.5
+#> 5      died   2023-01-23         2023-01-07        2023-01-08     24.5
+#> 6 recovered         <NA>         2023-01-03        2023-01-06       NA
 ```
 
 However, to simulate a more realistic line list using epidemiological
@@ -185,20 +185,20 @@ linelist <- sim_linelist(
   onset_to_death = onset_to_death
 )
 head(linelist)
-#>   id         case_name case_type sex age date_onset date_admission   outcome
-#> 1  1   Rushdi al-Ishak  probable   m  35 2023-01-01           <NA> recovered
-#> 2  2        Jeffrey Le confirmed   m  43 2023-01-01           <NA> recovered
-#> 3  3 Dominic Barringer suspected   m   1 2023-01-01           <NA> recovered
-#> 4  5      Tyler Kelley  probable   m  78 2023-01-01           <NA> recovered
-#> 5  6     Carolyn Moore confirmed   f  22 2023-01-01           <NA> recovered
-#> 6  8 Cheyenne Sayavong confirmed   f  28 2023-01-01     2023-01-04      died
+#>   id       case_name case_type sex age date_onset date_admission   outcome
+#> 1  1 Wajdi al-Demian  probable   m  35 2023-01-01           <NA> recovered
+#> 2  2   Raaid el-Diab confirmed   m  43 2023-01-01     2023-01-07 recovered
+#> 3  3  Nickolas Nault suspected   m   1 2023-01-01           <NA> recovered
+#> 4  5     Hee Kennedy confirmed   m  78 2023-01-01     2023-01-03      died
+#> 5  6     Hope Arshad suspected   f  22 2023-01-01     2023-01-28      died
+#> 6  8  Shanta Holiday  probable   f  28 2023-01-01           <NA> recovered
 #>   date_outcome date_first_contact date_last_contact ct_value
 #> 1         <NA>               <NA>              <NA>       NA
-#> 2         <NA>         2022-12-30        2023-01-05       24
+#> 2         <NA>         2022-12-30        2023-01-05     24.1
 #> 3         <NA>         2022-12-30        2023-01-02       NA
-#> 4         <NA>         2022-12-29        2023-01-02       NA
-#> 5         <NA>         2023-01-01        2023-01-03       24
-#> 6   2023-01-16         2023-01-03        2023-01-04       24
+#> 4   2023-01-21         2022-12-29        2023-01-02     24.1
+#> 5   2023-01-10         2023-01-01        2023-01-03       NA
+#> 6         <NA>         2023-01-03        2023-01-04       NA
 ```
 
 In this example, the line list is simulated using the default values
@@ -218,20 +218,20 @@ linelist <- sim_linelist(
   outbreak_start_date = as.Date("2019-12-01")
 )
 head(linelist)
-#>   id         case_name case_type sex age date_onset date_admission   outcome
-#> 1  1 Kiersten Matthews confirmed   f  72 2019-12-01           <NA> recovered
-#> 2  2         Omar Cruz confirmed   m  85 2019-12-01           <NA> recovered
-#> 3  3   Emilio Alvarado suspected   m  24 2019-12-01           <NA> recovered
-#> 4  4    Sonya Santiago confirmed   f  67 2019-12-01     2019-12-03 recovered
-#> 5  5   Michelle Brooks  probable   f  37 2019-12-02           <NA> recovered
-#> 6  6  Anastasia Hamlin confirmed   f  14 2019-12-02           <NA> recovered
+#>   id            case_name case_type sex age date_onset date_admission   outcome
+#> 1  1 Kristiana Acheampong confirmed   f  88 2019-12-01           <NA> recovered
+#> 2  3   Jadeeda el-Abdalla confirmed   f   8 2019-12-01           <NA> recovered
+#> 3  4     Dominic Sandoval  probable   m  48 2019-12-01           <NA> recovered
+#> 4  5          Zoe Johnson confirmed   f   3 2019-12-01           <NA> recovered
+#> 5  6        Breann Bruski  probable   f  25 2019-12-01           <NA> recovered
+#> 6  7       Joseph Charley suspected   m  57 2019-12-01           <NA> recovered
 #>   date_outcome date_first_contact date_last_contact ct_value
-#> 1         <NA>               <NA>              <NA>     23.5
-#> 2         <NA>         2019-11-30        2019-12-06     23.5
-#> 3         <NA>         2019-11-30        2019-12-01       NA
-#> 4         <NA>         2019-12-07        2019-12-09     23.5
-#> 5         <NA>         2019-12-01        2019-12-04       NA
-#> 6         <NA>         2019-12-01        2019-12-04     23.5
+#> 1         <NA>               <NA>              <NA>     26.7
+#> 2         <NA>         2019-11-30        2019-12-02     26.7
+#> 3         <NA>         2019-11-30        2019-12-03       NA
+#> 4         <NA>         2019-12-02        2019-12-04     26.7
+#> 5         <NA>         2019-11-28        2019-12-04       NA
+#> 6         <NA>         2019-12-05        2019-12-06       NA
 ```
 
 To simulate a table of contacts of cases (i.e. to reflect a contact
@@ -244,26 +244,21 @@ contacts <- sim_contacts(
   infectious_period = infectious_period, 
   prob_infection = 0.5
 )
-#> Warning: Number of cases exceeds maximum outbreak size. 
-#> Returning data early with 10176 cases and 20217 total contacts (including cases).
-```
-
-``` r
 head(contacts)
-#>             from               to age sex date_first_contact date_last_contact
-#> 1 Brandon Byrnes Mustaba el-Wahba  14   m         2023-01-01        2023-01-03
-#> 2 Brandon Byrnes  Lonnie Williams  33   m         2022-12-31        2023-01-05
-#> 3 Brandon Byrnes     Robert Brown  34   m         2022-12-28        2023-01-02
-#> 4 Brandon Byrnes    Desiree Mabry  76   f         2023-01-03        2023-01-06
-#> 5 Brandon Byrnes Salvador Trevino  73   m         2023-01-05        2023-01-07
-#> 6  Desiree Mabry          Gina Yu  90   f         2023-01-05        2023-01-06
-#>   was_case           status
-#> 1        N   under_followup
-#> 2        N lost_to_followup
-#> 3        N   under_followup
-#> 4        Y             case
-#> 5        N   under_followup
-#> 6        N   under_followup
+#>              from                 to age sex date_first_contact
+#> 1 Munisa el-Kamal      Alicia Topper  76   f         2023-01-05
+#> 2 Munisa el-Kamal     Donald Ramirez  24   m         2023-01-01
+#> 3 Munisa el-Kamal   Brittney Jarmond   7   f         2023-01-05
+#> 4 Munisa el-Kamal Ramalaan el-Saadeh  57   m         2023-01-01
+#> 5   Alicia Topper         Cody Cohen   7   m         2023-01-02
+#> 6   Alicia Topper        Ashley Kohl  48   f         2022-12-31
+#>   date_last_contact was_case         status
+#> 1        2023-01-07        Y           case
+#> 2        2023-01-03        Y           case
+#> 3        2023-01-05        N under_followup
+#> 4        2023-01-04        N        unknown
+#> 5        2023-01-04        Y           case
+#> 6        2023-01-03        Y           case
 ```
 
 If both the line list and contacts table are required, they can be
@@ -281,38 +276,38 @@ outbreak <- sim_outbreak(
   onset_to_death = onset_to_death
 )
 head(outbreak$linelist)
-#>   id        case_name case_type sex age date_onset date_admission   outcome
-#> 1  1 Annnees al-Nazir  probable   m  24 2023-01-01           <NA> recovered
-#> 2  2  Muammar al-Miah  probable   m  46 2023-01-02           <NA> recovered
-#> 3  4     Melina Tarin  probable   f  71 2023-01-02           <NA> recovered
-#> 4  6    Alysh Lovejoy suspected   f  13 2023-01-03           <NA> recovered
-#> 5  9    Dylan Scanlon confirmed   m  28 2023-01-03           <NA> recovered
-#> 6 11  Nikolay Mcinnis suspected   m  15 2023-01-03           <NA> recovered
+#>   id         case_name case_type sex age date_onset date_admission   outcome
+#> 1  1     Okatomi Reish confirmed   f  30 2023-01-01           <NA> recovered
+#> 2  6   Angel Escalante confirmed   m  83 2023-01-01           <NA> recovered
+#> 3  8  Miqdaad el-Turay  probable   m  17 2023-01-01           <NA> recovered
+#> 4  9 Jennifer Gonzalez confirmed   f  74 2023-01-01           <NA>      died
+#> 5 10        Brendan Wu confirmed   m  33 2023-01-01     2023-01-03 recovered
+#> 6 12   Erminio Mandell  probable   m  24 2023-01-01           <NA> recovered
 #>   date_outcome date_first_contact date_last_contact ct_value
-#> 1         <NA>               <NA>              <NA>       NA
-#> 2         <NA>         2023-01-04        2023-01-07       NA
-#> 3         <NA>         2023-01-03        2023-01-05       NA
-#> 4         <NA>         2023-01-04        2023-01-06       NA
-#> 5         <NA>         2023-01-04        2023-01-07     25.6
-#> 6         <NA>         2023-01-05        2023-01-06       NA
+#> 1         <NA>               <NA>              <NA>     23.9
+#> 2         <NA>         2023-01-01        2023-01-05     23.9
+#> 3         <NA>         2022-12-31        2023-01-02       NA
+#> 4   2023-01-21         2023-01-07        2023-01-08     23.9
+#> 5         <NA>         2023-01-01        2023-01-01     23.9
+#> 6         <NA>         2023-01-02        2023-01-05       NA
 ```
 
 ``` r
 head(outbreak$contacts)
-#>               from              to age sex date_first_contact date_last_contact
-#> 1 Annnees al-Nazir Muammar al-Miah  46   m         2023-01-04        2023-01-07
-#> 2 Annnees al-Nazir    Siena Quimby  76   f         2022-12-27        2023-01-02
-#> 3  Muammar al-Miah    Melina Tarin  71   f         2023-01-03        2023-01-05
-#> 4  Muammar al-Miah  Destinee Embry  49   f         2023-01-01        2023-01-04
-#> 5     Melina Tarin   Alysh Lovejoy  13   f         2023-01-04        2023-01-06
-#> 6    Alysh Lovejoy    Andrew Knott  55   m         2023-01-03        2023-01-05
-#>   was_case           status
-#> 1        Y             case
-#> 2        N lost_to_followup
-#> 3        Y             case
-#> 4        N   under_followup
-#> 5        Y             case
-#> 6        N   under_followup
+#>              from                 to age sex date_first_contact
+#> 1   Okatomi Reish         Jesse Lynn  44   f         2023-01-04
+#> 2   Okatomi Reish        Joshua Rose  89   m         2023-01-05
+#> 3   Okatomi Reish   Wadee'a al-Rayes  11   f         2023-01-04
+#> 4   Okatomi Reish  Khaleel al-Hamady  19   m         2022-12-30
+#> 5   Okatomi Reish    Angel Escalante  83   m         2023-01-01
+#> 6 Angel Escalante Burhaan el-Hashemi  87   m         2022-12-29
+#>   date_last_contact was_case           status
+#> 1        2023-01-05        N lost_to_followup
+#> 2        2023-01-05        N          unknown
+#> 3        2023-01-05        N   under_followup
+#> 4        2023-01-03        N   under_followup
+#> 5        2023-01-05        Y             case
+#> 6        2023-01-02        N          unknown
 ```
 
 ## Help

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -42,6 +42,7 @@ epicontacts
 epidict
 epiparameter
 errored
+etc
 facetted
 ggplot
 gh

--- a/man/dot-add_cols.Rd
+++ b/man/dot-add_cols.Rd
@@ -49,7 +49,7 @@ given in the \code{distribution} argument.}
 
 \item{outbreak_start_date}{A \code{date} for the start of the outbreak.}
 
-\item{onset_to_hosp}{A function or an \verb{<epidist>} object for the
+\item{onset_to_hosp}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
 set to \code{NULL} to not simulate hospitalisation (admission) dates.
 
@@ -69,7 +69,7 @@ hospitalisation risks Default is 20\% hospitalisation (\code{0.2}) for the entir
 population. If the \code{onset_to_hosp} argument is set to \code{NULL} this argument
 should also be set to \code{NULL}. See details and examples for more information.}
 
-\item{onset_to_death}{A function or an \verb{<epidist>} object for the
+\item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
 \code{NULL} to not simulate dates for individuals that died.
 
@@ -83,7 +83,7 @@ generator internally.
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.}
 
-\item{onset_to_recovery}{A function or an \verb{<epidist>} object for the
+\item{onset_to_recovery}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
 to not simulate dates for individuals that recovered.
 

--- a/man/dot-add_cols.Rd
+++ b/man/dot-add_cols.Rd
@@ -49,9 +49,19 @@ given in the \code{distribution} argument.}
 
 \item{outbreak_start_date}{A \code{date} for the start of the outbreak.}
 
-\item{onset_to_hosp}{An \verb{<epidist>} object, an anonymous function for
-the onset to hospitalisation delay distribution, or \code{NULL} to not simulate
-hospitalisation (admission) dates.}
+\item{onset_to_hosp}{A function or an \verb{<epidist>} object for the
+onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
+set to \code{NULL} to not simulate hospitalisation (admission) dates.
+
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the onset-to-hospitalisation delay. The
+function must have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.}
 
 \item{hosp_risk}{Either a single \code{numeric} for the hospitalisation risk of
 everyone in the population, or a \verb{<data.frame>} with age specific
@@ -59,14 +69,33 @@ hospitalisation risks Default is 20\% hospitalisation (\code{0.2}) for the entir
 population. If the \code{onset_to_hosp} argument is set to \code{NULL} this argument
 should also be set to \code{NULL}. See details and examples for more information.}
 
-\item{onset_to_death}{An \verb{<epidist>} object, an anonymous function for
-the onset to death delay distribution, or \code{NULL} to not simulate dates for
-individuals that died.}
+\item{onset_to_death}{A function or an \verb{<epidist>} object for the
+onset-to-death delay distribution. \code{onset_to_death} can also be set to
+\code{NULL} to not simulate dates for individuals that died.
 
-\item{onset_to_recovery}{An \verb{<epidist>} object, an anonymous function for
-the onset to death delay distribution, or \code{NULL} to not simulate dates for
-individuals that recovered. Default is \code{NULL} so by default cases that
-recover get an \code{NA} in the \verb{$date_outcome} line list column.}
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the onset-to-death delay. The function must
+have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.}
+
+\item{onset_to_recovery}{A function or an \verb{<epidist>} object for the
+onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
+to not simulate dates for individuals that recovered.
+
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the onset-to-recovery delay. The function
+must have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a random number
+generator internally.
+
+The default is \code{NULL} so by default cases that recover get an \code{NA} in the
+\verb{$date_outcome} line list column.}
 
 \item{hosp_death_risk}{Either a single \code{numeric} for the death risk for
 hospitalised individuals across the population, or a \verb{<data.frame>} with age

--- a/man/dot-add_cols.Rd
+++ b/man/dot-add_cols.Rd
@@ -61,13 +61,17 @@ An \verb{<epidist>} can be provided. This will be converted into a random number
 generator internally.
 
 The default is an anonymous function with a lognormal distribution random
-number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.}
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.
+
+If \code{onset_to_hosp} is set to \code{NULL} then \code{hosp_risk} and \code{hosp_death_risk}
+will be automatically set to \code{NULL} if not manually specified.}
 
 \item{hosp_risk}{Either a single \code{numeric} for the hospitalisation risk of
 everyone in the population, or a \verb{<data.frame>} with age specific
-hospitalisation risks Default is 20\% hospitalisation (\code{0.2}) for the entire
+hospitalisation risks. Default is 20\% hospitalisation (\code{0.2}) for the entire
 population. If the \code{onset_to_hosp} argument is set to \code{NULL} this argument
-should also be set to \code{NULL}. See details and examples for more information.}
+will automatically be set to \code{NULL} if not specified or can be manually
+set to \code{NULL}. See details and examples for more information.}
 
 \item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
@@ -81,7 +85,11 @@ An \verb{<epidist>} can be provided. This will be converted into a random number
 generator internally.
 
 The default is an anonymous function with a lognormal distribution random
-number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.}
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.
+
+If \code{onset_to_death} is set to \code{NULL} then \code{non_hosp_death_risk} and
+\code{hosp_death_risk} will be automatically set to \code{NULL} if not manually
+specified.}
 
 \item{onset_to_recovery}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
@@ -101,19 +109,21 @@ The default is \code{NULL} so by default cases that recover get an \code{NA} in 
 hospitalised individuals across the population, or a \verb{<data.frame>} with age
 specific hospitalised death risks Default is 50\% death risk in hospitals
 (\code{0.5}) for the entire population. If the \code{onset_to_death} argument is set
-to \code{NULL} this argument should also be set to \code{NULL}. See details and
-examples for more information. If a time-varying death risk is specified in
-the \code{config} the \code{hosp_death_risk} is interpreted as the maximum risk across
-the epidemic.}
+to \code{NULL} this argument will automatically be set to \code{NULL} if not specified
+or can be manually set to \code{NULL}. See details and examples for more
+information. The \code{hosp_death_risk} can vary through time if specified in
+the \code{time_varying_death_risk} element of \code{config}, see
+\code{vignette("time-varying-cfr", package = "simulist")} for more information.}
 
 \item{non_hosp_death_risk}{Either a single \code{numeric} for the death risk for
 outside of hospitals across the population, or a \verb{<data.frame>} with age
 specific death risks outside of hospitals. Default is 5\% death risk outside
 of hospitals  (\code{0.05}) for the entire population. If the \code{onset_to_death}
-argument is set to \code{NULL} this argument should also be set to \code{NULL}. See
-details and examples for more information. If a time-varying death risk is
-specified in the \code{config} the \code{non_hosp_death_risk} is interpreted as the
-maximum risk across the epidemic.}
+argument is set to \code{NULL} this argument will automatically be set to \code{NULL}
+if not specified or can be manually set to \code{NULL}. See details and examples
+for more information. The \code{non_hosp_death_risk} can vary through time if
+specified in the \code{time_varying_death_risk} element of \code{config}, see
+\code{vignette("time-varying-cfr", package = "simulist")} for more information.}
 
 \item{config}{A list of settings to adjust the randomly sampled delays and
 Ct values. See \code{\link[=create_config]{create_config()}} for more information.}

--- a/man/dot-check_sim_input.Rd
+++ b/man/dot-check_sim_input.Rd
@@ -88,7 +88,10 @@ An \verb{<epidist>} can be provided. This will be converted into a random number
 generator internally.
 
 The default is an anonymous function with a lognormal distribution random
-number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.}
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.
+
+If \code{onset_to_hosp} is set to \code{NULL} then \code{hosp_risk} and \code{hosp_death_risk}
+will be automatically set to \code{NULL} if not manually specified.}
 
 \item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
@@ -102,7 +105,11 @@ An \verb{<epidist>} can be provided. This will be converted into a random number
 generator internally.
 
 The default is an anonymous function with a lognormal distribution random
-number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.}
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.
+
+If \code{onset_to_death} is set to \code{NULL} then \code{non_hosp_death_risk} and
+\code{hosp_death_risk} will be automatically set to \code{NULL} if not manually
+specified.}
 
 \item{onset_to_recovery}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
@@ -132,27 +139,30 @@ contact tracing status must sum to one.}
 
 \item{hosp_risk}{Either a single \code{numeric} for the hospitalisation risk of
 everyone in the population, or a \verb{<data.frame>} with age specific
-hospitalisation risks Default is 20\% hospitalisation (\code{0.2}) for the entire
+hospitalisation risks. Default is 20\% hospitalisation (\code{0.2}) for the entire
 population. If the \code{onset_to_hosp} argument is set to \code{NULL} this argument
-should also be set to \code{NULL}. See details and examples for more information.}
+will automatically be set to \code{NULL} if not specified or can be manually
+set to \code{NULL}. See details and examples for more information.}
 
 \item{hosp_death_risk}{Either a single \code{numeric} for the death risk for
 hospitalised individuals across the population, or a \verb{<data.frame>} with age
 specific hospitalised death risks Default is 50\% death risk in hospitals
 (\code{0.5}) for the entire population. If the \code{onset_to_death} argument is set
-to \code{NULL} this argument should also be set to \code{NULL}. See details and
-examples for more information. If a time-varying death risk is specified in
-the \code{config} the \code{hosp_death_risk} is interpreted as the maximum risk across
-the epidemic.}
+to \code{NULL} this argument will automatically be set to \code{NULL} if not specified
+or can be manually set to \code{NULL}. See details and examples for more
+information. The \code{hosp_death_risk} can vary through time if specified in
+the \code{time_varying_death_risk} element of \code{config}, see
+\code{vignette("time-varying-cfr", package = "simulist")} for more information.}
 
 \item{non_hosp_death_risk}{Either a single \code{numeric} for the death risk for
 outside of hospitals across the population, or a \verb{<data.frame>} with age
 specific death risks outside of hospitals. Default is 5\% death risk outside
 of hospitals  (\code{0.05}) for the entire population. If the \code{onset_to_death}
-argument is set to \code{NULL} this argument should also be set to \code{NULL}. See
-details and examples for more information. If a time-varying death risk is
-specified in the \code{config} the \code{non_hosp_death_risk} is interpreted as the
-maximum risk across the epidemic.}
+argument is set to \code{NULL} this argument will automatically be set to \code{NULL}
+if not specified or can be manually set to \code{NULL}. See details and examples
+for more information. The \code{non_hosp_death_risk} can vary through time if
+specified in the \code{time_varying_death_risk} element of \code{config}, see
+\code{vignette("time-varying-cfr", package = "simulist")} for more information.}
 
 \item{population_age}{Either a \code{numeric} vector with two elements or a
 \verb{<data.frame>} with age structure in the population. Use a \code{numeric} vector

--- a/man/dot-check_sim_input.Rd
+++ b/man/dot-check_sim_input.Rd
@@ -30,11 +30,15 @@ this function is being called within.}
 \item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
 the number of contacts per infection.
 
-The function can be defined or anonymous. The function must return a vector
-of \code{numerics}. The vector is the probability mass of sampling a certain
-number of contacts, i.e. the first element in the vector is the weight of
-sampling zero contacts, the second element is the weight of sampling a single
-contact, etc. The function must have a single argument.
+The function can be defined or anonymous. The function must have a single
+argument in the form of an \code{integer} vector with elements representing the
+number of contacts, and return a \code{numeric} vector where each element
+corresponds to the probability of observing the number of contacts in the
+vector passed to the function. The index of the \code{numeric} vector returned
+is offset by one to the corresponding probability of observing the number
+of contacts, i.e. the first element of the output vector is the probability
+of observing zero contacts, the second element is the probability of
+observing one contact, etc.
 
 An \verb{<epidist>} can be provided. This will be converted into a probability
 mass function internally.
@@ -51,8 +55,8 @@ their contacts are assumed to be uniformly distributed within the
 infectious period. Infectious periods must be strictly positive.
 
 The function can be defined or anonymous. The function must return a vector
-of \code{numeric}s for the length of the infectious period. The function must
-have a single argument.
+of randomly generated real numbers representing sampled infectious periods. The function must
+have a single argument, the number of random infectious periods to generate.
 
 An \verb{<epidist>} can be provided. This will be converted into random number
 generator internally.

--- a/man/dot-check_sim_input.Rd
+++ b/man/dot-check_sim_input.Rd
@@ -42,7 +42,7 @@ mass function internally.
 The default is an anonymous function with a Poisson probability mass function
 (\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
 
-\item{infectious_period}{A function or an \verb{<epidist>} object for the
+\item{infectious_period}{A \code{function} or an \verb{<epidist>} object for the
 infectious period. This defines the duration from becoming infectious to
 no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
@@ -76,7 +76,7 @@ many iterations (internally) then the function errors, whereas if the
 maximum outbreak size is exceeded the function returns the data early and a
 warning stating how many cases and contacts are returned.}
 
-\item{onset_to_hosp}{A function or an \verb{<epidist>} object for the
+\item{onset_to_hosp}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
 set to \code{NULL} to not simulate hospitalisation (admission) dates.
 
@@ -90,7 +90,7 @@ generator internally.
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.}
 
-\item{onset_to_death}{A function or an \verb{<epidist>} object for the
+\item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
 \code{NULL} to not simulate dates for individuals that died.
 
@@ -104,7 +104,7 @@ generator internally.
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.}
 
-\item{onset_to_recovery}{A function or an \verb{<epidist>} object for the
+\item{onset_to_recovery}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
 to not simulate dates for individuals that recovered.
 

--- a/man/dot-check_sim_input.Rd
+++ b/man/dot-check_sim_input.Rd
@@ -55,8 +55,9 @@ their contacts are assumed to be uniformly distributed within the
 infectious period. Infectious periods must be strictly positive.
 
 The function can be defined or anonymous. The function must return a vector
-of randomly generated real numbers representing sampled infectious periods. The function must
-have a single argument, the number of random infectious periods to generate.
+of randomly generated real numbers representing sampled infectious periods.
+The function must have a single argument, the number of random infectious
+periods to generate.
 
 An \verb{<epidist>} can be provided. This will be converted into random number
 generator internally.

--- a/man/dot-check_sim_input.Rd
+++ b/man/dot-check_sim_input.Rd
@@ -27,18 +27,38 @@
 \item{sim_type}{A \code{character} string specifying which simulation function
 this function is being called within.}
 
-\item{contact_distribution}{An \verb{<epidist>} object or anonymous function for
-the contact distribution. This is any discrete density function that
-produces non-negative integers (including zero, \eqn{\mathbb{N}_0}) for the
-number of contacts per infection.}
+\item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
+the number of contacts per infection.
 
-\item{infectious_period}{An \verb{<epidist>} object or anonymous function for
-the infectious period. This defines the duration from becoming infectious
-to no longer infectious. In the simulation, individuals are assumed to
+The function can be defined or anonymous. The function must return a vector
+of \code{numerics}. The vector is the probability mass of sampling a certain
+number of contacts, i.e. the first element in the vector is the weight of
+sampling zero contacts, the second element is the weight of sampling a single
+contact, etc. The function must have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a probability
+mass function internally.
+
+The default is an anonymous function with a Poisson probability mass function
+(\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
+
+\item{infectious_period}{A function or an \verb{<epidist>} object for the
+infectious period. This defines the duration from becoming infectious to
+no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
 assumed to be zero). The time intervals between an infected individual and
 their contacts are assumed to be uniformly distributed within the
-infectious period. Infectious periods must be strictly positive.}
+infectious period. Infectious periods must be strictly positive.
+
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the infectious period. The function must
+have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \code{sdlog = 0.5}.}
 
 \item{prob_infection}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}
@@ -56,18 +76,47 @@ many iterations (internally) then the function errors, whereas if the
 maximum outbreak size is exceeded the function returns the data early and a
 warning stating how many cases and contacts are returned.}
 
-\item{onset_to_hosp}{An \verb{<epidist>} object, an anonymous function for
-the onset to hospitalisation delay distribution, or \code{NULL} to not simulate
-hospitalisation (admission) dates.}
+\item{onset_to_hosp}{A function or an \verb{<epidist>} object for the
+onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
+set to \code{NULL} to not simulate hospitalisation (admission) dates.
 
-\item{onset_to_death}{An \verb{<epidist>} object, an anonymous function for
-the onset to death delay distribution, or \code{NULL} to not simulate dates for
-individuals that died.}
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the onset-to-hospitalisation delay. The
+function must have a single argument.
 
-\item{onset_to_recovery}{An \verb{<epidist>} object, an anonymous function for
-the onset to death delay distribution, or \code{NULL} to not simulate dates for
-individuals that recovered. Default is \code{NULL} so by default cases that
-recover get an \code{NA} in the \verb{$date_outcome} line list column.}
+An \verb{<epidist>} can be provided. This will be converted into a random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.}
+
+\item{onset_to_death}{A function or an \verb{<epidist>} object for the
+onset-to-death delay distribution. \code{onset_to_death} can also be set to
+\code{NULL} to not simulate dates for individuals that died.
+
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the onset-to-death delay. The function must
+have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.}
+
+\item{onset_to_recovery}{A function or an \verb{<epidist>} object for the
+onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
+to not simulate dates for individuals that recovered.
+
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the onset-to-recovery delay. The function
+must have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a random number
+generator internally.
+
+The default is \code{NULL} so by default cases that recover get an \code{NA} in the
+\verb{$date_outcome} line list column.}
 
 \item{anonymise}{A \code{logical} boolean for whether case names should be
 anonymised. Default is \code{FALSE}.}

--- a/man/dot-cross_check_sim_input.Rd
+++ b/man/dot-cross_check_sim_input.Rd
@@ -26,7 +26,10 @@ An \verb{<epidist>} can be provided. This will be converted into a random number
 generator internally.
 
 The default is an anonymous function with a lognormal distribution random
-number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.}
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.
+
+If \code{onset_to_hosp} is set to \code{NULL} then \code{hosp_risk} and \code{hosp_death_risk}
+will be automatically set to \code{NULL} if not manually specified.}
 
 \item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
@@ -40,31 +43,38 @@ An \verb{<epidist>} can be provided. This will be converted into a random number
 generator internally.
 
 The default is an anonymous function with a lognormal distribution random
-number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.}
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.
+
+If \code{onset_to_death} is set to \code{NULL} then \code{non_hosp_death_risk} and
+\code{hosp_death_risk} will be automatically set to \code{NULL} if not manually
+specified.}
 
 \item{hosp_risk}{Either a single \code{numeric} for the hospitalisation risk of
 everyone in the population, or a \verb{<data.frame>} with age specific
-hospitalisation risks Default is 20\% hospitalisation (\code{0.2}) for the entire
+hospitalisation risks. Default is 20\% hospitalisation (\code{0.2}) for the entire
 population. If the \code{onset_to_hosp} argument is set to \code{NULL} this argument
-should also be set to \code{NULL}. See details and examples for more information.}
+will automatically be set to \code{NULL} if not specified or can be manually
+set to \code{NULL}. See details and examples for more information.}
 
 \item{hosp_death_risk}{Either a single \code{numeric} for the death risk for
 hospitalised individuals across the population, or a \verb{<data.frame>} with age
 specific hospitalised death risks Default is 50\% death risk in hospitals
 (\code{0.5}) for the entire population. If the \code{onset_to_death} argument is set
-to \code{NULL} this argument should also be set to \code{NULL}. See details and
-examples for more information. If a time-varying death risk is specified in
-the \code{config} the \code{hosp_death_risk} is interpreted as the maximum risk across
-the epidemic.}
+to \code{NULL} this argument will automatically be set to \code{NULL} if not specified
+or can be manually set to \code{NULL}. See details and examples for more
+information. The \code{hosp_death_risk} can vary through time if specified in
+the \code{time_varying_death_risk} element of \code{config}, see
+\code{vignette("time-varying-cfr", package = "simulist")} for more information.}
 
 \item{non_hosp_death_risk}{Either a single \code{numeric} for the death risk for
 outside of hospitals across the population, or a \verb{<data.frame>} with age
 specific death risks outside of hospitals. Default is 5\% death risk outside
 of hospitals  (\code{0.05}) for the entire population. If the \code{onset_to_death}
-argument is set to \code{NULL} this argument should also be set to \code{NULL}. See
-details and examples for more information. If a time-varying death risk is
-specified in the \code{config} the \code{non_hosp_death_risk} is interpreted as the
-maximum risk across the epidemic.}
+argument is set to \code{NULL} this argument will automatically be set to \code{NULL}
+if not specified or can be manually set to \code{NULL}. See details and examples
+for more information. The \code{non_hosp_death_risk} can vary through time if
+specified in the \code{time_varying_death_risk} element of \code{config}, see
+\code{vignette("time-varying-cfr", package = "simulist")} for more information.}
 }
 \value{
 Invisibly return the \code{onset_to_hosp} argument. The function is

--- a/man/dot-cross_check_sim_input.Rd
+++ b/man/dot-cross_check_sim_input.Rd
@@ -14,7 +14,7 @@ compatible with hospitalisation and death risks}
 )
 }
 \arguments{
-\item{onset_to_hosp}{A function or an \verb{<epidist>} object for the
+\item{onset_to_hosp}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
 set to \code{NULL} to not simulate hospitalisation (admission) dates.
 
@@ -28,7 +28,7 @@ generator internally.
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.}
 
-\item{onset_to_death}{A function or an \verb{<epidist>} object for the
+\item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
 \code{NULL} to not simulate dates for individuals that died.
 

--- a/man/dot-cross_check_sim_input.Rd
+++ b/man/dot-cross_check_sim_input.Rd
@@ -14,13 +14,33 @@ compatible with hospitalisation and death risks}
 )
 }
 \arguments{
-\item{onset_to_hosp}{An \verb{<epidist>} object, an anonymous function for
-the onset to hospitalisation delay distribution, or \code{NULL} to not simulate
-hospitalisation (admission) dates.}
+\item{onset_to_hosp}{A function or an \verb{<epidist>} object for the
+onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
+set to \code{NULL} to not simulate hospitalisation (admission) dates.
 
-\item{onset_to_death}{An \verb{<epidist>} object, an anonymous function for
-the onset to death delay distribution, or \code{NULL} to not simulate dates for
-individuals that died.}
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the onset-to-hospitalisation delay. The
+function must have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.}
+
+\item{onset_to_death}{A function or an \verb{<epidist>} object for the
+onset-to-death delay distribution. \code{onset_to_death} can also be set to
+\code{NULL} to not simulate dates for individuals that died.
+
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the onset-to-death delay. The function must
+have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.}
 
 \item{hosp_risk}{Either a single \code{numeric} for the hospitalisation risk of
 everyone in the population, or a \verb{<data.frame>} with age specific

--- a/man/dot-sim_internal.Rd
+++ b/man/dot-sim_internal.Rd
@@ -77,7 +77,10 @@ An \verb{<epidist>} can be provided. This will be converted into a random number
 generator internally.
 
 The default is an anonymous function with a lognormal distribution random
-number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.}
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.
+
+If \code{onset_to_hosp} is set to \code{NULL} then \code{hosp_risk} and \code{hosp_death_risk}
+will be automatically set to \code{NULL} if not manually specified.}
 
 \item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
@@ -91,7 +94,11 @@ An \verb{<epidist>} can be provided. This will be converted into a random number
 generator internally.
 
 The default is an anonymous function with a lognormal distribution random
-number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.}
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.
+
+If \code{onset_to_death} is set to \code{NULL} then \code{non_hosp_death_risk} and
+\code{hosp_death_risk} will be automatically set to \code{NULL} if not manually
+specified.}
 
 \item{onset_to_recovery}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
@@ -109,27 +116,30 @@ The default is \code{NULL} so by default cases that recover get an \code{NA} in 
 
 \item{hosp_risk}{Either a single \code{numeric} for the hospitalisation risk of
 everyone in the population, or a \verb{<data.frame>} with age specific
-hospitalisation risks Default is 20\% hospitalisation (\code{0.2}) for the entire
+hospitalisation risks. Default is 20\% hospitalisation (\code{0.2}) for the entire
 population. If the \code{onset_to_hosp} argument is set to \code{NULL} this argument
-should also be set to \code{NULL}. See details and examples for more information.}
+will automatically be set to \code{NULL} if not specified or can be manually
+set to \code{NULL}. See details and examples for more information.}
 
 \item{hosp_death_risk}{Either a single \code{numeric} for the death risk for
 hospitalised individuals across the population, or a \verb{<data.frame>} with age
 specific hospitalised death risks Default is 50\% death risk in hospitals
 (\code{0.5}) for the entire population. If the \code{onset_to_death} argument is set
-to \code{NULL} this argument should also be set to \code{NULL}. See details and
-examples for more information. If a time-varying death risk is specified in
-the \code{config} the \code{hosp_death_risk} is interpreted as the maximum risk across
-the epidemic.}
+to \code{NULL} this argument will automatically be set to \code{NULL} if not specified
+or can be manually set to \code{NULL}. See details and examples for more
+information. The \code{hosp_death_risk} can vary through time if specified in
+the \code{time_varying_death_risk} element of \code{config}, see
+\code{vignette("time-varying-cfr", package = "simulist")} for more information.}
 
 \item{non_hosp_death_risk}{Either a single \code{numeric} for the death risk for
 outside of hospitals across the population, or a \verb{<data.frame>} with age
 specific death risks outside of hospitals. Default is 5\% death risk outside
 of hospitals  (\code{0.05}) for the entire population. If the \code{onset_to_death}
-argument is set to \code{NULL} this argument should also be set to \code{NULL}. See
-details and examples for more information. If a time-varying death risk is
-specified in the \code{config} the \code{non_hosp_death_risk} is interpreted as the
-maximum risk across the epidemic.}
+argument is set to \code{NULL} this argument will automatically be set to \code{NULL}
+if not specified or can be manually set to \code{NULL}. See details and examples
+for more information. The \code{non_hosp_death_risk} can vary through time if
+specified in the \code{time_varying_death_risk} element of \code{config}, see
+\code{vignette("time-varying-cfr", package = "simulist")} for more information.}
 
 \item{outbreak_start_date}{A \code{date} for the start of the outbreak.}
 

--- a/man/dot-sim_internal.Rd
+++ b/man/dot-sim_internal.Rd
@@ -29,34 +29,83 @@ within \pkg{simulist}}
 \item{sim_type}{A \code{character} string specifying which simulation function
 this function is being called within.}
 
-\item{contact_distribution}{An \verb{<epidist>} object or anonymous function for
-the contact distribution. This is any discrete density function that
-produces non-negative integers (including zero, \eqn{\mathbb{N}_0}) for the
-number of contacts per infection.}
+\item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
+the number of contacts per infection.
 
-\item{infectious_period}{An \verb{<epidist>} object or anonymous function for
-the infectious period. This defines the duration from becoming infectious
-to no longer infectious. In the simulation, individuals are assumed to
+The function can be defined or anonymous. The function must return a vector
+of \code{numerics}. The vector is the probability mass of sampling a certain
+number of contacts, i.e. the first element in the vector is the weight of
+sampling zero contacts, the second element is the weight of sampling a single
+contact, etc. The function must have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a probability
+mass function internally.
+
+The default is an anonymous function with a Poisson probability mass function
+(\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
+
+\item{infectious_period}{A function or an \verb{<epidist>} object for the
+infectious period. This defines the duration from becoming infectious to
+no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
 assumed to be zero). The time intervals between an infected individual and
 their contacts are assumed to be uniformly distributed within the
-infectious period. Infectious periods must be strictly positive.}
+infectious period. Infectious periods must be strictly positive.
+
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the infectious period. The function must
+have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \code{sdlog = 0.5}.}
 
 \item{prob_infection}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}
 
-\item{onset_to_hosp}{An \verb{<epidist>} object, an anonymous function for
-the onset to hospitalisation delay distribution, or \code{NULL} to not simulate
-hospitalisation (admission) dates.}
+\item{onset_to_hosp}{A function or an \verb{<epidist>} object for the
+onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
+set to \code{NULL} to not simulate hospitalisation (admission) dates.
 
-\item{onset_to_death}{An \verb{<epidist>} object, an anonymous function for
-the onset to death delay distribution, or \code{NULL} to not simulate dates for
-individuals that died.}
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the onset-to-hospitalisation delay. The
+function must have a single argument.
 
-\item{onset_to_recovery}{An \verb{<epidist>} object, an anonymous function for
-the onset to death delay distribution, or \code{NULL} to not simulate dates for
-individuals that recovered. Default is \code{NULL} so by default cases that
-recover get an \code{NA} in the \verb{$date_outcome} line list column.}
+An \verb{<epidist>} can be provided. This will be converted into a random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.}
+
+\item{onset_to_death}{A function or an \verb{<epidist>} object for the
+onset-to-death delay distribution. \code{onset_to_death} can also be set to
+\code{NULL} to not simulate dates for individuals that died.
+
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the onset-to-death delay. The function must
+have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.}
+
+\item{onset_to_recovery}{A function or an \verb{<epidist>} object for the
+onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
+to not simulate dates for individuals that recovered.
+
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the onset-to-recovery delay. The function
+must have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a random number
+generator internally.
+
+The default is \code{NULL} so by default cases that recover get an \code{NA} in the
+\verb{$date_outcome} line list column.}
 
 \item{hosp_risk}{Either a single \code{numeric} for the hospitalisation risk of
 everyone in the population, or a \verb{<data.frame>} with age specific

--- a/man/dot-sim_internal.Rd
+++ b/man/dot-sim_internal.Rd
@@ -57,8 +57,9 @@ their contacts are assumed to be uniformly distributed within the
 infectious period. Infectious periods must be strictly positive.
 
 The function can be defined or anonymous. The function must return a vector
-of randomly generated real numbers representing sampled infectious periods. The function must
-have a single argument, the number of random infectious periods to generate.
+of randomly generated real numbers representing sampled infectious periods.
+The function must have a single argument, the number of random infectious
+periods to generate.
 
 An \verb{<epidist>} can be provided. This will be converted into random number
 generator internally.

--- a/man/dot-sim_internal.Rd
+++ b/man/dot-sim_internal.Rd
@@ -32,11 +32,15 @@ this function is being called within.}
 \item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
 the number of contacts per infection.
 
-The function can be defined or anonymous. The function must return a vector
-of \code{numerics}. The vector is the probability mass of sampling a certain
-number of contacts, i.e. the first element in the vector is the weight of
-sampling zero contacts, the second element is the weight of sampling a single
-contact, etc. The function must have a single argument.
+The function can be defined or anonymous. The function must have a single
+argument in the form of an \code{integer} vector with elements representing the
+number of contacts, and return a \code{numeric} vector where each element
+corresponds to the probability of observing the number of contacts in the
+vector passed to the function. The index of the \code{numeric} vector returned
+is offset by one to the corresponding probability of observing the number
+of contacts, i.e. the first element of the output vector is the probability
+of observing zero contacts, the second element is the probability of
+observing one contact, etc.
 
 An \verb{<epidist>} can be provided. This will be converted into a probability
 mass function internally.
@@ -53,8 +57,8 @@ their contacts are assumed to be uniformly distributed within the
 infectious period. Infectious periods must be strictly positive.
 
 The function can be defined or anonymous. The function must return a vector
-of \code{numeric}s for the length of the infectious period. The function must
-have a single argument.
+of randomly generated real numbers representing sampled infectious periods. The function must
+have a single argument, the number of random infectious periods to generate.
 
 An \verb{<epidist>} can be provided. This will be converted into random number
 generator internally.

--- a/man/dot-sim_internal.Rd
+++ b/man/dot-sim_internal.Rd
@@ -44,7 +44,7 @@ mass function internally.
 The default is an anonymous function with a Poisson probability mass function
 (\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
 
-\item{infectious_period}{A function or an \verb{<epidist>} object for the
+\item{infectious_period}{A \code{function} or an \verb{<epidist>} object for the
 infectious period. This defines the duration from becoming infectious to
 no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
@@ -65,7 +65,7 @@ number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \
 \item{prob_infection}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}
 
-\item{onset_to_hosp}{A function or an \verb{<epidist>} object for the
+\item{onset_to_hosp}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
 set to \code{NULL} to not simulate hospitalisation (admission) dates.
 
@@ -79,7 +79,7 @@ generator internally.
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.}
 
-\item{onset_to_death}{A function or an \verb{<epidist>} object for the
+\item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
 \code{NULL} to not simulate dates for individuals that died.
 
@@ -93,7 +93,7 @@ generator internally.
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.}
 
-\item{onset_to_recovery}{A function or an \verb{<epidist>} object for the
+\item{onset_to_recovery}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
 to not simulate dates for individuals that recovered.
 

--- a/man/dot-sim_network_bp.Rd
+++ b/man/dot-sim_network_bp.Rd
@@ -42,8 +42,9 @@ their contacts are assumed to be uniformly distributed within the
 infectious period. Infectious periods must be strictly positive.
 
 The function can be defined or anonymous. The function must return a vector
-of randomly generated real numbers representing sampled infectious periods. The function must
-have a single argument, the number of random infectious periods to generate.
+of randomly generated real numbers representing sampled infectious periods.
+The function must have a single argument, the number of random infectious
+periods to generate.
 
 An \verb{<epidist>} can be provided. This will be converted into random number
 generator internally.

--- a/man/dot-sim_network_bp.Rd
+++ b/man/dot-sim_network_bp.Rd
@@ -14,18 +14,38 @@ infection for each contact}
 )
 }
 \arguments{
-\item{contact_distribution}{An \verb{<epidist>} object or anonymous function for
-the contact distribution. This is any discrete density function that
-produces non-negative integers (including zero, \eqn{\mathbb{N}_0}) for the
-number of contacts per infection.}
+\item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
+the number of contacts per infection.
 
-\item{infectious_period}{An \verb{<epidist>} object or anonymous function for
-the infectious period. This defines the duration from becoming infectious
-to no longer infectious. In the simulation, individuals are assumed to
+The function can be defined or anonymous. The function must return a vector
+of \code{numerics}. The vector is the probability mass of sampling a certain
+number of contacts, i.e. the first element in the vector is the weight of
+sampling zero contacts, the second element is the weight of sampling a single
+contact, etc. The function must have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a probability
+mass function internally.
+
+The default is an anonymous function with a Poisson probability mass function
+(\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
+
+\item{infectious_period}{A function or an \verb{<epidist>} object for the
+infectious period. This defines the duration from becoming infectious to
+no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
 assumed to be zero). The time intervals between an infected individual and
 their contacts are assumed to be uniformly distributed within the
-infectious period. Infectious periods must be strictly positive.}
+infectious period. Infectious periods must be strictly positive.
+
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the infectious period. The function must
+have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \code{sdlog = 0.5}.}
 
 \item{prob_infection}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}

--- a/man/dot-sim_network_bp.Rd
+++ b/man/dot-sim_network_bp.Rd
@@ -17,11 +17,15 @@ infection for each contact}
 \item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
 the number of contacts per infection.
 
-The function can be defined or anonymous. The function must return a vector
-of \code{numerics}. The vector is the probability mass of sampling a certain
-number of contacts, i.e. the first element in the vector is the weight of
-sampling zero contacts, the second element is the weight of sampling a single
-contact, etc. The function must have a single argument.
+The function can be defined or anonymous. The function must have a single
+argument in the form of an \code{integer} vector with elements representing the
+number of contacts, and return a \code{numeric} vector where each element
+corresponds to the probability of observing the number of contacts in the
+vector passed to the function. The index of the \code{numeric} vector returned
+is offset by one to the corresponding probability of observing the number
+of contacts, i.e. the first element of the output vector is the probability
+of observing zero contacts, the second element is the probability of
+observing one contact, etc.
 
 An \verb{<epidist>} can be provided. This will be converted into a probability
 mass function internally.
@@ -38,8 +42,8 @@ their contacts are assumed to be uniformly distributed within the
 infectious period. Infectious periods must be strictly positive.
 
 The function can be defined or anonymous. The function must return a vector
-of \code{numeric}s for the length of the infectious period. The function must
-have a single argument.
+of randomly generated real numbers representing sampled infectious periods. The function must
+have a single argument, the number of random infectious periods to generate.
 
 An \verb{<epidist>} can be provided. This will be converted into random number
 generator internally.

--- a/man/dot-sim_network_bp.Rd
+++ b/man/dot-sim_network_bp.Rd
@@ -29,7 +29,7 @@ mass function internally.
 The default is an anonymous function with a Poisson probability mass function
 (\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
 
-\item{infectious_period}{A function or an \verb{<epidist>} object for the
+\item{infectious_period}{A \code{function} or an \verb{<epidist>} object for the
 infectious period. This defines the duration from becoming infectious to
 no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is

--- a/man/sim_contacts.Rd
+++ b/man/sim_contacts.Rd
@@ -33,7 +33,7 @@ mass function internally.
 The default is an anonymous function with a Poisson probability mass function
 (\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
 
-\item{infectious_period}{A function or an \verb{<epidist>} object for the
+\item{infectious_period}{A \code{function} or an \verb{<epidist>} object for the
 infectious period. This defines the duration from becoming infectious to
 no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is

--- a/man/sim_contacts.Rd
+++ b/man/sim_contacts.Rd
@@ -21,11 +21,15 @@ sim_contacts(
 \item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
 the number of contacts per infection.
 
-The function can be defined or anonymous. The function must return a vector
-of \code{numerics}. The vector is the probability mass of sampling a certain
-number of contacts, i.e. the first element in the vector is the weight of
-sampling zero contacts, the second element is the weight of sampling a single
-contact, etc. The function must have a single argument.
+The function can be defined or anonymous. The function must have a single
+argument in the form of an \code{integer} vector with elements representing the
+number of contacts, and return a \code{numeric} vector where each element
+corresponds to the probability of observing the number of contacts in the
+vector passed to the function. The index of the \code{numeric} vector returned
+is offset by one to the corresponding probability of observing the number
+of contacts, i.e. the first element of the output vector is the probability
+of observing zero contacts, the second element is the probability of
+observing one contact, etc.
 
 An \verb{<epidist>} can be provided. This will be converted into a probability
 mass function internally.
@@ -42,8 +46,8 @@ their contacts are assumed to be uniformly distributed within the
 infectious period. Infectious periods must be strictly positive.
 
 The function can be defined or anonymous. The function must return a vector
-of \code{numeric}s for the length of the infectious period. The function must
-have a single argument.
+of randomly generated real numbers representing sampled infectious periods. The function must
+have a single argument, the number of random infectious periods to generate.
 
 An \verb{<epidist>} can be provided. This will be converted into random number
 generator internally.

--- a/man/sim_contacts.Rd
+++ b/man/sim_contacts.Rd
@@ -18,18 +18,38 @@ sim_contacts(
 )
 }
 \arguments{
-\item{contact_distribution}{An \verb{<epidist>} object or anonymous function for
-the contact distribution. This is any discrete density function that
-produces non-negative integers (including zero, \eqn{\mathbb{N}_0}) for the
-number of contacts per infection.}
+\item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
+the number of contacts per infection.
 
-\item{infectious_period}{An \verb{<epidist>} object or anonymous function for
-the infectious period. This defines the duration from becoming infectious
-to no longer infectious. In the simulation, individuals are assumed to
+The function can be defined or anonymous. The function must return a vector
+of \code{numerics}. The vector is the probability mass of sampling a certain
+number of contacts, i.e. the first element in the vector is the weight of
+sampling zero contacts, the second element is the weight of sampling a single
+contact, etc. The function must have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a probability
+mass function internally.
+
+The default is an anonymous function with a Poisson probability mass function
+(\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
+
+\item{infectious_period}{A function or an \verb{<epidist>} object for the
+infectious period. This defines the duration from becoming infectious to
+no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
 assumed to be zero). The time intervals between an infected individual and
 their contacts are assumed to be uniformly distributed within the
-infectious period. Infectious periods must be strictly positive.}
+infectious period. Infectious periods must be strictly positive.
+
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the infectious period. The function must
+have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \code{sdlog = 0.5}.}
 
 \item{prob_infection}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}

--- a/man/sim_contacts.Rd
+++ b/man/sim_contacts.Rd
@@ -5,9 +5,9 @@
 \title{Simulate contacts for an infectious disease outbreak}
 \usage{
 sim_contacts(
-  contact_distribution,
-  infectious_period,
-  prob_infection,
+  contact_distribution = function(x) stats::dpois(x = x, lambda = 2),
+  infectious_period = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5),
+  prob_infection = 0.5,
   outbreak_start_date = as.Date("2023-01-01"),
   anonymise = FALSE,
   outbreak_size = c(10, 10000),
@@ -73,7 +73,12 @@ A contacts \verb{<data.frame>}
 Simulate contacts for an infectious disease outbreak
 }
 \examples{
-# load data required to simulate contacts
+# quickly simulate contact tracing data using the function defaults
+contacts <- sim_contacts()
+head(contacts)
+
+# to simulate more realistic contact tracing data load epiparameters from
+# {epiparameter}
 contact_distribution <- epiparameter::epidist(
   disease = "COVID-19",
   epi_dist = "contact distribution",

--- a/man/sim_contacts.Rd
+++ b/man/sim_contacts.Rd
@@ -46,8 +46,9 @@ their contacts are assumed to be uniformly distributed within the
 infectious period. Infectious periods must be strictly positive.
 
 The function can be defined or anonymous. The function must return a vector
-of randomly generated real numbers representing sampled infectious periods. The function must
-have a single argument, the number of random infectious periods to generate.
+of randomly generated real numbers representing sampled infectious periods.
+The function must have a single argument, the number of random infectious
+periods to generate.
 
 An \verb{<epidist>} can be provided. This will be converted into random number
 generator internally.

--- a/man/sim_linelist.Rd
+++ b/man/sim_linelist.Rd
@@ -38,7 +38,7 @@ mass function internally.
 The default is an anonymous function with a Poisson probability mass function
 (\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
 
-\item{infectious_period}{A function or an \verb{<epidist>} object for the
+\item{infectious_period}{A \code{function} or an \verb{<epidist>} object for the
 infectious period. This defines the duration from becoming infectious to
 no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
@@ -59,7 +59,7 @@ number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \
 \item{prob_infection}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}
 
-\item{onset_to_hosp}{A function or an \verb{<epidist>} object for the
+\item{onset_to_hosp}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
 set to \code{NULL} to not simulate hospitalisation (admission) dates.
 
@@ -73,7 +73,7 @@ generator internally.
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.}
 
-\item{onset_to_death}{A function or an \verb{<epidist>} object for the
+\item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
 \code{NULL} to not simulate dates for individuals that died.
 
@@ -87,7 +87,7 @@ generator internally.
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.}
 
-\item{onset_to_recovery}{A function or an \verb{<epidist>} object for the
+\item{onset_to_recovery}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
 to not simulate dates for individuals that recovered.
 

--- a/man/sim_linelist.Rd
+++ b/man/sim_linelist.Rd
@@ -26,11 +26,15 @@ sim_linelist(
 \item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
 the number of contacts per infection.
 
-The function can be defined or anonymous. The function must return a vector
-of \code{numerics}. The vector is the probability mass of sampling a certain
-number of contacts, i.e. the first element in the vector is the weight of
-sampling zero contacts, the second element is the weight of sampling a single
-contact, etc. The function must have a single argument.
+The function can be defined or anonymous. The function must have a single
+argument in the form of an \code{integer} vector with elements representing the
+number of contacts, and return a \code{numeric} vector where each element
+corresponds to the probability of observing the number of contacts in the
+vector passed to the function. The index of the \code{numeric} vector returned
+is offset by one to the corresponding probability of observing the number
+of contacts, i.e. the first element of the output vector is the probability
+of observing zero contacts, the second element is the probability of
+observing one contact, etc.
 
 An \verb{<epidist>} can be provided. This will be converted into a probability
 mass function internally.
@@ -47,8 +51,8 @@ their contacts are assumed to be uniformly distributed within the
 infectious period. Infectious periods must be strictly positive.
 
 The function can be defined or anonymous. The function must return a vector
-of \code{numeric}s for the length of the infectious period. The function must
-have a single argument.
+of randomly generated real numbers representing sampled infectious periods. The function must
+have a single argument, the number of random infectious periods to generate.
 
 An \verb{<epidist>} can be provided. This will be converted into random number
 generator internally.

--- a/man/sim_linelist.Rd
+++ b/man/sim_linelist.Rd
@@ -51,8 +51,9 @@ their contacts are assumed to be uniformly distributed within the
 infectious period. Infectious periods must be strictly positive.
 
 The function can be defined or anonymous. The function must return a vector
-of randomly generated real numbers representing sampled infectious periods. The function must
-have a single argument, the number of random infectious periods to generate.
+of randomly generated real numbers representing sampled infectious periods.
+The function must have a single argument, the number of random infectious
+periods to generate.
 
 An \verb{<epidist>} can be provided. This will be converted into random number
 generator internally.

--- a/man/sim_linelist.Rd
+++ b/man/sim_linelist.Rd
@@ -5,11 +5,11 @@
 \title{Simulate a line list}
 \usage{
 sim_linelist(
-  contact_distribution,
-  infectious_period,
-  prob_infection,
-  onset_to_hosp,
-  onset_to_death,
+  contact_distribution = function(x) stats::dpois(x = x, lambda = 2),
+  infectious_period = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5),
+  prob_infection = 0.5,
+  onset_to_hosp = function(x) stats::rlnorm(n = x, meanlog = 1.5, sdlog = 0.5),
+  onset_to_death = function(x) stats::rlnorm(n = x, meanlog = 2.5, sdlog = 0.5),
   onset_to_recovery = NULL,
   hosp_risk = 0.2,
   hosp_death_risk = 0.5,
@@ -137,7 +137,12 @@ that age group. Proportions must sum to one.
 }
 }
 \examples{
-# load data required to simulate line list
+# quickly simulate a line list using the function defaults
+linelist <- sim_linelist()
+head(linelist)
+
+# to simulate a more realistic line list load epiparameters from
+# {epiparameter}
 contact_distribution <- epiparameter::epidist(
   disease = "COVID-19",
   epi_dist = "contact distribution",

--- a/man/sim_linelist.Rd
+++ b/man/sim_linelist.Rd
@@ -23,34 +23,83 @@ sim_linelist(
 )
 }
 \arguments{
-\item{contact_distribution}{An \verb{<epidist>} object or anonymous function for
-the contact distribution. This is any discrete density function that
-produces non-negative integers (including zero, \eqn{\mathbb{N}_0}) for the
-number of contacts per infection.}
+\item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
+the number of contacts per infection.
 
-\item{infectious_period}{An \verb{<epidist>} object or anonymous function for
-the infectious period. This defines the duration from becoming infectious
-to no longer infectious. In the simulation, individuals are assumed to
+The function can be defined or anonymous. The function must return a vector
+of \code{numerics}. The vector is the probability mass of sampling a certain
+number of contacts, i.e. the first element in the vector is the weight of
+sampling zero contacts, the second element is the weight of sampling a single
+contact, etc. The function must have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a probability
+mass function internally.
+
+The default is an anonymous function with a Poisson probability mass function
+(\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
+
+\item{infectious_period}{A function or an \verb{<epidist>} object for the
+infectious period. This defines the duration from becoming infectious to
+no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
 assumed to be zero). The time intervals between an infected individual and
 their contacts are assumed to be uniformly distributed within the
-infectious period. Infectious periods must be strictly positive.}
+infectious period. Infectious periods must be strictly positive.
+
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the infectious period. The function must
+have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \code{sdlog = 0.5}.}
 
 \item{prob_infection}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}
 
-\item{onset_to_hosp}{An \verb{<epidist>} object, an anonymous function for
-the onset to hospitalisation delay distribution, or \code{NULL} to not simulate
-hospitalisation (admission) dates.}
+\item{onset_to_hosp}{A function or an \verb{<epidist>} object for the
+onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
+set to \code{NULL} to not simulate hospitalisation (admission) dates.
 
-\item{onset_to_death}{An \verb{<epidist>} object, an anonymous function for
-the onset to death delay distribution, or \code{NULL} to not simulate dates for
-individuals that died.}
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the onset-to-hospitalisation delay. The
+function must have a single argument.
 
-\item{onset_to_recovery}{An \verb{<epidist>} object, an anonymous function for
-the onset to death delay distribution, or \code{NULL} to not simulate dates for
-individuals that recovered. Default is \code{NULL} so by default cases that
-recover get an \code{NA} in the \verb{$date_outcome} line list column.}
+An \verb{<epidist>} can be provided. This will be converted into a random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.}
+
+\item{onset_to_death}{A function or an \verb{<epidist>} object for the
+onset-to-death delay distribution. \code{onset_to_death} can also be set to
+\code{NULL} to not simulate dates for individuals that died.
+
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the onset-to-death delay. The function must
+have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.}
+
+\item{onset_to_recovery}{A function or an \verb{<epidist>} object for the
+onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
+to not simulate dates for individuals that recovered.
+
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the onset-to-recovery delay. The function
+must have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a random number
+generator internally.
+
+The default is \code{NULL} so by default cases that recover get an \code{NA} in the
+\verb{$date_outcome} line list column.}
 
 \item{hosp_risk}{Either a single \code{numeric} for the hospitalisation risk of
 everyone in the population, or a \verb{<data.frame>} with age specific
@@ -112,7 +161,7 @@ A line list \verb{<data.frame>}
 }
 \description{
 The line list is simulated using a branching process and
-parameterised with user defined epidemiological parameters.
+parameterised with epidemiological parameters.
 }
 \details{
 For age-stratified hospitalised and death risks a \verb{<data.frame>}

--- a/man/sim_linelist.Rd
+++ b/man/sim_linelist.Rd
@@ -71,7 +71,10 @@ An \verb{<epidist>} can be provided. This will be converted into a random number
 generator internally.
 
 The default is an anonymous function with a lognormal distribution random
-number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.}
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.
+
+If \code{onset_to_hosp} is set to \code{NULL} then \code{hosp_risk} and \code{hosp_death_risk}
+will be automatically set to \code{NULL} if not manually specified.}
 
 \item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
@@ -85,7 +88,11 @@ An \verb{<epidist>} can be provided. This will be converted into a random number
 generator internally.
 
 The default is an anonymous function with a lognormal distribution random
-number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.}
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.
+
+If \code{onset_to_death} is set to \code{NULL} then \code{non_hosp_death_risk} and
+\code{hosp_death_risk} will be automatically set to \code{NULL} if not manually
+specified.}
 
 \item{onset_to_recovery}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
@@ -103,27 +110,30 @@ The default is \code{NULL} so by default cases that recover get an \code{NA} in 
 
 \item{hosp_risk}{Either a single \code{numeric} for the hospitalisation risk of
 everyone in the population, or a \verb{<data.frame>} with age specific
-hospitalisation risks Default is 20\% hospitalisation (\code{0.2}) for the entire
+hospitalisation risks. Default is 20\% hospitalisation (\code{0.2}) for the entire
 population. If the \code{onset_to_hosp} argument is set to \code{NULL} this argument
-should also be set to \code{NULL}. See details and examples for more information.}
+will automatically be set to \code{NULL} if not specified or can be manually
+set to \code{NULL}. See details and examples for more information.}
 
 \item{hosp_death_risk}{Either a single \code{numeric} for the death risk for
 hospitalised individuals across the population, or a \verb{<data.frame>} with age
 specific hospitalised death risks Default is 50\% death risk in hospitals
 (\code{0.5}) for the entire population. If the \code{onset_to_death} argument is set
-to \code{NULL} this argument should also be set to \code{NULL}. See details and
-examples for more information. If a time-varying death risk is specified in
-the \code{config} the \code{hosp_death_risk} is interpreted as the maximum risk across
-the epidemic.}
+to \code{NULL} this argument will automatically be set to \code{NULL} if not specified
+or can be manually set to \code{NULL}. See details and examples for more
+information. The \code{hosp_death_risk} can vary through time if specified in
+the \code{time_varying_death_risk} element of \code{config}, see
+\code{vignette("time-varying-cfr", package = "simulist")} for more information.}
 
 \item{non_hosp_death_risk}{Either a single \code{numeric} for the death risk for
 outside of hospitals across the population, or a \verb{<data.frame>} with age
 specific death risks outside of hospitals. Default is 5\% death risk outside
 of hospitals  (\code{0.05}) for the entire population. If the \code{onset_to_death}
-argument is set to \code{NULL} this argument should also be set to \code{NULL}. See
-details and examples for more information. If a time-varying death risk is
-specified in the \code{config} the \code{non_hosp_death_risk} is interpreted as the
-maximum risk across the epidemic.}
+argument is set to \code{NULL} this argument will automatically be set to \code{NULL}
+if not specified or can be manually set to \code{NULL}. See details and examples
+for more information. The \code{non_hosp_death_risk} can vary through time if
+specified in the \code{time_varying_death_risk} element of \code{config}, see
+\code{vignette("time-varying-cfr", package = "simulist")} for more information.}
 
 \item{outbreak_start_date}{A \code{date} for the start of the outbreak.}
 

--- a/man/sim_outbreak.Rd
+++ b/man/sim_outbreak.Rd
@@ -40,7 +40,7 @@ mass function internally.
 The default is an anonymous function with a Poisson probability mass function
 (\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
 
-\item{infectious_period}{A function or an \verb{<epidist>} object for the
+\item{infectious_period}{A \code{function} or an \verb{<epidist>} object for the
 infectious period. This defines the duration from becoming infectious to
 no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
@@ -61,7 +61,7 @@ number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \
 \item{prob_infection}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}
 
-\item{onset_to_hosp}{A function or an \verb{<epidist>} object for the
+\item{onset_to_hosp}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
 set to \code{NULL} to not simulate hospitalisation (admission) dates.
 
@@ -75,7 +75,7 @@ generator internally.
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.}
 
-\item{onset_to_death}{A function or an \verb{<epidist>} object for the
+\item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
 \code{NULL} to not simulate dates for individuals that died.
 
@@ -89,7 +89,7 @@ generator internally.
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.}
 
-\item{onset_to_recovery}{A function or an \verb{<epidist>} object for the
+\item{onset_to_recovery}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
 to not simulate dates for individuals that recovered.
 

--- a/man/sim_outbreak.Rd
+++ b/man/sim_outbreak.Rd
@@ -28,11 +28,15 @@ sim_outbreak(
 \item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
 the number of contacts per infection.
 
-The function can be defined or anonymous. The function must return a vector
-of \code{numerics}. The vector is the probability mass of sampling a certain
-number of contacts, i.e. the first element in the vector is the weight of
-sampling zero contacts, the second element is the weight of sampling a single
-contact, etc. The function must have a single argument.
+The function can be defined or anonymous. The function must have a single
+argument in the form of an \code{integer} vector with elements representing the
+number of contacts, and return a \code{numeric} vector where each element
+corresponds to the probability of observing the number of contacts in the
+vector passed to the function. The index of the \code{numeric} vector returned
+is offset by one to the corresponding probability of observing the number
+of contacts, i.e. the first element of the output vector is the probability
+of observing zero contacts, the second element is the probability of
+observing one contact, etc.
 
 An \verb{<epidist>} can be provided. This will be converted into a probability
 mass function internally.
@@ -49,8 +53,8 @@ their contacts are assumed to be uniformly distributed within the
 infectious period. Infectious periods must be strictly positive.
 
 The function can be defined or anonymous. The function must return a vector
-of \code{numeric}s for the length of the infectious period. The function must
-have a single argument.
+of randomly generated real numbers representing sampled infectious periods. The function must
+have a single argument, the number of random infectious periods to generate.
 
 An \verb{<epidist>} can be provided. This will be converted into random number
 generator internally.

--- a/man/sim_outbreak.Rd
+++ b/man/sim_outbreak.Rd
@@ -25,34 +25,83 @@ sim_outbreak(
 )
 }
 \arguments{
-\item{contact_distribution}{An \verb{<epidist>} object or anonymous function for
-the contact distribution. This is any discrete density function that
-produces non-negative integers (including zero, \eqn{\mathbb{N}_0}) for the
-number of contacts per infection.}
+\item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
+the number of contacts per infection.
 
-\item{infectious_period}{An \verb{<epidist>} object or anonymous function for
-the infectious period. This defines the duration from becoming infectious
-to no longer infectious. In the simulation, individuals are assumed to
+The function can be defined or anonymous. The function must return a vector
+of \code{numerics}. The vector is the probability mass of sampling a certain
+number of contacts, i.e. the first element in the vector is the weight of
+sampling zero contacts, the second element is the weight of sampling a single
+contact, etc. The function must have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a probability
+mass function internally.
+
+The default is an anonymous function with a Poisson probability mass function
+(\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
+
+\item{infectious_period}{A function or an \verb{<epidist>} object for the
+infectious period. This defines the duration from becoming infectious to
+no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
 assumed to be zero). The time intervals between an infected individual and
 their contacts are assumed to be uniformly distributed within the
-infectious period. Infectious periods must be strictly positive.}
+infectious period. Infectious periods must be strictly positive.
+
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the infectious period. The function must
+have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \code{sdlog = 0.5}.}
 
 \item{prob_infection}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}
 
-\item{onset_to_hosp}{An \verb{<epidist>} object, an anonymous function for
-the onset to hospitalisation delay distribution, or \code{NULL} to not simulate
-hospitalisation (admission) dates.}
+\item{onset_to_hosp}{A function or an \verb{<epidist>} object for the
+onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
+set to \code{NULL} to not simulate hospitalisation (admission) dates.
 
-\item{onset_to_death}{An \verb{<epidist>} object, an anonymous function for
-the onset to death delay distribution, or \code{NULL} to not simulate dates for
-individuals that died.}
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the onset-to-hospitalisation delay. The
+function must have a single argument.
 
-\item{onset_to_recovery}{An \verb{<epidist>} object, an anonymous function for
-the onset to death delay distribution, or \code{NULL} to not simulate dates for
-individuals that recovered. Default is \code{NULL} so by default cases that
-recover get an \code{NA} in the \verb{$date_outcome} line list column.}
+An \verb{<epidist>} can be provided. This will be converted into a random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.}
+
+\item{onset_to_death}{A function or an \verb{<epidist>} object for the
+onset-to-death delay distribution. \code{onset_to_death} can also be set to
+\code{NULL} to not simulate dates for individuals that died.
+
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the onset-to-death delay. The function must
+have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a random number
+generator internally.
+
+The default is an anonymous function with a lognormal distribution random
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.}
+
+\item{onset_to_recovery}{A function or an \verb{<epidist>} object for the
+onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
+to not simulate dates for individuals that recovered.
+
+The function can be defined or anonymous. The function must return a vector
+of \code{numeric}s for the length of the onset-to-recovery delay. The function
+must have a single argument.
+
+An \verb{<epidist>} can be provided. This will be converted into a random number
+generator internally.
+
+The default is \code{NULL} so by default cases that recover get an \code{NA} in the
+\verb{$date_outcome} line list column.}
 
 \item{hosp_risk}{Either a single \code{numeric} for the hospitalisation risk of
 everyone in the population, or a \verb{<data.frame>} with age specific
@@ -123,8 +172,7 @@ A list with two elements:
 }
 \description{
 The line list and contacts are simulated using a branching
-process and parameterised with previously published epidemiological
-parameters.
+process and parameterised with epidemiological parameters.
 }
 \details{
 For age-stratified hospitalised and death risks a \verb{<data.frame>}

--- a/man/sim_outbreak.Rd
+++ b/man/sim_outbreak.Rd
@@ -73,7 +73,10 @@ An \verb{<epidist>} can be provided. This will be converted into a random number
 generator internally.
 
 The default is an anonymous function with a lognormal distribution random
-number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.}
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.
+
+If \code{onset_to_hosp} is set to \code{NULL} then \code{hosp_risk} and \code{hosp_death_risk}
+will be automatically set to \code{NULL} if not manually specified.}
 
 \item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
@@ -87,7 +90,11 @@ An \verb{<epidist>} can be provided. This will be converted into a random number
 generator internally.
 
 The default is an anonymous function with a lognormal distribution random
-number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.}
+number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.
+
+If \code{onset_to_death} is set to \code{NULL} then \code{non_hosp_death_risk} and
+\code{hosp_death_risk} will be automatically set to \code{NULL} if not manually
+specified.}
 
 \item{onset_to_recovery}{A \code{function} or an \verb{<epidist>} object for the
 onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
@@ -105,27 +112,30 @@ The default is \code{NULL} so by default cases that recover get an \code{NA} in 
 
 \item{hosp_risk}{Either a single \code{numeric} for the hospitalisation risk of
 everyone in the population, or a \verb{<data.frame>} with age specific
-hospitalisation risks Default is 20\% hospitalisation (\code{0.2}) for the entire
+hospitalisation risks. Default is 20\% hospitalisation (\code{0.2}) for the entire
 population. If the \code{onset_to_hosp} argument is set to \code{NULL} this argument
-should also be set to \code{NULL}. See details and examples for more information.}
+will automatically be set to \code{NULL} if not specified or can be manually
+set to \code{NULL}. See details and examples for more information.}
 
 \item{hosp_death_risk}{Either a single \code{numeric} for the death risk for
 hospitalised individuals across the population, or a \verb{<data.frame>} with age
 specific hospitalised death risks Default is 50\% death risk in hospitals
 (\code{0.5}) for the entire population. If the \code{onset_to_death} argument is set
-to \code{NULL} this argument should also be set to \code{NULL}. See details and
-examples for more information. If a time-varying death risk is specified in
-the \code{config} the \code{hosp_death_risk} is interpreted as the maximum risk across
-the epidemic.}
+to \code{NULL} this argument will automatically be set to \code{NULL} if not specified
+or can be manually set to \code{NULL}. See details and examples for more
+information. The \code{hosp_death_risk} can vary through time if specified in
+the \code{time_varying_death_risk} element of \code{config}, see
+\code{vignette("time-varying-cfr", package = "simulist")} for more information.}
 
 \item{non_hosp_death_risk}{Either a single \code{numeric} for the death risk for
 outside of hospitals across the population, or a \verb{<data.frame>} with age
 specific death risks outside of hospitals. Default is 5\% death risk outside
 of hospitals  (\code{0.05}) for the entire population. If the \code{onset_to_death}
-argument is set to \code{NULL} this argument should also be set to \code{NULL}. See
-details and examples for more information. If a time-varying death risk is
-specified in the \code{config} the \code{non_hosp_death_risk} is interpreted as the
-maximum risk across the epidemic.}
+argument is set to \code{NULL} this argument will automatically be set to \code{NULL}
+if not specified or can be manually set to \code{NULL}. See details and examples
+for more information. The \code{non_hosp_death_risk} can vary through time if
+specified in the \code{time_varying_death_risk} element of \code{config}, see
+\code{vignette("time-varying-cfr", package = "simulist")} for more information.}
 
 \item{outbreak_start_date}{A \code{date} for the start of the outbreak.}
 

--- a/man/sim_outbreak.Rd
+++ b/man/sim_outbreak.Rd
@@ -5,11 +5,11 @@
 \title{Simulate a line list and a contacts table}
 \usage{
 sim_outbreak(
-  contact_distribution,
-  infectious_period,
-  prob_infection,
-  onset_to_hosp,
-  onset_to_death,
+  contact_distribution = function(x) stats::dpois(x = x, lambda = 2),
+  infectious_period = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5),
+  prob_infection = 0.5,
+  onset_to_hosp = function(x) stats::rlnorm(n = x, meanlog = 1.5, sdlog = 0.5),
+  onset_to_death = function(x) stats::rlnorm(n = x, meanlog = 2.5, sdlog = 0.5),
   onset_to_recovery = NULL,
   hosp_risk = 0.2,
   hosp_death_risk = 0.5,
@@ -149,7 +149,13 @@ that age group. Proportions must sum to one.
 }
 }
 \examples{
-# load data required to simulate outbreak data
+# quickly simulate an outbreak using the function defaults
+outbreak <- sim_outbreak()
+head(outbreak$linelist)
+head(outbreak$contacts)
+
+# to simulate a more realistic outbreak load epiparameters from
+# {epiparameter}
 contact_distribution <- epiparameter::epidist(
   disease = "COVID-19",
   epi_dist = "contact distribution",

--- a/man/sim_outbreak.Rd
+++ b/man/sim_outbreak.Rd
@@ -53,8 +53,9 @@ their contacts are assumed to be uniformly distributed within the
 infectious period. Infectious periods must be strictly positive.
 
 The function can be defined or anonymous. The function must return a vector
-of randomly generated real numbers representing sampled infectious periods. The function must
-have a single argument, the number of random infectious periods to generate.
+of randomly generated real numbers representing sampled infectious periods.
+The function must have a single argument, the number of random infectious
+periods to generate.
 
 An \verb{<epidist>} can be provided. This will be converted into random number
 generator internally.

--- a/tests/testthat/_snaps/sim_contacts.md
+++ b/tests/testthat/_snaps/sim_contacts.md
@@ -1,3 +1,51 @@
+# sim_contacts works as expected with defaults
+
+    Code
+      sim_contacts()
+    Output
+                             from                       to age sex date_first_contact
+      1     Naasiruddeen al-Jafri          Naadir al-Saleh  26   m         2023-01-04
+      2     Naasiruddeen al-Jafri Louis Baltazar-Francisco  15   m         2023-01-02
+      3  Louis Baltazar-Francisco       Kalia Lubthisophon  58   f         2023-01-16
+      4  Louis Baltazar-Francisco           Skylinn Topaha  29   f         2023-01-11
+      5  Louis Baltazar-Francisco           Aurreana Salas  24   f         2023-01-12
+      6        Kalia Lubthisophon           Rachel Stevens  42   f         2023-01-15
+      7        Kalia Lubthisophon        Mitchell Sandoval  48   m         2023-01-18
+      8        Kalia Lubthisophon          Haala al-Akhter  76   f         2023-01-19
+      9            Rachel Stevens       Mersadez Barringer  39   f         2023-01-24
+      10          Haala al-Akhter           Yulisa Estrada  24   f         2023-01-21
+      11          Haala al-Akhter        Bethany Mccracken  53   f         2023-01-22
+      12           Yulisa Estrada             Cade Amerson  86   m         2023-01-24
+      13           Yulisa Estrada             Andrew Wixom  40   m         2023-01-25
+      14             Cade Amerson             Celsa Torres  83   f         2023-01-26
+      15             Celsa Torres         Tristan Stockton  90   m         2023-02-02
+      16             Celsa Torres         Bassaam al-Faris  35   m         2023-02-05
+      17             Celsa Torres         Triana Henderson  43   f         2023-02-04
+      18         Bassaam al-Faris        Jennifer Gallegos   1   f         2023-02-06
+      19         Bassaam al-Faris           Patrick Martin  29   m         2023-01-31
+      20         Bassaam al-Faris            Bryant Taylor  78   m         2023-02-04
+         date_last_contact was_case           status
+      1         2023-01-06        N   under_followup
+      2         2023-01-03        Y             case
+      3         2023-01-19        Y             case
+      4         2023-01-16        N lost_to_followup
+      5         2023-01-16        N   under_followup
+      6         2023-01-19        Y             case
+      7         2023-01-21        N   under_followup
+      8         2023-01-21        Y             case
+      9         2023-01-28        N lost_to_followup
+      10        2023-01-24        Y             case
+      11        2023-01-26        N   under_followup
+      12        2023-01-26        Y             case
+      13        2023-01-27        N          unknown
+      14        2023-02-03        Y             case
+      15        2023-02-05        N   under_followup
+      16        2023-02-07        Y             case
+      17        2023-02-05        N lost_to_followup
+      18        2023-02-09        N   under_followup
+      19        2023-02-06        Y             case
+      20        2023-02-07        N lost_to_followup
+
 # sim_contacts works as expected
 
     Code

--- a/tests/testthat/_snaps/sim_linelist.md
+++ b/tests/testthat/_snaps/sim_linelist.md
@@ -1,3 +1,327 @@
+# sim_linelist works as expected with defaults
+
+    Code
+      sim_linelist()
+    Output
+           id                case_name case_type sex age date_onset date_admission
+      1     1           Dylan Quintana confirmed   m  59 2023-01-01           <NA>
+      2     2             Briana Owens confirmed   f  90 2023-01-01     2023-01-06
+      3     3          Elaine Phillips  probable   f   4 2023-01-02     2023-01-08
+      4     5            Justin Farley  probable   m  29 2023-01-04           <NA>
+      5     6         Sadeeda el-Obeid suspected   f  14 2023-01-05           <NA>
+      6     7           Mouneek Israel  probable   f  85 2023-01-06           <NA>
+      7    10             Taylor Jones confirmed   m  25 2023-01-13           <NA>
+      8    11             Theresa Wurm confirmed   f  34 2023-01-11           <NA>
+      9    12 Brianna Villalobos Nunez  probable   f  89 2023-01-13           <NA>
+      10   14         Ayyoob al-Younis confirmed   m  63 2023-01-11           <NA>
+      11   18        Muneer al-Abdalla confirmed   m  74 2023-01-14     2023-01-19
+      12   19            Sara Schwindt confirmed   f  34 2023-01-12           <NA>
+      13   22           Katherine Phan confirmed   f  29 2023-01-12           <NA>
+      14   24       Kimberly Valentine  probable   f  46 2023-01-13           <NA>
+      15   27            Ty'Ese Porter  probable   f  24 2023-01-14           <NA>
+      16   29           Courtnee Miles suspected   f  41 2023-01-21           <NA>
+      17   30             Alexah Stott confirmed   f  72 2023-01-19           <NA>
+      18   31         Labeeb el-Saadeh confirmed   m   6 2023-01-20           <NA>
+      19   33        Gunther Rodriguez confirmed   m  61 2023-01-14           <NA>
+      20   34           Aqeela el-Akel confirmed   f  44 2023-01-14           <NA>
+      21   35              Mayra Vigil confirmed   f  71 2023-01-27           <NA>
+      22   38              Shane Binol suspected   m  69 2023-01-23           <NA>
+      23   39            Travis Atwood confirmed   m  61 2023-01-23           <NA>
+      24   41              Monique Yoo  probable   f  64 2023-01-24           <NA>
+      25   44             Joseph Bruce confirmed   m  61 2023-01-22           <NA>
+      26   45        Khaira el-Ibrahim  probable   f  66 2023-01-22           <NA>
+      27   47           Desmond Garnes confirmed   m  81 2023-01-28           <NA>
+      28   50           Myles Wakasugi confirmed   m  53 2023-01-28           <NA>
+      29   51            Joshua Moreno confirmed   m  45 2023-01-29           <NA>
+      30   53    Normajeanne Walker Jr suspected   f  42 2023-02-02           <NA>
+      31   54          Miles Cournoyer confirmed   m  78 2023-02-03           <NA>
+      32   55   Alec Thompson-Brashear confirmed   m  35 2023-01-24           <NA>
+      33   56        Zakiyya al-Meskin confirmed   f  54 2023-01-26           <NA>
+      34   58              Joel Curtis confirmed   m  68 2023-01-25           <NA>
+      35   59             Ryan Stolley  probable   m   3 2023-01-23           <NA>
+      36   60             Misael Giron  probable   m  44 2023-01-29     2023-02-02
+      37   63           Talaal al-Kazi confirmed   m  62 2023-01-31     2023-02-09
+      38   64          Naazim el-Ishak confirmed   m  35 2023-01-29           <NA>
+      39   65         Angelique Lobato suspected   f  90 2023-02-03           <NA>
+      40   66        Carousel Franklin  probable   f  25 2023-02-01           <NA>
+      41   71           Alvina Tunnell confirmed   f  46 2023-01-29           <NA>
+      42   73          Zumruda el-Dada confirmed   f   8 2023-02-01     2023-02-05
+      43   77          Trent Hernandez confirmed   m  63 2023-01-30           <NA>
+      44   78          Shelby Marshall  probable   f  54 2023-01-29           <NA>
+      45   80            Savanna Smith  probable   f  67 2023-02-03           <NA>
+      46   85           Justin Vallejo confirmed   m  37 2023-02-02           <NA>
+      47   88          Muneeb al-Latif confirmed   m  73 2023-01-30     2023-02-05
+      48   89         Laquinn Sengdara suspected   m  13 2023-02-02     2023-02-07
+      49   90        Vanessa Blackmore confirmed   f  72 2023-02-01     2023-02-03
+      50   93    Robert Ruschmeyer III confirmed   m  61 2023-02-04     2023-02-10
+      51   97               Atif Redai confirmed   m  22 2023-02-05           <NA>
+      52   98         Alexandra Devere suspected   f  29 2023-02-04           <NA>
+      53  101        Samuel Heinselman  probable   m  17 2023-02-07     2023-02-10
+      54  108              Kelvin Soto confirmed   m  71 2023-02-14           <NA>
+      55  111             Meghan Acker  probable   f  90 2023-02-09           <NA>
+      56  113             Justin Brown confirmed   m  23 2023-02-12           <NA>
+      57  114        Yasmeen Fields II  probable   f  35 2023-02-16     2023-02-19
+      58  116            Matthew Crowe suspected   m  62 2023-02-24     2023-02-28
+      59  119               Rosa Vigil  probable   f  57 2023-02-23           <NA>
+      60  120            Justin Aldava suspected   f  44 2023-02-18           <NA>
+      61  122         Rosalio Aguinaga suspected   m  57 2023-03-02           <NA>
+      62  123       Aaron D Alessandro confirmed   m  63 2023-03-08           <NA>
+      63  125       Chykeiljah Purdham confirmed   f  46 2023-02-28           <NA>
+      64  126        Mamdooh el-Salame suspected   m  66 2023-02-26           <NA>
+      65  130         Michael Robinson  probable   m  68 2023-03-07           <NA>
+      66  131           Phillip Medina confirmed   m  12 2023-03-09           <NA>
+      67  133            Natalia Phung confirmed   f  51 2023-03-18           <NA>
+      68  138        Jocilynn Shumpert confirmed   f   2 2023-03-10           <NA>
+      69  139            Troy Leighton confirmed   m  53 2023-03-09           <NA>
+      70  142     Canteskuya Lestenkof  probable   f  76 2023-03-23           <NA>
+      71  143          Isaac Rodriguez suspected   m  82 2023-03-21           <NA>
+      72  145          Arnasya Wigfall suspected   f  25 2023-03-15     2023-03-17
+      73  146       Brittany Alvizures  probable   f  76 2023-03-13           <NA>
+      74  147      Shaelumiel Phillips suspected   m  14 2023-03-13     2023-03-17
+      75  150             Kelsey Dille suspected   f  76 2023-03-11     2023-03-13
+      76  153            Riley Piontek suspected   m  78 2023-03-15           <NA>
+      77  154            Vanessa Rojas suspected   f  75 2023-03-24           <NA>
+      78  155        Rasheeqa el-Abbas suspected   f  76 2023-03-24           <NA>
+      79  157          Aarifa al-Nouri confirmed   f  80 2023-03-18     2023-03-24
+      80  158          Kelsi Dominguez confirmed   f  41 2023-03-18           <NA>
+      81  159    Maria Karlson-Pacheco confirmed   f  78 2023-03-19           <NA>
+      82  163         Reymundo Herrera confirmed   m  28 2023-03-15           <NA>
+      83  164             Mariah Black suspected   f   2 2023-03-21           <NA>
+      84  166               Bella Boss confirmed   f  82 2023-03-26           <NA>
+      85  171               David Moak suspected   m   5 2023-03-22     2023-03-25
+      86  172          Jazmyn Gallegos suspected   f   1 2023-03-20           <NA>
+      87  173          Carl Levi Sharp suspected   m  44 2023-03-19           <NA>
+      88  174          Yusri al-Khatib confirmed   m  76 2023-03-16           <NA>
+      89  175          Jeffrey Donegan confirmed   m   3 2023-03-29           <NA>
+      90  176           William Delger suspected   m  15 2023-03-25           <NA>
+      91  177               Dyami Polk  probable   m  19 2023-03-26           <NA>
+      92  178        Samantha Lockhart confirmed   f  76 2023-03-25           <NA>
+      93  182     Dominic Robinson III  probable   m  90 2023-03-27           <NA>
+      94  186     Oscar Rodriguez Loya confirmed   m  64 2023-04-03           <NA>
+      95  189          Widdad al-Jamal  probable   f  35 2023-03-29           <NA>
+      96  195       Annaliese Freiburg confirmed   f  84 2023-03-27           <NA>
+      97  196          Muhsin el-Irani  probable   m  18 2023-03-30           <NA>
+      98  197            Briana Eshima  probable   f  79 2023-03-28           <NA>
+      99  199               Elise Bugh confirmed   f  49 2023-04-07           <NA>
+      100 200        Erin Riley Doudna suspected   f  56 2023-04-05           <NA>
+      101 201            Brianna Price confirmed   f  76 2023-04-07           <NA>
+      102 202       Manuel Archambault suspected   m  41 2023-04-03     2023-04-10
+      103 205             Jaelyn Moore  probable   f  29 2023-04-01           <NA>
+      104 209              Aaron Davis  probable   m  39 2023-04-05           <NA>
+      105 210         Timothy Schwartz confirmed   m  32 2023-04-01           <NA>
+      106 211               Eric Okoye suspected   m   9 2023-04-06     2023-04-09
+      107 213              Cindy Cheng  probable   f  39 2023-04-11     2023-04-13
+      108 214       Patrick Paton-Ilse  probable   m  12 2023-04-17           <NA>
+      109 219          Christian Ingle  probable   m  52 2023-04-10     2023-04-13
+      110 221           Kimberly Leung confirmed   f  22 2023-04-02           <NA>
+      111 224             Jaliya Smith confirmed   f  68 2023-04-08           <NA>
+      112 226            Tyler Garhart  probable   m  57 2023-04-06           <NA>
+      113 229       Nabeel al-Mohammad confirmed   m   8 2023-04-12     2023-04-15
+      114 230             Alicia Vigil suspected   f  28 2023-04-12     2023-04-22
+      115 232               Aqil Davis  probable   m   2 2023-04-02           <NA>
+      116 233         Zachary Mckenney  probable   m  84 2023-04-09           <NA>
+      117 234             Angeline Kim suspected   f  52 2023-04-09           <NA>
+      118 235            Pierce Parent confirmed   m  58 2023-04-12     2023-04-17
+      119 236           Brenna Brockel confirmed   f  29 2023-04-10     2023-04-17
+      120 238        Hasana el-Hussein  probable   f  30 2023-04-14           <NA>
+      121 240            Donald Dunlap confirmed   m  71 2023-04-15           <NA>
+      122 243             Jarnell Shah confirmed   m  43 2023-04-13     2023-04-15
+      123 245            Elijah Reaves suspected   m  40 2023-04-15           <NA>
+      124 250             Eric Gilmore suspected   m  46 2023-04-16           <NA>
+      125 251          Arshad al-Sadri confirmed   m  69 2023-04-11           <NA>
+      126 252          Rif'a al-Naderi confirmed   f  69 2023-04-20           <NA>
+      127 253  Oswaldo Thomas Trujillo suspected   m  38 2023-04-20           <NA>
+      128 254        Muntasir al-Sayed confirmed   m  28 2023-04-16     2023-04-20
+      129 255          Sabri al-Ismail confirmed   m  82 2023-04-16           <NA>
+      130 258               Tylee Vang suspected   f  19 2023-04-14           <NA>
+      131 261            Sidqi el-Naim  probable   m  46 2023-04-26           <NA>
+      132 262          Amber Autterson confirmed   f  71 2023-04-13           <NA>
+      133 264        Alexandra Blalock  probable   f   4 2023-04-25     2023-04-27
+      134 265             Joshua Jones confirmed   m  31 2023-04-25           <NA>
+      135 267            Vanessa Lopez confirmed   f  16 2023-04-20           <NA>
+      136 268        Christian Vaquera confirmed   m  53 2023-04-21           <NA>
+      137 277               Ivan Perez confirmed   m  14 2023-05-01           <NA>
+      138 278     Angelica Orta Zepeda suspected   f  48 2023-04-28           <NA>
+      139 279              Raul Chavez  probable   m  89 2023-04-25     2023-05-01
+      140 280           Germaine Ealom  probable   m  39 2023-04-26           <NA>
+      141 282             Tyler Wilson confirmed   m  20 2023-04-21           <NA>
+      142 284            Maris Manning confirmed   f   6 2023-05-03           <NA>
+      143 285      Candace Plenty Wolf  probable   f  28 2023-05-05           <NA>
+      144 291             Avery Nguyen confirmed   m  42 2023-05-01     2023-05-10
+      145 292        Maariya el-Younis confirmed   f  71 2023-04-23           <NA>
+      146 293           Heather Orlady suspected   f   9 2023-05-05           <NA>
+      147 296      Brenda Molina-Brown suspected   f  61 2023-05-06           <NA>
+      148 298         Tareef el-Naderi confirmed   m  53 2023-05-02           <NA>
+      149 301                  Tina Le suspected   f  76 2023-04-23           <NA>
+      150 302          Precious Malloy confirmed   f  69 2023-04-26           <NA>
+      151 304           Elias Martinez confirmed   m  50 2023-05-07           <NA>
+      152 307           Destiny Turner confirmed   f   7 2023-05-09           <NA>
+      153 310        Brittney Morrison confirmed   f  45 2023-04-24           <NA>
+      154 311           Nathaniel Lone confirmed   m  83 2023-04-25           <NA>
+      155 313             Rachel Pruet  probable   f  41 2023-04-27           <NA>
+      156 316               Amy Tandon confirmed   f  88 2023-05-10           <NA>
+      157 320                Nico Shea suspected   m  79 2023-05-01           <NA>
+      158 326           Brenden Hughes  probable   m  82 2023-05-08     2023-05-21
+            outcome date_outcome date_first_contact date_last_contact ct_value
+      1   recovered         <NA>               <NA>              <NA>     26.3
+      2        died   2023-01-19         2022-12-31        2023-01-05     26.3
+      3        died   2023-01-08         2022-12-30        2023-01-01       NA
+      4   recovered         <NA>         2023-01-05        2023-01-05       NA
+      5   recovered         <NA>         2023-01-07        2023-01-08       NA
+      6        died   2023-01-15         2023-01-03        2023-01-06       NA
+      7   recovered         <NA>         2023-01-06        2023-01-06     26.3
+      8   recovered         <NA>         2023-01-01        2023-01-06     26.3
+      9   recovered         <NA>         2023-01-06        2023-01-08       NA
+      10  recovered         <NA>         2023-01-02        2023-01-08     26.3
+      11  recovered         <NA>         2023-01-12        2023-01-17     26.3
+      12       died   2023-03-02         2023-01-09        2023-01-11     26.3
+      13  recovered         <NA>         2023-01-12        2023-01-14     26.3
+      14  recovered         <NA>         2023-01-10        2023-01-16       NA
+      15  recovered         <NA>         2023-01-11        2023-01-13       NA
+      16  recovered         <NA>         2023-01-11        2023-01-15       NA
+      17  recovered         <NA>         2023-01-14        2023-01-17     26.3
+      18  recovered         <NA>         2023-01-14        2023-01-16     26.3
+      19  recovered         <NA>         2023-01-12        2023-01-16     26.3
+      20  recovered         <NA>         2023-01-13        2023-01-17     26.3
+      21  recovered         <NA>         2023-01-22        2023-01-23     26.3
+      22       died   2023-01-28         2023-01-20        2023-01-22       NA
+      23  recovered         <NA>         2023-01-19        2023-01-23     26.3
+      24  recovered         <NA>         2023-01-19        2023-01-22       NA
+      25  recovered         <NA>         2023-01-23        2023-01-24     26.3
+      26  recovered         <NA>         2023-01-23        2023-01-25       NA
+      27  recovered         <NA>         2023-01-23        2023-01-28     26.3
+      28  recovered         <NA>         2023-01-22        2023-01-24     26.3
+      29  recovered         <NA>         2023-01-23        2023-01-28     26.3
+      30  recovered         <NA>         2023-01-25        2023-01-26       NA
+      31  recovered         <NA>         2023-01-24        2023-01-26     26.3
+      32  recovered         <NA>         2023-01-23        2023-01-26     26.3
+      33  recovered         <NA>         2023-01-18        2023-01-23     26.3
+      34  recovered         <NA>         2023-01-19        2023-01-23     26.3
+      35  recovered         <NA>         2023-01-22        2023-01-26       NA
+      36       died   2023-02-14         2023-01-27        2023-01-27       NA
+      37       died   2023-02-17         2023-01-26        2023-01-28     26.3
+      38  recovered         <NA>         2023-01-25        2023-01-30     26.3
+      39  recovered         <NA>         2023-01-27        2023-01-30       NA
+      40  recovered         <NA>         2023-01-27        2023-01-31       NA
+      41  recovered         <NA>         2023-01-30        2023-01-31     26.3
+      42       died   2023-02-10         2023-02-01        2023-02-04     26.3
+      43  recovered         <NA>         2023-01-28        2023-02-02     26.3
+      44  recovered         <NA>         2023-01-27        2023-02-02       NA
+      45  recovered         <NA>         2023-02-03        2023-02-04       NA
+      46  recovered         <NA>         2023-02-01        2023-02-03     26.3
+      47  recovered         <NA>         2023-01-31        2023-02-01     26.3
+      48  recovered         <NA>         2023-01-30        2023-02-02       NA
+      49  recovered         <NA>         2023-01-31        2023-01-31     26.3
+      50  recovered         <NA>         2023-01-30        2023-02-04     26.3
+      51       died   2023-02-18         2023-02-04        2023-02-06     26.3
+      52  recovered         <NA>         2023-02-03        2023-02-05       NA
+      53  recovered         <NA>         2023-01-30        2023-02-04       NA
+      54  recovered         <NA>         2023-02-05        2023-02-08     26.3
+      55  recovered         <NA>         2023-02-06        2023-02-08       NA
+      56  recovered         <NA>         2023-02-10        2023-02-11     26.3
+      57  recovered         <NA>         2023-02-14        2023-02-19       NA
+      58       died   2023-03-28         2023-02-13        2023-02-16       NA
+      59  recovered         <NA>         2023-02-10        2023-02-13       NA
+      60  recovered         <NA>         2023-02-16        2023-02-18       NA
+      61  recovered         <NA>         2023-03-02        2023-03-02       NA
+      62  recovered         <NA>         2023-02-26        2023-03-03     26.3
+      63  recovered         <NA>         2023-02-24        2023-02-26     26.3
+      64  recovered         <NA>         2023-02-17        2023-02-23       NA
+      65  recovered         <NA>         2023-03-06        2023-03-07       NA
+      66  recovered         <NA>         2023-03-03        2023-03-04     26.3
+      67  recovered         <NA>         2023-03-07        2023-03-09     26.3
+      68  recovered         <NA>         2023-03-06        2023-03-11     26.3
+      69  recovered         <NA>         2023-03-07        2023-03-11     26.3
+      70  recovered         <NA>         2023-03-18        2023-03-23       NA
+      71  recovered         <NA>         2023-03-20        2023-03-20       NA
+      72       died   2023-03-28         2023-03-07        2023-03-12       NA
+      73  recovered         <NA>         2023-03-10        2023-03-14       NA
+      74       died   2023-04-11         2023-03-06        2023-03-11       NA
+      75       died   2023-03-21         2023-03-10        2023-03-11       NA
+      76  recovered         <NA>         2023-03-16        2023-03-21       NA
+      77  recovered         <NA>         2023-03-16        2023-03-19       NA
+      78  recovered         <NA>         2023-03-12        2023-03-19       NA
+      79       died   2023-04-02         2023-03-13        2023-03-14     26.3
+      80  recovered         <NA>         2023-03-12        2023-03-14     26.3
+      81  recovered         <NA>         2023-03-12        2023-03-17     26.3
+      82  recovered         <NA>         2023-03-12        2023-03-17     26.3
+      83  recovered         <NA>         2023-03-15        2023-03-18       NA
+      84  recovered         <NA>         2023-03-21        2023-03-25     26.3
+      85       died   2023-03-30         2023-03-16        2023-03-20       NA
+      86  recovered         <NA>         2023-03-18        2023-03-21       NA
+      87  recovered         <NA>         2023-03-17        2023-03-18       NA
+      88  recovered         <NA>         2023-03-20        2023-03-21     26.3
+      89  recovered         <NA>         2023-03-26        2023-03-27     26.3
+      90       died   2023-04-11         2023-03-24        2023-03-24       NA
+      91  recovered         <NA>         2023-03-22        2023-03-24       NA
+      92  recovered         <NA>         2023-03-19        2023-03-24     26.3
+      93  recovered         <NA>         2023-03-20        2023-03-20       NA
+      94  recovered         <NA>         2023-03-29        2023-04-01     26.3
+      95  recovered         <NA>         2023-03-27        2023-03-28       NA
+      96  recovered         <NA>         2023-03-23        2023-03-28     26.3
+      97  recovered         <NA>         2023-03-25        2023-03-29       NA
+      98       died   2023-04-06         2023-03-26        2023-03-28       NA
+      99  recovered         <NA>         2023-04-02        2023-04-07     26.3
+      100 recovered         <NA>         2023-04-03        2023-04-06       NA
+      101 recovered         <NA>         2023-03-31        2023-04-03     26.3
+      102      died   2023-05-01         2023-03-28        2023-04-01       NA
+      103 recovered         <NA>         2023-03-24        2023-03-29       NA
+      104 recovered         <NA>         2023-03-28        2023-04-01       NA
+      105 recovered         <NA>         2023-03-30        2023-04-06     26.3
+      106      died   2023-04-17         2023-04-03        2023-04-05       NA
+      107      died   2023-05-03         2023-04-07        2023-04-08       NA
+      108      died   2023-05-09         2023-04-08        2023-04-08       NA
+      109 recovered         <NA>         2023-04-06        2023-04-06       NA
+      110 recovered         <NA>         2023-04-01        2023-04-05     26.3
+      111 recovered         <NA>         2023-04-03        2023-04-06     26.3
+      112 recovered         <NA>         2023-04-01        2023-04-04       NA
+      113 recovered         <NA>         2023-04-11        2023-04-16     26.3
+      114 recovered         <NA>         2023-04-09        2023-04-12       NA
+      115 recovered         <NA>         2023-04-05        2023-04-06       NA
+      116 recovered         <NA>         2023-04-01        2023-04-03       NA
+      117 recovered         <NA>         2023-04-01        2023-04-09       NA
+      118 recovered         <NA>         2023-04-04        2023-04-08     26.3
+      119      died   2023-04-24         2023-04-12        2023-04-13     26.3
+      120      died   2023-05-02         2023-04-14        2023-04-17       NA
+      121 recovered         <NA>         2023-04-03        2023-04-05     26.3
+      122 recovered         <NA>         2023-04-09        2023-04-12     26.3
+      123 recovered         <NA>         2023-04-10        2023-04-16       NA
+      124 recovered         <NA>         2023-04-06        2023-04-11       NA
+      125 recovered         <NA>         2023-04-07        2023-04-12     26.3
+      126 recovered         <NA>         2023-04-04        2023-04-11     26.3
+      127 recovered         <NA>         2023-04-10        2023-04-11       NA
+      128 recovered         <NA>         2023-04-13        2023-04-16     26.3
+      129 recovered         <NA>         2023-04-14        2023-04-18     26.3
+      130 recovered         <NA>         2023-04-13        2023-04-14       NA
+      131 recovered         <NA>         2023-04-15        2023-04-18       NA
+      132 recovered         <NA>         2023-04-14        2023-04-14     26.3
+      133 recovered         <NA>         2023-04-12        2023-04-21       NA
+      134 recovered         <NA>         2023-04-16        2023-04-21     26.3
+      135 recovered         <NA>         2023-04-19        2023-04-25     26.3
+      136      died   2023-05-04         2023-04-23        2023-04-25     26.3
+      137 recovered         <NA>         2023-04-11        2023-04-15     26.3
+      138 recovered         <NA>         2023-04-23        2023-04-26       NA
+      139      died   2023-05-07         2023-04-21        2023-04-22       NA
+      140 recovered         <NA>         2023-04-18        2023-04-22       NA
+      141 recovered         <NA>         2023-04-21        2023-04-25     26.3
+      142 recovered         <NA>         2023-05-05        2023-05-06     26.3
+      143 recovered         <NA>         2023-04-28        2023-04-29       NA
+      144      died   2023-05-28         2023-04-19        2023-04-21     26.3
+      145 recovered         <NA>         2023-04-21        2023-04-23     26.3
+      146 recovered         <NA>         2023-05-03        2023-05-05       NA
+      147 recovered         <NA>         2023-05-06        2023-05-08       NA
+      148 recovered         <NA>         2023-05-01        2023-05-03     26.3
+      149 recovered         <NA>         2023-04-25        2023-04-27       NA
+      150 recovered         <NA>         2023-04-20        2023-04-25     26.3
+      151 recovered         <NA>         2023-05-08        2023-05-10     26.3
+      152 recovered         <NA>         2023-04-28        2023-05-04     26.3
+      153 recovered         <NA>         2023-04-19        2023-04-25     26.3
+      154 recovered         <NA>         2023-04-25        2023-04-26     26.3
+      155 recovered         <NA>         2023-04-25        2023-04-29       NA
+      156 recovered         <NA>         2023-05-05        2023-05-08     26.3
+      157 recovered         <NA>         2023-04-22        2023-04-28       NA
+      158      died   2023-05-22         2023-05-01        2023-05-03       NA
+
 # sim_linelist works as expected
 
     Code

--- a/tests/testthat/_snaps/sim_linelist.md
+++ b/tests/testthat/_snaps/sim_linelist.md
@@ -3,324 +3,324 @@
     Code
       sim_linelist()
     Output
-           id                case_name case_type sex age date_onset date_admission
-      1     1           Dylan Quintana confirmed   m  59 2023-01-01           <NA>
-      2     2             Briana Owens confirmed   f  90 2023-01-01     2023-01-06
-      3     3          Elaine Phillips  probable   f   4 2023-01-02     2023-01-08
-      4     5            Justin Farley  probable   m  29 2023-01-04           <NA>
-      5     6         Sadeeda el-Obeid suspected   f  14 2023-01-05           <NA>
-      6     7           Mouneek Israel  probable   f  85 2023-01-06           <NA>
-      7    10             Taylor Jones confirmed   m  25 2023-01-13           <NA>
-      8    11             Theresa Wurm confirmed   f  34 2023-01-11           <NA>
-      9    12 Brianna Villalobos Nunez  probable   f  89 2023-01-13           <NA>
-      10   14         Ayyoob al-Younis confirmed   m  63 2023-01-11           <NA>
-      11   18        Muneer al-Abdalla confirmed   m  74 2023-01-14     2023-01-19
-      12   19            Sara Schwindt confirmed   f  34 2023-01-12           <NA>
-      13   22           Katherine Phan confirmed   f  29 2023-01-12           <NA>
-      14   24       Kimberly Valentine  probable   f  46 2023-01-13           <NA>
-      15   27            Ty'Ese Porter  probable   f  24 2023-01-14           <NA>
-      16   29           Courtnee Miles suspected   f  41 2023-01-21           <NA>
-      17   30             Alexah Stott confirmed   f  72 2023-01-19           <NA>
-      18   31         Labeeb el-Saadeh confirmed   m   6 2023-01-20           <NA>
-      19   33        Gunther Rodriguez confirmed   m  61 2023-01-14           <NA>
-      20   34           Aqeela el-Akel confirmed   f  44 2023-01-14           <NA>
-      21   35              Mayra Vigil confirmed   f  71 2023-01-27           <NA>
-      22   38              Shane Binol suspected   m  69 2023-01-23           <NA>
-      23   39            Travis Atwood confirmed   m  61 2023-01-23           <NA>
-      24   41              Monique Yoo  probable   f  64 2023-01-24           <NA>
-      25   44             Joseph Bruce confirmed   m  61 2023-01-22           <NA>
-      26   45        Khaira el-Ibrahim  probable   f  66 2023-01-22           <NA>
-      27   47           Desmond Garnes confirmed   m  81 2023-01-28           <NA>
-      28   50           Myles Wakasugi confirmed   m  53 2023-01-28           <NA>
-      29   51            Joshua Moreno confirmed   m  45 2023-01-29           <NA>
-      30   53    Normajeanne Walker Jr suspected   f  42 2023-02-02           <NA>
-      31   54          Miles Cournoyer confirmed   m  78 2023-02-03           <NA>
-      32   55   Alec Thompson-Brashear confirmed   m  35 2023-01-24           <NA>
-      33   56        Zakiyya al-Meskin confirmed   f  54 2023-01-26           <NA>
-      34   58              Joel Curtis confirmed   m  68 2023-01-25           <NA>
-      35   59             Ryan Stolley  probable   m   3 2023-01-23           <NA>
-      36   60             Misael Giron  probable   m  44 2023-01-29     2023-02-02
-      37   63           Talaal al-Kazi confirmed   m  62 2023-01-31     2023-02-09
-      38   64          Naazim el-Ishak confirmed   m  35 2023-01-29           <NA>
-      39   65         Angelique Lobato suspected   f  90 2023-02-03           <NA>
-      40   66        Carousel Franklin  probable   f  25 2023-02-01           <NA>
-      41   71           Alvina Tunnell confirmed   f  46 2023-01-29           <NA>
-      42   73          Zumruda el-Dada confirmed   f   8 2023-02-01     2023-02-05
-      43   77          Trent Hernandez confirmed   m  63 2023-01-30           <NA>
-      44   78          Shelby Marshall  probable   f  54 2023-01-29           <NA>
-      45   80            Savanna Smith  probable   f  67 2023-02-03           <NA>
-      46   85           Justin Vallejo confirmed   m  37 2023-02-02           <NA>
-      47   88          Muneeb al-Latif confirmed   m  73 2023-01-30     2023-02-05
-      48   89         Laquinn Sengdara suspected   m  13 2023-02-02     2023-02-07
-      49   90        Vanessa Blackmore confirmed   f  72 2023-02-01     2023-02-03
-      50   93    Robert Ruschmeyer III confirmed   m  61 2023-02-04     2023-02-10
-      51   97               Atif Redai confirmed   m  22 2023-02-05           <NA>
-      52   98         Alexandra Devere suspected   f  29 2023-02-04           <NA>
-      53  101        Samuel Heinselman  probable   m  17 2023-02-07     2023-02-10
-      54  108              Kelvin Soto confirmed   m  71 2023-02-14           <NA>
-      55  111             Meghan Acker  probable   f  90 2023-02-09           <NA>
-      56  113             Justin Brown confirmed   m  23 2023-02-12           <NA>
-      57  114        Yasmeen Fields II  probable   f  35 2023-02-16     2023-02-19
-      58  116            Matthew Crowe suspected   m  62 2023-02-24     2023-02-28
-      59  119               Rosa Vigil  probable   f  57 2023-02-23           <NA>
-      60  120            Justin Aldava suspected   f  44 2023-02-18           <NA>
-      61  122         Rosalio Aguinaga suspected   m  57 2023-03-02           <NA>
-      62  123       Aaron D Alessandro confirmed   m  63 2023-03-08           <NA>
-      63  125       Chykeiljah Purdham confirmed   f  46 2023-02-28           <NA>
-      64  126        Mamdooh el-Salame suspected   m  66 2023-02-26           <NA>
-      65  130         Michael Robinson  probable   m  68 2023-03-07           <NA>
-      66  131           Phillip Medina confirmed   m  12 2023-03-09           <NA>
-      67  133            Natalia Phung confirmed   f  51 2023-03-18           <NA>
-      68  138        Jocilynn Shumpert confirmed   f   2 2023-03-10           <NA>
-      69  139            Troy Leighton confirmed   m  53 2023-03-09           <NA>
-      70  142     Canteskuya Lestenkof  probable   f  76 2023-03-23           <NA>
-      71  143          Isaac Rodriguez suspected   m  82 2023-03-21           <NA>
-      72  145          Arnasya Wigfall suspected   f  25 2023-03-15     2023-03-17
-      73  146       Brittany Alvizures  probable   f  76 2023-03-13           <NA>
-      74  147      Shaelumiel Phillips suspected   m  14 2023-03-13     2023-03-17
-      75  150             Kelsey Dille suspected   f  76 2023-03-11     2023-03-13
-      76  153            Riley Piontek suspected   m  78 2023-03-15           <NA>
-      77  154            Vanessa Rojas suspected   f  75 2023-03-24           <NA>
-      78  155        Rasheeqa el-Abbas suspected   f  76 2023-03-24           <NA>
-      79  157          Aarifa al-Nouri confirmed   f  80 2023-03-18     2023-03-24
-      80  158          Kelsi Dominguez confirmed   f  41 2023-03-18           <NA>
-      81  159    Maria Karlson-Pacheco confirmed   f  78 2023-03-19           <NA>
-      82  163         Reymundo Herrera confirmed   m  28 2023-03-15           <NA>
-      83  164             Mariah Black suspected   f   2 2023-03-21           <NA>
-      84  166               Bella Boss confirmed   f  82 2023-03-26           <NA>
-      85  171               David Moak suspected   m   5 2023-03-22     2023-03-25
-      86  172          Jazmyn Gallegos suspected   f   1 2023-03-20           <NA>
-      87  173          Carl Levi Sharp suspected   m  44 2023-03-19           <NA>
-      88  174          Yusri al-Khatib confirmed   m  76 2023-03-16           <NA>
-      89  175          Jeffrey Donegan confirmed   m   3 2023-03-29           <NA>
-      90  176           William Delger suspected   m  15 2023-03-25           <NA>
-      91  177               Dyami Polk  probable   m  19 2023-03-26           <NA>
-      92  178        Samantha Lockhart confirmed   f  76 2023-03-25           <NA>
-      93  182     Dominic Robinson III  probable   m  90 2023-03-27           <NA>
-      94  186     Oscar Rodriguez Loya confirmed   m  64 2023-04-03           <NA>
-      95  189          Widdad al-Jamal  probable   f  35 2023-03-29           <NA>
-      96  195       Annaliese Freiburg confirmed   f  84 2023-03-27           <NA>
-      97  196          Muhsin el-Irani  probable   m  18 2023-03-30           <NA>
-      98  197            Briana Eshima  probable   f  79 2023-03-28           <NA>
-      99  199               Elise Bugh confirmed   f  49 2023-04-07           <NA>
-      100 200        Erin Riley Doudna suspected   f  56 2023-04-05           <NA>
-      101 201            Brianna Price confirmed   f  76 2023-04-07           <NA>
-      102 202       Manuel Archambault suspected   m  41 2023-04-03     2023-04-10
-      103 205             Jaelyn Moore  probable   f  29 2023-04-01           <NA>
-      104 209              Aaron Davis  probable   m  39 2023-04-05           <NA>
-      105 210         Timothy Schwartz confirmed   m  32 2023-04-01           <NA>
-      106 211               Eric Okoye suspected   m   9 2023-04-06     2023-04-09
-      107 213              Cindy Cheng  probable   f  39 2023-04-11     2023-04-13
-      108 214       Patrick Paton-Ilse  probable   m  12 2023-04-17           <NA>
-      109 219          Christian Ingle  probable   m  52 2023-04-10     2023-04-13
-      110 221           Kimberly Leung confirmed   f  22 2023-04-02           <NA>
-      111 224             Jaliya Smith confirmed   f  68 2023-04-08           <NA>
-      112 226            Tyler Garhart  probable   m  57 2023-04-06           <NA>
-      113 229       Nabeel al-Mohammad confirmed   m   8 2023-04-12     2023-04-15
-      114 230             Alicia Vigil suspected   f  28 2023-04-12     2023-04-22
-      115 232               Aqil Davis  probable   m   2 2023-04-02           <NA>
-      116 233         Zachary Mckenney  probable   m  84 2023-04-09           <NA>
-      117 234             Angeline Kim suspected   f  52 2023-04-09           <NA>
-      118 235            Pierce Parent confirmed   m  58 2023-04-12     2023-04-17
-      119 236           Brenna Brockel confirmed   f  29 2023-04-10     2023-04-17
-      120 238        Hasana el-Hussein  probable   f  30 2023-04-14           <NA>
-      121 240            Donald Dunlap confirmed   m  71 2023-04-15           <NA>
-      122 243             Jarnell Shah confirmed   m  43 2023-04-13     2023-04-15
-      123 245            Elijah Reaves suspected   m  40 2023-04-15           <NA>
-      124 250             Eric Gilmore suspected   m  46 2023-04-16           <NA>
-      125 251          Arshad al-Sadri confirmed   m  69 2023-04-11           <NA>
-      126 252          Rif'a al-Naderi confirmed   f  69 2023-04-20           <NA>
-      127 253  Oswaldo Thomas Trujillo suspected   m  38 2023-04-20           <NA>
-      128 254        Muntasir al-Sayed confirmed   m  28 2023-04-16     2023-04-20
-      129 255          Sabri al-Ismail confirmed   m  82 2023-04-16           <NA>
-      130 258               Tylee Vang suspected   f  19 2023-04-14           <NA>
-      131 261            Sidqi el-Naim  probable   m  46 2023-04-26           <NA>
-      132 262          Amber Autterson confirmed   f  71 2023-04-13           <NA>
-      133 264        Alexandra Blalock  probable   f   4 2023-04-25     2023-04-27
-      134 265             Joshua Jones confirmed   m  31 2023-04-25           <NA>
-      135 267            Vanessa Lopez confirmed   f  16 2023-04-20           <NA>
-      136 268        Christian Vaquera confirmed   m  53 2023-04-21           <NA>
-      137 277               Ivan Perez confirmed   m  14 2023-05-01           <NA>
-      138 278     Angelica Orta Zepeda suspected   f  48 2023-04-28           <NA>
-      139 279              Raul Chavez  probable   m  89 2023-04-25     2023-05-01
-      140 280           Germaine Ealom  probable   m  39 2023-04-26           <NA>
-      141 282             Tyler Wilson confirmed   m  20 2023-04-21           <NA>
-      142 284            Maris Manning confirmed   f   6 2023-05-03           <NA>
-      143 285      Candace Plenty Wolf  probable   f  28 2023-05-05           <NA>
-      144 291             Avery Nguyen confirmed   m  42 2023-05-01     2023-05-10
-      145 292        Maariya el-Younis confirmed   f  71 2023-04-23           <NA>
-      146 293           Heather Orlady suspected   f   9 2023-05-05           <NA>
-      147 296      Brenda Molina-Brown suspected   f  61 2023-05-06           <NA>
-      148 298         Tareef el-Naderi confirmed   m  53 2023-05-02           <NA>
-      149 301                  Tina Le suspected   f  76 2023-04-23           <NA>
-      150 302          Precious Malloy confirmed   f  69 2023-04-26           <NA>
-      151 304           Elias Martinez confirmed   m  50 2023-05-07           <NA>
-      152 307           Destiny Turner confirmed   f   7 2023-05-09           <NA>
-      153 310        Brittney Morrison confirmed   f  45 2023-04-24           <NA>
-      154 311           Nathaniel Lone confirmed   m  83 2023-04-25           <NA>
-      155 313             Rachel Pruet  probable   f  41 2023-04-27           <NA>
-      156 316               Amy Tandon confirmed   f  88 2023-05-10           <NA>
-      157 320                Nico Shea suspected   m  79 2023-05-01           <NA>
-      158 326           Brenden Hughes  probable   m  82 2023-05-08     2023-05-21
+           id                 case_name case_type sex age date_onset date_admission
+      1     1      Marquione Currington suspected   m  59 2023-01-01     2023-01-09
+      2     2        Ghaaliba el-Hassen  probable   f  90 2023-01-01           <NA>
+      3     3   Leslie Morales-Gonzalez  probable   f   4 2023-01-02           <NA>
+      4     5          Labeeb el-Hariri confirmed   m  29 2023-01-04           <NA>
+      5     6               Carla Moore confirmed   f  14 2023-01-05     2023-01-09
+      6     7        Saabiqa al-Hammoud  probable   f  85 2023-01-06     2023-01-08
+      7    10              Alex Voliton confirmed   m  25 2023-01-13           <NA>
+      8    11                 Mara Gast confirmed   f  34 2023-01-11     2023-01-24
+      9    12       Dasha Willis-Arvizu suspected   f  89 2023-01-13           <NA>
+      10   14          Justus Goodstein suspected   m  63 2023-01-11           <NA>
+      11   18       Kiyontus Howard III confirmed   m  74 2023-01-14           <NA>
+      12   19        Alexandria Hoshiko suspected   f  34 2023-01-12           <NA>
+      13   22              Sarah Walker confirmed   f  29 2023-01-12           <NA>
+      14   24             Kylie Warthen confirmed   f  46 2023-01-13           <NA>
+      15   27                 Corey Mao confirmed   f  24 2023-01-14     2023-01-19
+      16   29              Alyce Hodges confirmed   f  41 2023-01-21           <NA>
+      17   30        Kimuraamor Mizelle confirmed   f  72 2023-01-19           <NA>
+      18   31          Christopher Bell  probable   m   6 2023-01-20           <NA>
+      19   33               Evan Mulder confirmed   m  61 2023-01-14           <NA>
+      20   34              Lauren Garza suspected   f  44 2023-01-14     2023-02-10
+      21   35           Mahaa al-Arshad  probable   f  71 2023-01-27           <NA>
+      22   38           Mastoor al-Azer suspected   m  69 2023-01-23           <NA>
+      23   39           Deshawn Gallion confirmed   m  61 2023-01-23           <NA>
+      24   41 Makalia Hernandez Mendoza suspected   f  64 2023-01-24           <NA>
+      25   44                Lewis Tani  probable   m  61 2023-01-22           <NA>
+      26   45             Shalin Decker confirmed   f  66 2023-01-22           <NA>
+      27   47             Alexander Bly confirmed   m  81 2023-01-28           <NA>
+      28   50            Alexander Ryan  probable   m  53 2023-01-28     2023-01-30
+      29   51              Israel Downs suspected   m  45 2023-01-29           <NA>
+      30   53            Hannah Johnson suspected   f  42 2023-02-02     2023-02-11
+      31   54          Maaiz al-Harroun confirmed   m  78 2023-02-03           <NA>
+      32   55            Sabri el-Pasha suspected   m  35 2023-01-24           <NA>
+      33   56         Lizabeth Anderson confirmed   f  54 2023-01-26           <NA>
+      34   58             Elijah Nguyen confirmed   m  68 2023-01-25     2023-01-29
+      35   59          Hilmi al-Mustafa confirmed   m   3 2023-01-23           <NA>
+      36   60              Darian Ramos suspected   m  44 2023-01-29     2023-02-02
+      37   63           Ayyoob al-Sabet  probable   m  62 2023-01-31           <NA>
+      38   64          Quraish el-Aslam  probable   m  35 2023-01-29           <NA>
+      39   65              Joanne Daley confirmed   f  90 2023-02-03     2023-02-08
+      40   66                Erica Rupp suspected   f  25 2023-02-01     2023-02-05
+      41   71         Shantavia Barnett suspected   f  46 2023-01-29           <NA>
+      42   73          Azeeza al-Othman confirmed   f   8 2023-02-01           <NA>
+      43   77           Saamir al-Kalil  probable   m  63 2023-01-30           <NA>
+      44   78             Sarah Hankins confirmed   f  54 2023-01-29           <NA>
+      45   80         Majeeda el-Baluch  probable   f  67 2023-02-03           <NA>
+      46   85            Isaac Cardenas confirmed   m  37 2023-02-02           <NA>
+      47   88            Adam Gallagher suspected   m  73 2023-01-30           <NA>
+      48   89              Zachary Abel confirmed   m  13 2023-02-02           <NA>
+      49   90           Waleeda al-Alam suspected   f  72 2023-02-01           <NA>
+      50   93            Qais el-Younes confirmed   m  61 2023-02-04           <NA>
+      51   97          Ridwaan el-Zaman confirmed   m  22 2023-02-05           <NA>
+      52   98           Azeema al-Rayes confirmed   f  29 2023-02-04           <NA>
+      53  101            Subhi al-Qasim confirmed   m  17 2023-02-07           <NA>
+      54  108               Luis Chacon  probable   m  71 2023-02-14           <NA>
+      55  111             Marley Wilson confirmed   f  90 2023-02-09           <NA>
+      56  113            Mondray Thomas suspected   m  23 2023-02-12           <NA>
+      57  114         Humaina al-Habeeb  probable   f  35 2023-02-16           <NA>
+      58  116             Ishan Kumagai confirmed   m  62 2023-02-24           <NA>
+      59  119             Joanna Guerra  probable   f  57 2023-02-23           <NA>
+      60  120           Dashelle Milner confirmed   f  44 2023-02-18           <NA>
+      61  122             Derek Cooksey confirmed   m  57 2023-03-02           <NA>
+      62  123           Suhaib al-Hoque  probable   m  63 2023-03-08     2023-03-11
+      63  125           Christine Bajwa confirmed   f  46 2023-02-28           <NA>
+      64  126       Jalen Herrera-Vigil  probable   m  66 2023-02-26           <NA>
+      65  130                   Alex Vu  probable   m  68 2023-03-07           <NA>
+      66  131          Alexander Nakata  probable   m  12 2023-03-09           <NA>
+      67  133            Alia Archuleta confirmed   f  51 2023-03-18           <NA>
+      68  138           Maazina el-Amin  probable   f   2 2023-03-10           <NA>
+      69  139             Albert Marley confirmed   m  53 2023-03-09     2023-03-16
+      70  142          Mackenzie Conley confirmed   f  76 2023-03-23           <NA>
+      71  143              Angel Silvas confirmed   m  82 2023-03-21           <NA>
+      72  145             Keyona Dydell suspected   f  25 2023-03-15           <NA>
+      73  146                Laura Sher confirmed   f  76 2023-03-13           <NA>
+      74  147         Tuvshinbayar Tran  probable   m  14 2023-03-13     2023-03-17
+      75  150            Maiya Hazelman  probable   f  76 2023-03-11           <NA>
+      76  153                  Mori Hsu  probable   m  78 2023-03-15           <NA>
+      77  154           Gretchen Prieto confirmed   f  75 2023-03-24     2023-03-31
+      78  155           Kameela al-Zaki confirmed   f  76 2023-03-24           <NA>
+      79  157         Zumruda al-Arshad  probable   f  80 2023-03-18           <NA>
+      80  158              Nimesha Kane  probable   f  41 2023-03-18           <NA>
+      81  159               Jennifer An confirmed   f  78 2023-03-19           <NA>
+      82  163            Matthew Welter confirmed   m  28 2023-03-15           <NA>
+      83  164            Kendall Rhoads suspected   f   2 2023-03-21           <NA>
+      84  166           Antaiaja Cromer  probable   f  82 2023-03-26           <NA>
+      85  171            Fikri al-Amara  probable   m   5 2023-03-22           <NA>
+      86  172       Gabriella Two  Crow confirmed   f   1 2023-03-20           <NA>
+      87  173              Yutitham Tan  probable   m  44 2023-03-19     2023-03-22
+      88  174         Ramalaan el-Zafar  probable   m  76 2023-03-16           <NA>
+      89  175    Carlo Ceazar Phanekham  probable   m   3 2023-03-29           <NA>
+      90  176            Brandon Bailey  probable   m  15 2023-03-25           <NA>
+      91  177         Mu'taz al-Shabazz confirmed   m  19 2023-03-26           <NA>
+      92  178               Ana Guijosa confirmed   f  76 2023-03-25           <NA>
+      93  182              Ethan Turner  probable   m  90 2023-03-27           <NA>
+      94  186       Raashid el-Shehadeh confirmed   m  64 2023-04-03           <NA>
+      95  189             Nuzha el-Ally  probable   f  35 2023-03-29           <NA>
+      96  195           Tiffany Lenahan confirmed   f  84 2023-03-27           <NA>
+      97  196            Joshua Sanchez confirmed   m  18 2023-03-30     2023-04-03
+      98  197          Lolette Robinson confirmed   f  79 2023-03-28     2023-04-03
+      99  199            Mariah Simmons suspected   f  49 2023-04-07           <NA>
+      100 200              Dawna Beeton confirmed   f  56 2023-04-05           <NA>
+      101 201                 Mia Lumba suspected   f  76 2023-04-07     2023-04-12
+      102 202            David Reichman suspected   m  41 2023-04-03           <NA>
+      103 205        Mackenzie Mcmullen suspected   f  29 2023-04-01           <NA>
+      104 209            Michael Navajo  probable   m  39 2023-04-05     2023-04-12
+      105 210           Ernesto Cachola  probable   m  32 2023-04-01           <NA>
+      106 211           Emmanuel Ibarra confirmed   m   9 2023-04-06           <NA>
+      107 213           Rachel Mcdonald confirmed   f  39 2023-04-11     2023-04-13
+      108 214          Saleet al-Rahimi  probable   m  12 2023-04-17     2023-04-20
+      109 219            Jamaal el-Reza  probable   m  52 2023-04-10           <NA>
+      110 221           Dalicia Wilkins confirmed   f  22 2023-04-02           <NA>
+      111 224          Jameela al-Rahim confirmed   f  68 2023-04-08           <NA>
+      112 226              James Morgan suspected   m  57 2023-04-06           <NA>
+      113 229            Desmond Castro confirmed   m   8 2023-04-12           <NA>
+      114 230               Elijah Ross confirmed   f  28 2023-04-12           <NA>
+      115 232              Yuvorn Ahmad confirmed   m   2 2023-04-02           <NA>
+      116 233           Jericho Powless confirmed   m  84 2023-04-09           <NA>
+      117 234               Claire Osse confirmed   f  52 2023-04-09     2023-04-13
+      118 235           Dearee Scurlock suspected   m  58 2023-04-12           <NA>
+      119 236            Hafsa el-Pasha confirmed   f  29 2023-04-10           <NA>
+      120 238           Danielle Finken confirmed   f  30 2023-04-14           <NA>
+      121 240           Yusri al-Salame suspected   m  71 2023-04-15           <NA>
+      122 243               Cody Parker confirmed   m  43 2023-04-13           <NA>
+      123 245               Connor Hahs  probable   m  40 2023-04-15           <NA>
+      124 250               Kevin Huang  probable   m  46 2023-04-16           <NA>
+      125 251               Yusuf Shahi confirmed   m  69 2023-04-11           <NA>
+      126 252             Ruby Martinez confirmed   f  69 2023-04-20           <NA>
+      127 253             Jameel Curtis suspected   m  38 2023-04-20           <NA>
+      128 254              Ryan Sorrell suspected   m  28 2023-04-16           <NA>
+      129 255              Otoniel Huff  probable   m  82 2023-04-16           <NA>
+      130 258      Nafeesa el-Mohiuddin confirmed   f  19 2023-04-14           <NA>
+      131 261          Muhaajir al-Ozer confirmed   m  46 2023-04-26           <NA>
+      132 262             Jazmine Mcgee confirmed   f  71 2023-04-13     2023-04-18
+      133 264        Nawwaara al-Hammad confirmed   f   4 2023-04-25     2023-04-27
+      134 265           Trevor Videtzky confirmed   m  31 2023-04-25           <NA>
+      135 267          Ghaaliya al-Azzi confirmed   f  16 2023-04-20     2023-04-24
+      136 268          Mansoor el-Salem confirmed   m  53 2023-04-21     2023-04-29
+      137 277             Russell Stott suspected   m  14 2023-05-01           <NA>
+      138 278             Diksha Javaid suspected   f  48 2023-04-28     2023-05-01
+      139 279            Ronnie Labadie  probable   m  89 2023-04-25           <NA>
+      140 280        Alexander Mitchell confirmed   m  39 2023-04-26           <NA>
+      141 282          Brandon Marchman confirmed   m  20 2023-04-21     2023-04-26
+      142 284            Jasmine Thomas suspected   f   6 2023-05-03           <NA>
+      143 285           De'Chelle Yorks suspected   f  28 2023-05-05           <NA>
+      144 291   Alexander Rangel Mendez confirmed   m  42 2023-05-01           <NA>
+      145 292          Taylor Pickering suspected   f  71 2023-04-23           <NA>
+      146 293      Cheyanna Bear-Flores confirmed   f   9 2023-05-05           <NA>
+      147 296        Rhiannon Aviado II confirmed   f  61 2023-05-06           <NA>
+      148 298                Samuel San confirmed   m  53 2023-05-02           <NA>
+      149 301              Lafaith Bean confirmed   f  76 2023-04-23           <NA>
+      150 302          Morgan Tollivoro  probable   f  69 2023-04-26           <NA>
+      151 304            Weston Henzler confirmed   m  50 2023-05-07     2023-05-11
+      152 307           Hissa el-Yassin confirmed   f   7 2023-05-09           <NA>
+      153 310            Afaaf el-Anwar confirmed   f  45 2023-04-24           <NA>
+      154 311             Joshua Molina suspected   m  83 2023-04-25           <NA>
+      155 313         Nichole Scharnell confirmed   f  41 2023-04-27           <NA>
+      156 316              Renae Mcadoo confirmed   f  88 2023-05-10           <NA>
+      157 320  Jeremy Montelongo Declay confirmed   m  79 2023-05-01           <NA>
+      158 326           Jez-Mas Powells suspected   m  82 2023-05-08     2023-05-21
             outcome date_outcome date_first_contact date_last_contact ct_value
-      1   recovered         <NA>               <NA>              <NA>     26.3
-      2        died   2023-01-19         2022-12-31        2023-01-05     26.3
-      3        died   2023-01-08         2022-12-30        2023-01-01       NA
-      4   recovered         <NA>         2023-01-05        2023-01-05       NA
-      5   recovered         <NA>         2023-01-07        2023-01-08       NA
-      6        died   2023-01-15         2023-01-03        2023-01-06       NA
-      7   recovered         <NA>         2023-01-06        2023-01-06     26.3
-      8   recovered         <NA>         2023-01-01        2023-01-06     26.3
+      1        died   2023-01-13               <NA>              <NA>       NA
+      2   recovered         <NA>         2022-12-31        2023-01-05       NA
+      3   recovered         <NA>         2022-12-30        2023-01-01       NA
+      4   recovered         <NA>         2023-01-05        2023-01-05     24.5
+      5        died   2023-01-23         2023-01-07        2023-01-08     24.5
+      6   recovered         <NA>         2023-01-03        2023-01-06       NA
+      7   recovered         <NA>         2023-01-06        2023-01-06     24.5
+      8        died   2023-01-20         2023-01-01        2023-01-06     24.5
       9   recovered         <NA>         2023-01-06        2023-01-08       NA
-      10  recovered         <NA>         2023-01-02        2023-01-08     26.3
-      11  recovered         <NA>         2023-01-12        2023-01-17     26.3
-      12       died   2023-03-02         2023-01-09        2023-01-11     26.3
-      13  recovered         <NA>         2023-01-12        2023-01-14     26.3
-      14  recovered         <NA>         2023-01-10        2023-01-16       NA
-      15  recovered         <NA>         2023-01-11        2023-01-13       NA
-      16  recovered         <NA>         2023-01-11        2023-01-15       NA
-      17  recovered         <NA>         2023-01-14        2023-01-17     26.3
-      18  recovered         <NA>         2023-01-14        2023-01-16     26.3
-      19  recovered         <NA>         2023-01-12        2023-01-16     26.3
-      20  recovered         <NA>         2023-01-13        2023-01-17     26.3
-      21  recovered         <NA>         2023-01-22        2023-01-23     26.3
-      22       died   2023-01-28         2023-01-20        2023-01-22       NA
-      23  recovered         <NA>         2023-01-19        2023-01-23     26.3
+      10  recovered         <NA>         2023-01-02        2023-01-08       NA
+      11  recovered         <NA>         2023-01-12        2023-01-17     24.5
+      12  recovered         <NA>         2023-01-09        2023-01-11       NA
+      13  recovered         <NA>         2023-01-12        2023-01-14     24.5
+      14  recovered         <NA>         2023-01-10        2023-01-16     24.5
+      15       died   2023-01-27         2023-01-11        2023-01-13     24.5
+      16  recovered         <NA>         2023-01-11        2023-01-15     24.5
+      17  recovered         <NA>         2023-01-14        2023-01-17     24.5
+      18  recovered         <NA>         2023-01-14        2023-01-16       NA
+      19  recovered         <NA>         2023-01-12        2023-01-16     24.5
+      20  recovered         <NA>         2023-01-13        2023-01-17       NA
+      21  recovered         <NA>         2023-01-22        2023-01-23       NA
+      22  recovered         <NA>         2023-01-20        2023-01-22       NA
+      23       died   2023-01-26         2023-01-19        2023-01-23     24.5
       24  recovered         <NA>         2023-01-19        2023-01-22       NA
-      25  recovered         <NA>         2023-01-23        2023-01-24     26.3
-      26  recovered         <NA>         2023-01-23        2023-01-25       NA
-      27  recovered         <NA>         2023-01-23        2023-01-28     26.3
-      28  recovered         <NA>         2023-01-22        2023-01-24     26.3
-      29  recovered         <NA>         2023-01-23        2023-01-28     26.3
+      25  recovered         <NA>         2023-01-23        2023-01-24       NA
+      26  recovered         <NA>         2023-01-23        2023-01-25     24.5
+      27  recovered         <NA>         2023-01-23        2023-01-28     24.5
+      28       died   2023-02-16         2023-01-22        2023-01-24       NA
+      29  recovered         <NA>         2023-01-23        2023-01-28       NA
       30  recovered         <NA>         2023-01-25        2023-01-26       NA
-      31  recovered         <NA>         2023-01-24        2023-01-26     26.3
-      32  recovered         <NA>         2023-01-23        2023-01-26     26.3
-      33  recovered         <NA>         2023-01-18        2023-01-23     26.3
-      34  recovered         <NA>         2023-01-19        2023-01-23     26.3
-      35  recovered         <NA>         2023-01-22        2023-01-26       NA
-      36       died   2023-02-14         2023-01-27        2023-01-27       NA
-      37       died   2023-02-17         2023-01-26        2023-01-28     26.3
-      38  recovered         <NA>         2023-01-25        2023-01-30     26.3
-      39  recovered         <NA>         2023-01-27        2023-01-30       NA
+      31  recovered         <NA>         2023-01-24        2023-01-26     24.5
+      32  recovered         <NA>         2023-01-23        2023-01-26       NA
+      33  recovered         <NA>         2023-01-18        2023-01-23     24.5
+      34  recovered         <NA>         2023-01-19        2023-01-23     24.5
+      35       died   2023-02-03         2023-01-22        2023-01-26     24.5
+      36       died   2023-02-09         2023-01-27        2023-01-27       NA
+      37  recovered         <NA>         2023-01-26        2023-01-28       NA
+      38  recovered         <NA>         2023-01-25        2023-01-30       NA
+      39       died   2023-02-21         2023-01-27        2023-01-30     24.5
       40  recovered         <NA>         2023-01-27        2023-01-31       NA
-      41  recovered         <NA>         2023-01-30        2023-01-31     26.3
-      42       died   2023-02-10         2023-02-01        2023-02-04     26.3
-      43  recovered         <NA>         2023-01-28        2023-02-02     26.3
-      44  recovered         <NA>         2023-01-27        2023-02-02       NA
-      45  recovered         <NA>         2023-02-03        2023-02-04       NA
-      46  recovered         <NA>         2023-02-01        2023-02-03     26.3
-      47  recovered         <NA>         2023-01-31        2023-02-01     26.3
-      48  recovered         <NA>         2023-01-30        2023-02-02       NA
-      49  recovered         <NA>         2023-01-31        2023-01-31     26.3
-      50  recovered         <NA>         2023-01-30        2023-02-04     26.3
-      51       died   2023-02-18         2023-02-04        2023-02-06     26.3
-      52  recovered         <NA>         2023-02-03        2023-02-05       NA
-      53  recovered         <NA>         2023-01-30        2023-02-04       NA
-      54  recovered         <NA>         2023-02-05        2023-02-08     26.3
-      55  recovered         <NA>         2023-02-06        2023-02-08       NA
-      56  recovered         <NA>         2023-02-10        2023-02-11     26.3
+      41  recovered         <NA>         2023-01-30        2023-01-31       NA
+      42  recovered         <NA>         2023-02-01        2023-02-04     24.5
+      43  recovered         <NA>         2023-01-28        2023-02-02       NA
+      44  recovered         <NA>         2023-01-27        2023-02-02     24.5
+      45       died   2023-02-09         2023-02-03        2023-02-04       NA
+      46  recovered         <NA>         2023-02-01        2023-02-03     24.5
+      47  recovered         <NA>         2023-01-31        2023-02-01       NA
+      48  recovered         <NA>         2023-01-30        2023-02-02     24.5
+      49  recovered         <NA>         2023-01-31        2023-01-31       NA
+      50  recovered         <NA>         2023-01-30        2023-02-04     24.5
+      51       died   2023-02-18         2023-02-04        2023-02-06     24.5
+      52  recovered         <NA>         2023-02-03        2023-02-05     24.5
+      53  recovered         <NA>         2023-01-30        2023-02-04     24.5
+      54  recovered         <NA>         2023-02-05        2023-02-08       NA
+      55  recovered         <NA>         2023-02-06        2023-02-08     24.5
+      56  recovered         <NA>         2023-02-10        2023-02-11       NA
       57  recovered         <NA>         2023-02-14        2023-02-19       NA
-      58       died   2023-03-28         2023-02-13        2023-02-16       NA
+      58  recovered         <NA>         2023-02-13        2023-02-16     24.5
       59  recovered         <NA>         2023-02-10        2023-02-13       NA
-      60  recovered         <NA>         2023-02-16        2023-02-18       NA
-      61  recovered         <NA>         2023-03-02        2023-03-02       NA
-      62  recovered         <NA>         2023-02-26        2023-03-03     26.3
-      63  recovered         <NA>         2023-02-24        2023-02-26     26.3
+      60  recovered         <NA>         2023-02-16        2023-02-18     24.5
+      61       died   2023-03-20         2023-03-02        2023-03-02     24.5
+      62       died   2023-03-25         2023-02-26        2023-03-03       NA
+      63  recovered         <NA>         2023-02-24        2023-02-26     24.5
       64  recovered         <NA>         2023-02-17        2023-02-23       NA
-      65  recovered         <NA>         2023-03-06        2023-03-07       NA
-      66  recovered         <NA>         2023-03-03        2023-03-04     26.3
-      67  recovered         <NA>         2023-03-07        2023-03-09     26.3
-      68  recovered         <NA>         2023-03-06        2023-03-11     26.3
-      69  recovered         <NA>         2023-03-07        2023-03-11     26.3
-      70  recovered         <NA>         2023-03-18        2023-03-23       NA
-      71  recovered         <NA>         2023-03-20        2023-03-20       NA
-      72       died   2023-03-28         2023-03-07        2023-03-12       NA
-      73  recovered         <NA>         2023-03-10        2023-03-14       NA
-      74       died   2023-04-11         2023-03-06        2023-03-11       NA
-      75       died   2023-03-21         2023-03-10        2023-03-11       NA
+      65       died   2023-03-15         2023-03-06        2023-03-07       NA
+      66  recovered         <NA>         2023-03-03        2023-03-04       NA
+      67  recovered         <NA>         2023-03-07        2023-03-09     24.5
+      68  recovered         <NA>         2023-03-06        2023-03-11       NA
+      69       died   2023-03-14         2023-03-07        2023-03-11     24.5
+      70  recovered         <NA>         2023-03-18        2023-03-23     24.5
+      71  recovered         <NA>         2023-03-20        2023-03-20     24.5
+      72  recovered         <NA>         2023-03-07        2023-03-12       NA
+      73  recovered         <NA>         2023-03-10        2023-03-14     24.5
+      74  recovered         <NA>         2023-03-06        2023-03-11       NA
+      75  recovered         <NA>         2023-03-10        2023-03-11       NA
       76  recovered         <NA>         2023-03-16        2023-03-21       NA
-      77  recovered         <NA>         2023-03-16        2023-03-19       NA
-      78  recovered         <NA>         2023-03-12        2023-03-19       NA
-      79       died   2023-04-02         2023-03-13        2023-03-14     26.3
-      80  recovered         <NA>         2023-03-12        2023-03-14     26.3
-      81  recovered         <NA>         2023-03-12        2023-03-17     26.3
-      82  recovered         <NA>         2023-03-12        2023-03-17     26.3
+      77  recovered         <NA>         2023-03-16        2023-03-19     24.5
+      78  recovered         <NA>         2023-03-12        2023-03-19     24.5
+      79  recovered         <NA>         2023-03-13        2023-03-14       NA
+      80  recovered         <NA>         2023-03-12        2023-03-14       NA
+      81  recovered         <NA>         2023-03-12        2023-03-17     24.5
+      82  recovered         <NA>         2023-03-12        2023-03-17     24.5
       83  recovered         <NA>         2023-03-15        2023-03-18       NA
-      84  recovered         <NA>         2023-03-21        2023-03-25     26.3
-      85       died   2023-03-30         2023-03-16        2023-03-20       NA
-      86  recovered         <NA>         2023-03-18        2023-03-21       NA
-      87  recovered         <NA>         2023-03-17        2023-03-18       NA
-      88  recovered         <NA>         2023-03-20        2023-03-21     26.3
-      89  recovered         <NA>         2023-03-26        2023-03-27     26.3
-      90       died   2023-04-11         2023-03-24        2023-03-24       NA
-      91  recovered         <NA>         2023-03-22        2023-03-24       NA
-      92  recovered         <NA>         2023-03-19        2023-03-24     26.3
+      84  recovered         <NA>         2023-03-21        2023-03-25       NA
+      85  recovered         <NA>         2023-03-16        2023-03-20       NA
+      86  recovered         <NA>         2023-03-18        2023-03-21     24.5
+      87       died   2023-04-03         2023-03-17        2023-03-18       NA
+      88  recovered         <NA>         2023-03-20        2023-03-21       NA
+      89  recovered         <NA>         2023-03-26        2023-03-27       NA
+      90  recovered         <NA>         2023-03-24        2023-03-24       NA
+      91  recovered         <NA>         2023-03-22        2023-03-24     24.5
+      92  recovered         <NA>         2023-03-19        2023-03-24     24.5
       93  recovered         <NA>         2023-03-20        2023-03-20       NA
-      94  recovered         <NA>         2023-03-29        2023-04-01     26.3
+      94  recovered         <NA>         2023-03-29        2023-04-01     24.5
       95  recovered         <NA>         2023-03-27        2023-03-28       NA
-      96  recovered         <NA>         2023-03-23        2023-03-28     26.3
-      97  recovered         <NA>         2023-03-25        2023-03-29       NA
-      98       died   2023-04-06         2023-03-26        2023-03-28       NA
-      99  recovered         <NA>         2023-04-02        2023-04-07     26.3
-      100 recovered         <NA>         2023-04-03        2023-04-06       NA
-      101 recovered         <NA>         2023-03-31        2023-04-03     26.3
-      102      died   2023-05-01         2023-03-28        2023-04-01       NA
+      96  recovered         <NA>         2023-03-23        2023-03-28     24.5
+      97  recovered         <NA>         2023-03-25        2023-03-29     24.5
+      98  recovered         <NA>         2023-03-26        2023-03-28     24.5
+      99  recovered         <NA>         2023-04-02        2023-04-07       NA
+      100 recovered         <NA>         2023-04-03        2023-04-06     24.5
+      101 recovered         <NA>         2023-03-31        2023-04-03       NA
+      102 recovered         <NA>         2023-03-28        2023-04-01       NA
       103 recovered         <NA>         2023-03-24        2023-03-29       NA
       104 recovered         <NA>         2023-03-28        2023-04-01       NA
-      105 recovered         <NA>         2023-03-30        2023-04-06     26.3
-      106      died   2023-04-17         2023-04-03        2023-04-05       NA
-      107      died   2023-05-03         2023-04-07        2023-04-08       NA
-      108      died   2023-05-09         2023-04-08        2023-04-08       NA
+      105      died   2023-04-12         2023-03-30        2023-04-06       NA
+      106 recovered         <NA>         2023-04-03        2023-04-05     24.5
+      107      died   2023-04-14         2023-04-07        2023-04-08     24.5
+      108      died   2023-04-28         2023-04-08        2023-04-08       NA
       109 recovered         <NA>         2023-04-06        2023-04-06       NA
-      110 recovered         <NA>         2023-04-01        2023-04-05     26.3
-      111 recovered         <NA>         2023-04-03        2023-04-06     26.3
+      110 recovered         <NA>         2023-04-01        2023-04-05     24.5
+      111 recovered         <NA>         2023-04-03        2023-04-06     24.5
       112 recovered         <NA>         2023-04-01        2023-04-04       NA
-      113 recovered         <NA>         2023-04-11        2023-04-16     26.3
-      114 recovered         <NA>         2023-04-09        2023-04-12       NA
-      115 recovered         <NA>         2023-04-05        2023-04-06       NA
-      116 recovered         <NA>         2023-04-01        2023-04-03       NA
-      117 recovered         <NA>         2023-04-01        2023-04-09       NA
-      118 recovered         <NA>         2023-04-04        2023-04-08     26.3
-      119      died   2023-04-24         2023-04-12        2023-04-13     26.3
-      120      died   2023-05-02         2023-04-14        2023-04-17       NA
-      121 recovered         <NA>         2023-04-03        2023-04-05     26.3
-      122 recovered         <NA>         2023-04-09        2023-04-12     26.3
+      113 recovered         <NA>         2023-04-11        2023-04-16     24.5
+      114 recovered         <NA>         2023-04-09        2023-04-12     24.5
+      115 recovered         <NA>         2023-04-05        2023-04-06     24.5
+      116 recovered         <NA>         2023-04-01        2023-04-03     24.5
+      117      died   2023-04-18         2023-04-01        2023-04-09     24.5
+      118 recovered         <NA>         2023-04-04        2023-04-08       NA
+      119 recovered         <NA>         2023-04-12        2023-04-13     24.5
+      120      died   2023-04-22         2023-04-14        2023-04-17     24.5
+      121 recovered         <NA>         2023-04-03        2023-04-05       NA
+      122 recovered         <NA>         2023-04-09        2023-04-12     24.5
       123 recovered         <NA>         2023-04-10        2023-04-16       NA
       124 recovered         <NA>         2023-04-06        2023-04-11       NA
-      125 recovered         <NA>         2023-04-07        2023-04-12     26.3
-      126 recovered         <NA>         2023-04-04        2023-04-11     26.3
+      125 recovered         <NA>         2023-04-07        2023-04-12     24.5
+      126 recovered         <NA>         2023-04-04        2023-04-11     24.5
       127 recovered         <NA>         2023-04-10        2023-04-11       NA
-      128 recovered         <NA>         2023-04-13        2023-04-16     26.3
-      129 recovered         <NA>         2023-04-14        2023-04-18     26.3
-      130 recovered         <NA>         2023-04-13        2023-04-14       NA
-      131 recovered         <NA>         2023-04-15        2023-04-18       NA
-      132 recovered         <NA>         2023-04-14        2023-04-14     26.3
-      133 recovered         <NA>         2023-04-12        2023-04-21       NA
-      134 recovered         <NA>         2023-04-16        2023-04-21     26.3
-      135 recovered         <NA>         2023-04-19        2023-04-25     26.3
-      136      died   2023-05-04         2023-04-23        2023-04-25     26.3
-      137 recovered         <NA>         2023-04-11        2023-04-15     26.3
+      128 recovered         <NA>         2023-04-13        2023-04-16       NA
+      129 recovered         <NA>         2023-04-14        2023-04-18       NA
+      130 recovered         <NA>         2023-04-13        2023-04-14     24.5
+      131 recovered         <NA>         2023-04-15        2023-04-18     24.5
+      132      died   2023-05-02         2023-04-14        2023-04-14     24.5
+      133 recovered         <NA>         2023-04-12        2023-04-21     24.5
+      134 recovered         <NA>         2023-04-16        2023-04-21     24.5
+      135 recovered         <NA>         2023-04-19        2023-04-25     24.5
+      136      died   2023-05-05         2023-04-23        2023-04-25     24.5
+      137 recovered         <NA>         2023-04-11        2023-04-15       NA
       138 recovered         <NA>         2023-04-23        2023-04-26       NA
-      139      died   2023-05-07         2023-04-21        2023-04-22       NA
-      140 recovered         <NA>         2023-04-18        2023-04-22       NA
-      141 recovered         <NA>         2023-04-21        2023-04-25     26.3
-      142 recovered         <NA>         2023-05-05        2023-05-06     26.3
+      139 recovered         <NA>         2023-04-21        2023-04-22       NA
+      140 recovered         <NA>         2023-04-18        2023-04-22     24.5
+      141 recovered         <NA>         2023-04-21        2023-04-25     24.5
+      142 recovered         <NA>         2023-05-05        2023-05-06       NA
       143 recovered         <NA>         2023-04-28        2023-04-29       NA
-      144      died   2023-05-28         2023-04-19        2023-04-21     26.3
-      145 recovered         <NA>         2023-04-21        2023-04-23     26.3
-      146 recovered         <NA>         2023-05-03        2023-05-05       NA
-      147 recovered         <NA>         2023-05-06        2023-05-08       NA
-      148 recovered         <NA>         2023-05-01        2023-05-03     26.3
-      149 recovered         <NA>         2023-04-25        2023-04-27       NA
-      150 recovered         <NA>         2023-04-20        2023-04-25     26.3
-      151 recovered         <NA>         2023-05-08        2023-05-10     26.3
-      152 recovered         <NA>         2023-04-28        2023-05-04     26.3
-      153 recovered         <NA>         2023-04-19        2023-04-25     26.3
-      154 recovered         <NA>         2023-04-25        2023-04-26     26.3
-      155 recovered         <NA>         2023-04-25        2023-04-29       NA
-      156 recovered         <NA>         2023-05-05        2023-05-08     26.3
-      157 recovered         <NA>         2023-04-22        2023-04-28       NA
-      158      died   2023-05-22         2023-05-01        2023-05-03       NA
+      144 recovered         <NA>         2023-04-19        2023-04-21     24.5
+      145 recovered         <NA>         2023-04-21        2023-04-23       NA
+      146 recovered         <NA>         2023-05-03        2023-05-05     24.5
+      147 recovered         <NA>         2023-05-06        2023-05-08     24.5
+      148 recovered         <NA>         2023-05-01        2023-05-03     24.5
+      149 recovered         <NA>         2023-04-25        2023-04-27     24.5
+      150 recovered         <NA>         2023-04-20        2023-04-25       NA
+      151 recovered         <NA>         2023-05-08        2023-05-10     24.5
+      152 recovered         <NA>         2023-04-28        2023-05-04     24.5
+      153 recovered         <NA>         2023-04-19        2023-04-25     24.5
+      154 recovered         <NA>         2023-04-25        2023-04-26       NA
+      155 recovered         <NA>         2023-04-25        2023-04-29     24.5
+      156 recovered         <NA>         2023-05-05        2023-05-08     24.5
+      157 recovered         <NA>         2023-04-22        2023-04-28     24.5
+      158      died   2023-05-17         2023-05-01        2023-05-03       NA
 
 # sim_linelist works as expected
 

--- a/tests/testthat/_snaps/sim_outbreak.md
+++ b/tests/testthat/_snaps/sim_outbreak.md
@@ -4,715 +4,715 @@
       sim_outbreak()
     Output
       $linelist
-           id                case_name case_type sex age date_onset date_admission
-      1     1           Dylan Quintana confirmed   m  59 2023-01-01           <NA>
-      2     2             Briana Owens confirmed   f  90 2023-01-01     2023-01-06
-      3     3          Elaine Phillips  probable   f   4 2023-01-02     2023-01-08
-      4     5            Justin Farley  probable   m  29 2023-01-04           <NA>
-      5     6         Sadeeda el-Obeid suspected   f  14 2023-01-05           <NA>
-      6     7           Mouneek Israel  probable   f  85 2023-01-06           <NA>
-      7    10             Taylor Jones confirmed   m  25 2023-01-13           <NA>
-      8    11             Theresa Wurm confirmed   f  34 2023-01-11           <NA>
-      9    12 Brianna Villalobos Nunez  probable   f  89 2023-01-13           <NA>
-      10   14         Ayyoob al-Younis confirmed   m  63 2023-01-11           <NA>
-      11   18        Muneer al-Abdalla confirmed   m  74 2023-01-14     2023-01-19
-      12   19            Sara Schwindt confirmed   f  34 2023-01-12           <NA>
-      13   22           Katherine Phan confirmed   f  29 2023-01-12           <NA>
-      14   24       Kimberly Valentine  probable   f  46 2023-01-13           <NA>
-      15   27            Ty'Ese Porter  probable   f  24 2023-01-14           <NA>
-      16   29           Courtnee Miles suspected   f  41 2023-01-21           <NA>
-      17   30             Alexah Stott confirmed   f  72 2023-01-19           <NA>
-      18   31         Labeeb el-Saadeh confirmed   m   6 2023-01-20           <NA>
-      19   33        Gunther Rodriguez confirmed   m  61 2023-01-14           <NA>
-      20   34           Aqeela el-Akel confirmed   f  44 2023-01-14           <NA>
-      21   35              Mayra Vigil confirmed   f  71 2023-01-27           <NA>
-      22   38              Shane Binol suspected   m  69 2023-01-23           <NA>
-      23   39            Travis Atwood confirmed   m  61 2023-01-23           <NA>
-      24   41              Monique Yoo  probable   f  64 2023-01-24           <NA>
-      25   44             Joseph Bruce confirmed   m  61 2023-01-22           <NA>
-      26   45        Khaira el-Ibrahim  probable   f  66 2023-01-22           <NA>
-      27   47           Desmond Garnes confirmed   m  81 2023-01-28           <NA>
-      28   50           Myles Wakasugi confirmed   m  53 2023-01-28           <NA>
-      29   51            Joshua Moreno confirmed   m  45 2023-01-29           <NA>
-      30   53    Normajeanne Walker Jr suspected   f  42 2023-02-02           <NA>
-      31   54          Miles Cournoyer confirmed   m  78 2023-02-03           <NA>
-      32   55   Alec Thompson-Brashear confirmed   m  35 2023-01-24           <NA>
-      33   56        Zakiyya al-Meskin confirmed   f  54 2023-01-26           <NA>
-      34   58              Joel Curtis confirmed   m  68 2023-01-25           <NA>
-      35   59             Ryan Stolley  probable   m   3 2023-01-23           <NA>
-      36   60             Misael Giron  probable   m  44 2023-01-29     2023-02-02
-      37   63           Talaal al-Kazi confirmed   m  62 2023-01-31     2023-02-09
-      38   64          Naazim el-Ishak confirmed   m  35 2023-01-29           <NA>
-      39   65         Angelique Lobato suspected   f  90 2023-02-03           <NA>
-      40   66        Carousel Franklin  probable   f  25 2023-02-01           <NA>
-      41   71           Alvina Tunnell confirmed   f  46 2023-01-29           <NA>
-      42   73          Zumruda el-Dada confirmed   f   8 2023-02-01     2023-02-05
-      43   77          Trent Hernandez confirmed   m  63 2023-01-30           <NA>
-      44   78          Shelby Marshall  probable   f  54 2023-01-29           <NA>
-      45   80            Savanna Smith  probable   f  67 2023-02-03           <NA>
-      46   85           Justin Vallejo confirmed   m  37 2023-02-02           <NA>
-      47   88          Muneeb al-Latif confirmed   m  73 2023-01-30     2023-02-05
-      48   89         Laquinn Sengdara suspected   m  13 2023-02-02     2023-02-07
-      49   90        Vanessa Blackmore confirmed   f  72 2023-02-01     2023-02-03
-      50   93    Robert Ruschmeyer III confirmed   m  61 2023-02-04     2023-02-10
-      51   97               Atif Redai confirmed   m  22 2023-02-05           <NA>
-      52   98         Alexandra Devere suspected   f  29 2023-02-04           <NA>
-      53  101        Samuel Heinselman  probable   m  17 2023-02-07     2023-02-10
-      54  108              Kelvin Soto confirmed   m  71 2023-02-14           <NA>
-      55  111             Meghan Acker  probable   f  90 2023-02-09           <NA>
-      56  113             Justin Brown confirmed   m  23 2023-02-12           <NA>
-      57  114        Yasmeen Fields II  probable   f  35 2023-02-16     2023-02-19
-      58  116            Matthew Crowe suspected   m  62 2023-02-24     2023-02-28
-      59  119               Rosa Vigil  probable   f  57 2023-02-23           <NA>
-      60  120            Justin Aldava suspected   f  44 2023-02-18           <NA>
-      61  122         Rosalio Aguinaga suspected   m  57 2023-03-02           <NA>
-      62  123       Aaron D Alessandro confirmed   m  63 2023-03-08           <NA>
-      63  125       Chykeiljah Purdham confirmed   f  46 2023-02-28           <NA>
-      64  126        Mamdooh el-Salame suspected   m  66 2023-02-26           <NA>
-      65  130         Michael Robinson  probable   m  68 2023-03-07           <NA>
-      66  131           Phillip Medina confirmed   m  12 2023-03-09           <NA>
-      67  133            Natalia Phung confirmed   f  51 2023-03-18           <NA>
-      68  138        Jocilynn Shumpert confirmed   f   2 2023-03-10           <NA>
-      69  139            Troy Leighton confirmed   m  53 2023-03-09           <NA>
-      70  142     Canteskuya Lestenkof  probable   f  76 2023-03-23           <NA>
-      71  143          Isaac Rodriguez suspected   m  82 2023-03-21           <NA>
-      72  145          Arnasya Wigfall suspected   f  25 2023-03-15     2023-03-17
-      73  146       Brittany Alvizures  probable   f  76 2023-03-13           <NA>
-      74  147      Shaelumiel Phillips suspected   m  14 2023-03-13     2023-03-17
-      75  150             Kelsey Dille suspected   f  76 2023-03-11     2023-03-13
-      76  153            Riley Piontek suspected   m  78 2023-03-15           <NA>
-      77  154            Vanessa Rojas suspected   f  75 2023-03-24           <NA>
-      78  155        Rasheeqa el-Abbas suspected   f  76 2023-03-24           <NA>
-      79  157          Aarifa al-Nouri confirmed   f  80 2023-03-18     2023-03-24
-      80  158          Kelsi Dominguez confirmed   f  41 2023-03-18           <NA>
-      81  159    Maria Karlson-Pacheco confirmed   f  78 2023-03-19           <NA>
-      82  163         Reymundo Herrera confirmed   m  28 2023-03-15           <NA>
-      83  164             Mariah Black suspected   f   2 2023-03-21           <NA>
-      84  166               Bella Boss confirmed   f  82 2023-03-26           <NA>
-      85  171               David Moak suspected   m   5 2023-03-22     2023-03-25
-      86  172          Jazmyn Gallegos suspected   f   1 2023-03-20           <NA>
-      87  173          Carl Levi Sharp suspected   m  44 2023-03-19           <NA>
-      88  174          Yusri al-Khatib confirmed   m  76 2023-03-16           <NA>
-      89  175          Jeffrey Donegan confirmed   m   3 2023-03-29           <NA>
-      90  176           William Delger suspected   m  15 2023-03-25           <NA>
-      91  177               Dyami Polk  probable   m  19 2023-03-26           <NA>
-      92  178        Samantha Lockhart confirmed   f  76 2023-03-25           <NA>
-      93  182     Dominic Robinson III  probable   m  90 2023-03-27           <NA>
-      94  186     Oscar Rodriguez Loya confirmed   m  64 2023-04-03           <NA>
-      95  189          Widdad al-Jamal  probable   f  35 2023-03-29           <NA>
-      96  195       Annaliese Freiburg confirmed   f  84 2023-03-27           <NA>
-      97  196          Muhsin el-Irani  probable   m  18 2023-03-30           <NA>
-      98  197            Briana Eshima  probable   f  79 2023-03-28           <NA>
-      99  199               Elise Bugh confirmed   f  49 2023-04-07           <NA>
-      100 200        Erin Riley Doudna suspected   f  56 2023-04-05           <NA>
-      101 201            Brianna Price confirmed   f  76 2023-04-07           <NA>
-      102 202       Manuel Archambault suspected   m  41 2023-04-03     2023-04-10
-      103 205             Jaelyn Moore  probable   f  29 2023-04-01           <NA>
-      104 209              Aaron Davis  probable   m  39 2023-04-05           <NA>
-      105 210         Timothy Schwartz confirmed   m  32 2023-04-01           <NA>
-      106 211               Eric Okoye suspected   m   9 2023-04-06     2023-04-09
-      107 213              Cindy Cheng  probable   f  39 2023-04-11     2023-04-13
-      108 214       Patrick Paton-Ilse  probable   m  12 2023-04-17           <NA>
-      109 219          Christian Ingle  probable   m  52 2023-04-10     2023-04-13
-      110 221           Kimberly Leung confirmed   f  22 2023-04-02           <NA>
-      111 224             Jaliya Smith confirmed   f  68 2023-04-08           <NA>
-      112 226            Tyler Garhart  probable   m  57 2023-04-06           <NA>
-      113 229       Nabeel al-Mohammad confirmed   m   8 2023-04-12     2023-04-15
-      114 230             Alicia Vigil suspected   f  28 2023-04-12     2023-04-22
-      115 232               Aqil Davis  probable   m   2 2023-04-02           <NA>
-      116 233         Zachary Mckenney  probable   m  84 2023-04-09           <NA>
-      117 234             Angeline Kim suspected   f  52 2023-04-09           <NA>
-      118 235            Pierce Parent confirmed   m  58 2023-04-12     2023-04-17
-      119 236           Brenna Brockel confirmed   f  29 2023-04-10     2023-04-17
-      120 238        Hasana el-Hussein  probable   f  30 2023-04-14           <NA>
-      121 240            Donald Dunlap confirmed   m  71 2023-04-15           <NA>
-      122 243             Jarnell Shah confirmed   m  43 2023-04-13     2023-04-15
-      123 245            Elijah Reaves suspected   m  40 2023-04-15           <NA>
-      124 250             Eric Gilmore suspected   m  46 2023-04-16           <NA>
-      125 251          Arshad al-Sadri confirmed   m  69 2023-04-11           <NA>
-      126 252          Rif'a al-Naderi confirmed   f  69 2023-04-20           <NA>
-      127 253  Oswaldo Thomas Trujillo suspected   m  38 2023-04-20           <NA>
-      128 254        Muntasir al-Sayed confirmed   m  28 2023-04-16     2023-04-20
-      129 255          Sabri al-Ismail confirmed   m  82 2023-04-16           <NA>
-      130 258               Tylee Vang suspected   f  19 2023-04-14           <NA>
-      131 261            Sidqi el-Naim  probable   m  46 2023-04-26           <NA>
-      132 262          Amber Autterson confirmed   f  71 2023-04-13           <NA>
-      133 264        Alexandra Blalock  probable   f   4 2023-04-25     2023-04-27
-      134 265             Joshua Jones confirmed   m  31 2023-04-25           <NA>
-      135 267            Vanessa Lopez confirmed   f  16 2023-04-20           <NA>
-      136 268        Christian Vaquera confirmed   m  53 2023-04-21           <NA>
-      137 277               Ivan Perez confirmed   m  14 2023-05-01           <NA>
-      138 278     Angelica Orta Zepeda suspected   f  48 2023-04-28           <NA>
-      139 279              Raul Chavez  probable   m  89 2023-04-25     2023-05-01
-      140 280           Germaine Ealom  probable   m  39 2023-04-26           <NA>
-      141 282             Tyler Wilson confirmed   m  20 2023-04-21           <NA>
-      142 284            Maris Manning confirmed   f   6 2023-05-03           <NA>
-      143 285      Candace Plenty Wolf  probable   f  28 2023-05-05           <NA>
-      144 291             Avery Nguyen confirmed   m  42 2023-05-01     2023-05-10
-      145 292        Maariya el-Younis confirmed   f  71 2023-04-23           <NA>
-      146 293           Heather Orlady suspected   f   9 2023-05-05           <NA>
-      147 296      Brenda Molina-Brown suspected   f  61 2023-05-06           <NA>
-      148 298         Tareef el-Naderi confirmed   m  53 2023-05-02           <NA>
-      149 301                  Tina Le suspected   f  76 2023-04-23           <NA>
-      150 302          Precious Malloy confirmed   f  69 2023-04-26           <NA>
-      151 304           Elias Martinez confirmed   m  50 2023-05-07           <NA>
-      152 307           Destiny Turner confirmed   f   7 2023-05-09           <NA>
-      153 310        Brittney Morrison confirmed   f  45 2023-04-24           <NA>
-      154 311           Nathaniel Lone confirmed   m  83 2023-04-25           <NA>
-      155 313             Rachel Pruet  probable   f  41 2023-04-27           <NA>
-      156 316               Amy Tandon confirmed   f  88 2023-05-10           <NA>
-      157 320                Nico Shea suspected   m  79 2023-05-01           <NA>
-      158 326           Brenden Hughes  probable   m  82 2023-05-08     2023-05-21
+           id                 case_name case_type sex age date_onset date_admission
+      1     1      Marquione Currington suspected   m  59 2023-01-01     2023-01-09
+      2     2        Ghaaliba el-Hassen  probable   f  90 2023-01-01           <NA>
+      3     3   Leslie Morales-Gonzalez  probable   f   4 2023-01-02           <NA>
+      4     5          Labeeb el-Hariri confirmed   m  29 2023-01-04           <NA>
+      5     6               Carla Moore confirmed   f  14 2023-01-05     2023-01-09
+      6     7        Saabiqa al-Hammoud  probable   f  85 2023-01-06     2023-01-08
+      7    10              Alex Voliton confirmed   m  25 2023-01-13           <NA>
+      8    11                 Mara Gast confirmed   f  34 2023-01-11     2023-01-24
+      9    12       Dasha Willis-Arvizu suspected   f  89 2023-01-13           <NA>
+      10   14          Justus Goodstein suspected   m  63 2023-01-11           <NA>
+      11   18       Kiyontus Howard III confirmed   m  74 2023-01-14           <NA>
+      12   19        Alexandria Hoshiko suspected   f  34 2023-01-12           <NA>
+      13   22              Sarah Walker confirmed   f  29 2023-01-12           <NA>
+      14   24             Kylie Warthen confirmed   f  46 2023-01-13           <NA>
+      15   27                 Corey Mao confirmed   f  24 2023-01-14     2023-01-19
+      16   29              Alyce Hodges confirmed   f  41 2023-01-21           <NA>
+      17   30        Kimuraamor Mizelle confirmed   f  72 2023-01-19           <NA>
+      18   31          Christopher Bell  probable   m   6 2023-01-20           <NA>
+      19   33               Evan Mulder confirmed   m  61 2023-01-14           <NA>
+      20   34              Lauren Garza suspected   f  44 2023-01-14     2023-02-10
+      21   35           Mahaa al-Arshad  probable   f  71 2023-01-27           <NA>
+      22   38           Mastoor al-Azer suspected   m  69 2023-01-23           <NA>
+      23   39           Deshawn Gallion confirmed   m  61 2023-01-23           <NA>
+      24   41 Makalia Hernandez Mendoza suspected   f  64 2023-01-24           <NA>
+      25   44                Lewis Tani  probable   m  61 2023-01-22           <NA>
+      26   45             Shalin Decker confirmed   f  66 2023-01-22           <NA>
+      27   47             Alexander Bly confirmed   m  81 2023-01-28           <NA>
+      28   50            Alexander Ryan  probable   m  53 2023-01-28     2023-01-30
+      29   51              Israel Downs suspected   m  45 2023-01-29           <NA>
+      30   53            Hannah Johnson suspected   f  42 2023-02-02     2023-02-11
+      31   54          Maaiz al-Harroun confirmed   m  78 2023-02-03           <NA>
+      32   55            Sabri el-Pasha suspected   m  35 2023-01-24           <NA>
+      33   56         Lizabeth Anderson confirmed   f  54 2023-01-26           <NA>
+      34   58             Elijah Nguyen confirmed   m  68 2023-01-25     2023-01-29
+      35   59          Hilmi al-Mustafa confirmed   m   3 2023-01-23           <NA>
+      36   60              Darian Ramos suspected   m  44 2023-01-29     2023-02-02
+      37   63           Ayyoob al-Sabet  probable   m  62 2023-01-31           <NA>
+      38   64          Quraish el-Aslam  probable   m  35 2023-01-29           <NA>
+      39   65              Joanne Daley confirmed   f  90 2023-02-03     2023-02-08
+      40   66                Erica Rupp suspected   f  25 2023-02-01     2023-02-05
+      41   71         Shantavia Barnett suspected   f  46 2023-01-29           <NA>
+      42   73          Azeeza al-Othman confirmed   f   8 2023-02-01           <NA>
+      43   77           Saamir al-Kalil  probable   m  63 2023-01-30           <NA>
+      44   78             Sarah Hankins confirmed   f  54 2023-01-29           <NA>
+      45   80         Majeeda el-Baluch  probable   f  67 2023-02-03           <NA>
+      46   85            Isaac Cardenas confirmed   m  37 2023-02-02           <NA>
+      47   88            Adam Gallagher suspected   m  73 2023-01-30           <NA>
+      48   89              Zachary Abel confirmed   m  13 2023-02-02           <NA>
+      49   90           Waleeda al-Alam suspected   f  72 2023-02-01           <NA>
+      50   93            Qais el-Younes confirmed   m  61 2023-02-04           <NA>
+      51   97          Ridwaan el-Zaman confirmed   m  22 2023-02-05           <NA>
+      52   98           Azeema al-Rayes confirmed   f  29 2023-02-04           <NA>
+      53  101            Subhi al-Qasim confirmed   m  17 2023-02-07           <NA>
+      54  108               Luis Chacon  probable   m  71 2023-02-14           <NA>
+      55  111             Marley Wilson confirmed   f  90 2023-02-09           <NA>
+      56  113            Mondray Thomas suspected   m  23 2023-02-12           <NA>
+      57  114         Humaina al-Habeeb  probable   f  35 2023-02-16           <NA>
+      58  116             Ishan Kumagai confirmed   m  62 2023-02-24           <NA>
+      59  119             Joanna Guerra  probable   f  57 2023-02-23           <NA>
+      60  120           Dashelle Milner confirmed   f  44 2023-02-18           <NA>
+      61  122             Derek Cooksey confirmed   m  57 2023-03-02           <NA>
+      62  123           Suhaib al-Hoque  probable   m  63 2023-03-08     2023-03-11
+      63  125           Christine Bajwa confirmed   f  46 2023-02-28           <NA>
+      64  126       Jalen Herrera-Vigil  probable   m  66 2023-02-26           <NA>
+      65  130                   Alex Vu  probable   m  68 2023-03-07           <NA>
+      66  131          Alexander Nakata  probable   m  12 2023-03-09           <NA>
+      67  133            Alia Archuleta confirmed   f  51 2023-03-18           <NA>
+      68  138           Maazina el-Amin  probable   f   2 2023-03-10           <NA>
+      69  139             Albert Marley confirmed   m  53 2023-03-09     2023-03-16
+      70  142          Mackenzie Conley confirmed   f  76 2023-03-23           <NA>
+      71  143              Angel Silvas confirmed   m  82 2023-03-21           <NA>
+      72  145             Keyona Dydell suspected   f  25 2023-03-15           <NA>
+      73  146                Laura Sher confirmed   f  76 2023-03-13           <NA>
+      74  147         Tuvshinbayar Tran  probable   m  14 2023-03-13     2023-03-17
+      75  150            Maiya Hazelman  probable   f  76 2023-03-11           <NA>
+      76  153                  Mori Hsu  probable   m  78 2023-03-15           <NA>
+      77  154           Gretchen Prieto confirmed   f  75 2023-03-24     2023-03-31
+      78  155           Kameela al-Zaki confirmed   f  76 2023-03-24           <NA>
+      79  157         Zumruda al-Arshad  probable   f  80 2023-03-18           <NA>
+      80  158              Nimesha Kane  probable   f  41 2023-03-18           <NA>
+      81  159               Jennifer An confirmed   f  78 2023-03-19           <NA>
+      82  163            Matthew Welter confirmed   m  28 2023-03-15           <NA>
+      83  164            Kendall Rhoads suspected   f   2 2023-03-21           <NA>
+      84  166           Antaiaja Cromer  probable   f  82 2023-03-26           <NA>
+      85  171            Fikri al-Amara  probable   m   5 2023-03-22           <NA>
+      86  172       Gabriella Two  Crow confirmed   f   1 2023-03-20           <NA>
+      87  173              Yutitham Tan  probable   m  44 2023-03-19     2023-03-22
+      88  174         Ramalaan el-Zafar  probable   m  76 2023-03-16           <NA>
+      89  175    Carlo Ceazar Phanekham  probable   m   3 2023-03-29           <NA>
+      90  176            Brandon Bailey  probable   m  15 2023-03-25           <NA>
+      91  177         Mu'taz al-Shabazz confirmed   m  19 2023-03-26           <NA>
+      92  178               Ana Guijosa confirmed   f  76 2023-03-25           <NA>
+      93  182              Ethan Turner  probable   m  90 2023-03-27           <NA>
+      94  186       Raashid el-Shehadeh confirmed   m  64 2023-04-03           <NA>
+      95  189             Nuzha el-Ally  probable   f  35 2023-03-29           <NA>
+      96  195           Tiffany Lenahan confirmed   f  84 2023-03-27           <NA>
+      97  196            Joshua Sanchez confirmed   m  18 2023-03-30     2023-04-03
+      98  197          Lolette Robinson confirmed   f  79 2023-03-28     2023-04-03
+      99  199            Mariah Simmons suspected   f  49 2023-04-07           <NA>
+      100 200              Dawna Beeton confirmed   f  56 2023-04-05           <NA>
+      101 201                 Mia Lumba suspected   f  76 2023-04-07     2023-04-12
+      102 202            David Reichman suspected   m  41 2023-04-03           <NA>
+      103 205        Mackenzie Mcmullen suspected   f  29 2023-04-01           <NA>
+      104 209            Michael Navajo  probable   m  39 2023-04-05     2023-04-12
+      105 210           Ernesto Cachola  probable   m  32 2023-04-01           <NA>
+      106 211           Emmanuel Ibarra confirmed   m   9 2023-04-06           <NA>
+      107 213           Rachel Mcdonald confirmed   f  39 2023-04-11     2023-04-13
+      108 214          Saleet al-Rahimi  probable   m  12 2023-04-17     2023-04-20
+      109 219            Jamaal el-Reza  probable   m  52 2023-04-10           <NA>
+      110 221           Dalicia Wilkins confirmed   f  22 2023-04-02           <NA>
+      111 224          Jameela al-Rahim confirmed   f  68 2023-04-08           <NA>
+      112 226              James Morgan suspected   m  57 2023-04-06           <NA>
+      113 229            Desmond Castro confirmed   m   8 2023-04-12           <NA>
+      114 230               Elijah Ross confirmed   f  28 2023-04-12           <NA>
+      115 232              Yuvorn Ahmad confirmed   m   2 2023-04-02           <NA>
+      116 233           Jericho Powless confirmed   m  84 2023-04-09           <NA>
+      117 234               Claire Osse confirmed   f  52 2023-04-09     2023-04-13
+      118 235           Dearee Scurlock suspected   m  58 2023-04-12           <NA>
+      119 236            Hafsa el-Pasha confirmed   f  29 2023-04-10           <NA>
+      120 238           Danielle Finken confirmed   f  30 2023-04-14           <NA>
+      121 240           Yusri al-Salame suspected   m  71 2023-04-15           <NA>
+      122 243               Cody Parker confirmed   m  43 2023-04-13           <NA>
+      123 245               Connor Hahs  probable   m  40 2023-04-15           <NA>
+      124 250               Kevin Huang  probable   m  46 2023-04-16           <NA>
+      125 251               Yusuf Shahi confirmed   m  69 2023-04-11           <NA>
+      126 252             Ruby Martinez confirmed   f  69 2023-04-20           <NA>
+      127 253             Jameel Curtis suspected   m  38 2023-04-20           <NA>
+      128 254              Ryan Sorrell suspected   m  28 2023-04-16           <NA>
+      129 255              Otoniel Huff  probable   m  82 2023-04-16           <NA>
+      130 258      Nafeesa el-Mohiuddin confirmed   f  19 2023-04-14           <NA>
+      131 261          Muhaajir al-Ozer confirmed   m  46 2023-04-26           <NA>
+      132 262             Jazmine Mcgee confirmed   f  71 2023-04-13     2023-04-18
+      133 264        Nawwaara al-Hammad confirmed   f   4 2023-04-25     2023-04-27
+      134 265           Trevor Videtzky confirmed   m  31 2023-04-25           <NA>
+      135 267          Ghaaliya al-Azzi confirmed   f  16 2023-04-20     2023-04-24
+      136 268          Mansoor el-Salem confirmed   m  53 2023-04-21     2023-04-29
+      137 277             Russell Stott suspected   m  14 2023-05-01           <NA>
+      138 278             Diksha Javaid suspected   f  48 2023-04-28     2023-05-01
+      139 279            Ronnie Labadie  probable   m  89 2023-04-25           <NA>
+      140 280        Alexander Mitchell confirmed   m  39 2023-04-26           <NA>
+      141 282          Brandon Marchman confirmed   m  20 2023-04-21     2023-04-26
+      142 284            Jasmine Thomas suspected   f   6 2023-05-03           <NA>
+      143 285           De'Chelle Yorks suspected   f  28 2023-05-05           <NA>
+      144 291   Alexander Rangel Mendez confirmed   m  42 2023-05-01           <NA>
+      145 292          Taylor Pickering suspected   f  71 2023-04-23           <NA>
+      146 293      Cheyanna Bear-Flores confirmed   f   9 2023-05-05           <NA>
+      147 296        Rhiannon Aviado II confirmed   f  61 2023-05-06           <NA>
+      148 298                Samuel San confirmed   m  53 2023-05-02           <NA>
+      149 301              Lafaith Bean confirmed   f  76 2023-04-23           <NA>
+      150 302          Morgan Tollivoro  probable   f  69 2023-04-26           <NA>
+      151 304            Weston Henzler confirmed   m  50 2023-05-07     2023-05-11
+      152 307           Hissa el-Yassin confirmed   f   7 2023-05-09           <NA>
+      153 310            Afaaf el-Anwar confirmed   f  45 2023-04-24           <NA>
+      154 311             Joshua Molina suspected   m  83 2023-04-25           <NA>
+      155 313         Nichole Scharnell confirmed   f  41 2023-04-27           <NA>
+      156 316              Renae Mcadoo confirmed   f  88 2023-05-10           <NA>
+      157 320  Jeremy Montelongo Declay confirmed   m  79 2023-05-01           <NA>
+      158 326           Jez-Mas Powells suspected   m  82 2023-05-08     2023-05-21
             outcome date_outcome date_first_contact date_last_contact ct_value
-      1   recovered         <NA>               <NA>              <NA>     26.3
-      2        died   2023-01-19         2022-12-31        2023-01-05     26.3
-      3        died   2023-01-08         2022-12-30        2023-01-01       NA
-      4   recovered         <NA>         2023-01-05        2023-01-05       NA
-      5   recovered         <NA>         2023-01-07        2023-01-08       NA
-      6        died   2023-01-15         2023-01-03        2023-01-06       NA
-      7   recovered         <NA>         2023-01-06        2023-01-06     26.3
-      8   recovered         <NA>         2023-01-01        2023-01-06     26.3
+      1        died   2023-01-13               <NA>              <NA>       NA
+      2   recovered         <NA>         2022-12-31        2023-01-05       NA
+      3   recovered         <NA>         2022-12-30        2023-01-01       NA
+      4   recovered         <NA>         2023-01-05        2023-01-05     24.5
+      5        died   2023-01-23         2023-01-07        2023-01-08     24.5
+      6   recovered         <NA>         2023-01-03        2023-01-06       NA
+      7   recovered         <NA>         2023-01-06        2023-01-06     24.5
+      8        died   2023-01-20         2023-01-01        2023-01-06     24.5
       9   recovered         <NA>         2023-01-06        2023-01-08       NA
-      10  recovered         <NA>         2023-01-02        2023-01-08     26.3
-      11  recovered         <NA>         2023-01-12        2023-01-17     26.3
-      12       died   2023-03-02         2023-01-09        2023-01-11     26.3
-      13  recovered         <NA>         2023-01-12        2023-01-14     26.3
-      14  recovered         <NA>         2023-01-10        2023-01-16       NA
-      15  recovered         <NA>         2023-01-11        2023-01-13       NA
-      16  recovered         <NA>         2023-01-11        2023-01-15       NA
-      17  recovered         <NA>         2023-01-14        2023-01-17     26.3
-      18  recovered         <NA>         2023-01-14        2023-01-16     26.3
-      19  recovered         <NA>         2023-01-12        2023-01-16     26.3
-      20  recovered         <NA>         2023-01-13        2023-01-17     26.3
-      21  recovered         <NA>         2023-01-22        2023-01-23     26.3
-      22       died   2023-01-28         2023-01-20        2023-01-22       NA
-      23  recovered         <NA>         2023-01-19        2023-01-23     26.3
+      10  recovered         <NA>         2023-01-02        2023-01-08       NA
+      11  recovered         <NA>         2023-01-12        2023-01-17     24.5
+      12  recovered         <NA>         2023-01-09        2023-01-11       NA
+      13  recovered         <NA>         2023-01-12        2023-01-14     24.5
+      14  recovered         <NA>         2023-01-10        2023-01-16     24.5
+      15       died   2023-01-27         2023-01-11        2023-01-13     24.5
+      16  recovered         <NA>         2023-01-11        2023-01-15     24.5
+      17  recovered         <NA>         2023-01-14        2023-01-17     24.5
+      18  recovered         <NA>         2023-01-14        2023-01-16       NA
+      19  recovered         <NA>         2023-01-12        2023-01-16     24.5
+      20  recovered         <NA>         2023-01-13        2023-01-17       NA
+      21  recovered         <NA>         2023-01-22        2023-01-23       NA
+      22  recovered         <NA>         2023-01-20        2023-01-22       NA
+      23       died   2023-01-26         2023-01-19        2023-01-23     24.5
       24  recovered         <NA>         2023-01-19        2023-01-22       NA
-      25  recovered         <NA>         2023-01-23        2023-01-24     26.3
-      26  recovered         <NA>         2023-01-23        2023-01-25       NA
-      27  recovered         <NA>         2023-01-23        2023-01-28     26.3
-      28  recovered         <NA>         2023-01-22        2023-01-24     26.3
-      29  recovered         <NA>         2023-01-23        2023-01-28     26.3
+      25  recovered         <NA>         2023-01-23        2023-01-24       NA
+      26  recovered         <NA>         2023-01-23        2023-01-25     24.5
+      27  recovered         <NA>         2023-01-23        2023-01-28     24.5
+      28       died   2023-02-16         2023-01-22        2023-01-24       NA
+      29  recovered         <NA>         2023-01-23        2023-01-28       NA
       30  recovered         <NA>         2023-01-25        2023-01-26       NA
-      31  recovered         <NA>         2023-01-24        2023-01-26     26.3
-      32  recovered         <NA>         2023-01-23        2023-01-26     26.3
-      33  recovered         <NA>         2023-01-18        2023-01-23     26.3
-      34  recovered         <NA>         2023-01-19        2023-01-23     26.3
-      35  recovered         <NA>         2023-01-22        2023-01-26       NA
-      36       died   2023-02-14         2023-01-27        2023-01-27       NA
-      37       died   2023-02-17         2023-01-26        2023-01-28     26.3
-      38  recovered         <NA>         2023-01-25        2023-01-30     26.3
-      39  recovered         <NA>         2023-01-27        2023-01-30       NA
+      31  recovered         <NA>         2023-01-24        2023-01-26     24.5
+      32  recovered         <NA>         2023-01-23        2023-01-26       NA
+      33  recovered         <NA>         2023-01-18        2023-01-23     24.5
+      34  recovered         <NA>         2023-01-19        2023-01-23     24.5
+      35       died   2023-02-03         2023-01-22        2023-01-26     24.5
+      36       died   2023-02-09         2023-01-27        2023-01-27       NA
+      37  recovered         <NA>         2023-01-26        2023-01-28       NA
+      38  recovered         <NA>         2023-01-25        2023-01-30       NA
+      39       died   2023-02-21         2023-01-27        2023-01-30     24.5
       40  recovered         <NA>         2023-01-27        2023-01-31       NA
-      41  recovered         <NA>         2023-01-30        2023-01-31     26.3
-      42       died   2023-02-10         2023-02-01        2023-02-04     26.3
-      43  recovered         <NA>         2023-01-28        2023-02-02     26.3
-      44  recovered         <NA>         2023-01-27        2023-02-02       NA
-      45  recovered         <NA>         2023-02-03        2023-02-04       NA
-      46  recovered         <NA>         2023-02-01        2023-02-03     26.3
-      47  recovered         <NA>         2023-01-31        2023-02-01     26.3
-      48  recovered         <NA>         2023-01-30        2023-02-02       NA
-      49  recovered         <NA>         2023-01-31        2023-01-31     26.3
-      50  recovered         <NA>         2023-01-30        2023-02-04     26.3
-      51       died   2023-02-18         2023-02-04        2023-02-06     26.3
-      52  recovered         <NA>         2023-02-03        2023-02-05       NA
-      53  recovered         <NA>         2023-01-30        2023-02-04       NA
-      54  recovered         <NA>         2023-02-05        2023-02-08     26.3
-      55  recovered         <NA>         2023-02-06        2023-02-08       NA
-      56  recovered         <NA>         2023-02-10        2023-02-11     26.3
+      41  recovered         <NA>         2023-01-30        2023-01-31       NA
+      42  recovered         <NA>         2023-02-01        2023-02-04     24.5
+      43  recovered         <NA>         2023-01-28        2023-02-02       NA
+      44  recovered         <NA>         2023-01-27        2023-02-02     24.5
+      45       died   2023-02-09         2023-02-03        2023-02-04       NA
+      46  recovered         <NA>         2023-02-01        2023-02-03     24.5
+      47  recovered         <NA>         2023-01-31        2023-02-01       NA
+      48  recovered         <NA>         2023-01-30        2023-02-02     24.5
+      49  recovered         <NA>         2023-01-31        2023-01-31       NA
+      50  recovered         <NA>         2023-01-30        2023-02-04     24.5
+      51       died   2023-02-18         2023-02-04        2023-02-06     24.5
+      52  recovered         <NA>         2023-02-03        2023-02-05     24.5
+      53  recovered         <NA>         2023-01-30        2023-02-04     24.5
+      54  recovered         <NA>         2023-02-05        2023-02-08       NA
+      55  recovered         <NA>         2023-02-06        2023-02-08     24.5
+      56  recovered         <NA>         2023-02-10        2023-02-11       NA
       57  recovered         <NA>         2023-02-14        2023-02-19       NA
-      58       died   2023-03-28         2023-02-13        2023-02-16       NA
+      58  recovered         <NA>         2023-02-13        2023-02-16     24.5
       59  recovered         <NA>         2023-02-10        2023-02-13       NA
-      60  recovered         <NA>         2023-02-16        2023-02-18       NA
-      61  recovered         <NA>         2023-03-02        2023-03-02       NA
-      62  recovered         <NA>         2023-02-26        2023-03-03     26.3
-      63  recovered         <NA>         2023-02-24        2023-02-26     26.3
+      60  recovered         <NA>         2023-02-16        2023-02-18     24.5
+      61       died   2023-03-20         2023-03-02        2023-03-02     24.5
+      62       died   2023-03-25         2023-02-26        2023-03-03       NA
+      63  recovered         <NA>         2023-02-24        2023-02-26     24.5
       64  recovered         <NA>         2023-02-17        2023-02-23       NA
-      65  recovered         <NA>         2023-03-06        2023-03-07       NA
-      66  recovered         <NA>         2023-03-03        2023-03-04     26.3
-      67  recovered         <NA>         2023-03-07        2023-03-09     26.3
-      68  recovered         <NA>         2023-03-06        2023-03-11     26.3
-      69  recovered         <NA>         2023-03-07        2023-03-11     26.3
-      70  recovered         <NA>         2023-03-18        2023-03-23       NA
-      71  recovered         <NA>         2023-03-20        2023-03-20       NA
-      72       died   2023-03-28         2023-03-07        2023-03-12       NA
-      73  recovered         <NA>         2023-03-10        2023-03-14       NA
-      74       died   2023-04-11         2023-03-06        2023-03-11       NA
-      75       died   2023-03-21         2023-03-10        2023-03-11       NA
+      65       died   2023-03-15         2023-03-06        2023-03-07       NA
+      66  recovered         <NA>         2023-03-03        2023-03-04       NA
+      67  recovered         <NA>         2023-03-07        2023-03-09     24.5
+      68  recovered         <NA>         2023-03-06        2023-03-11       NA
+      69       died   2023-03-14         2023-03-07        2023-03-11     24.5
+      70  recovered         <NA>         2023-03-18        2023-03-23     24.5
+      71  recovered         <NA>         2023-03-20        2023-03-20     24.5
+      72  recovered         <NA>         2023-03-07        2023-03-12       NA
+      73  recovered         <NA>         2023-03-10        2023-03-14     24.5
+      74  recovered         <NA>         2023-03-06        2023-03-11       NA
+      75  recovered         <NA>         2023-03-10        2023-03-11       NA
       76  recovered         <NA>         2023-03-16        2023-03-21       NA
-      77  recovered         <NA>         2023-03-16        2023-03-19       NA
-      78  recovered         <NA>         2023-03-12        2023-03-19       NA
-      79       died   2023-04-02         2023-03-13        2023-03-14     26.3
-      80  recovered         <NA>         2023-03-12        2023-03-14     26.3
-      81  recovered         <NA>         2023-03-12        2023-03-17     26.3
-      82  recovered         <NA>         2023-03-12        2023-03-17     26.3
+      77  recovered         <NA>         2023-03-16        2023-03-19     24.5
+      78  recovered         <NA>         2023-03-12        2023-03-19     24.5
+      79  recovered         <NA>         2023-03-13        2023-03-14       NA
+      80  recovered         <NA>         2023-03-12        2023-03-14       NA
+      81  recovered         <NA>         2023-03-12        2023-03-17     24.5
+      82  recovered         <NA>         2023-03-12        2023-03-17     24.5
       83  recovered         <NA>         2023-03-15        2023-03-18       NA
-      84  recovered         <NA>         2023-03-21        2023-03-25     26.3
-      85       died   2023-03-30         2023-03-16        2023-03-20       NA
-      86  recovered         <NA>         2023-03-18        2023-03-21       NA
-      87  recovered         <NA>         2023-03-17        2023-03-18       NA
-      88  recovered         <NA>         2023-03-20        2023-03-21     26.3
-      89  recovered         <NA>         2023-03-26        2023-03-27     26.3
-      90       died   2023-04-11         2023-03-24        2023-03-24       NA
-      91  recovered         <NA>         2023-03-22        2023-03-24       NA
-      92  recovered         <NA>         2023-03-19        2023-03-24     26.3
+      84  recovered         <NA>         2023-03-21        2023-03-25       NA
+      85  recovered         <NA>         2023-03-16        2023-03-20       NA
+      86  recovered         <NA>         2023-03-18        2023-03-21     24.5
+      87       died   2023-04-03         2023-03-17        2023-03-18       NA
+      88  recovered         <NA>         2023-03-20        2023-03-21       NA
+      89  recovered         <NA>         2023-03-26        2023-03-27       NA
+      90  recovered         <NA>         2023-03-24        2023-03-24       NA
+      91  recovered         <NA>         2023-03-22        2023-03-24     24.5
+      92  recovered         <NA>         2023-03-19        2023-03-24     24.5
       93  recovered         <NA>         2023-03-20        2023-03-20       NA
-      94  recovered         <NA>         2023-03-29        2023-04-01     26.3
+      94  recovered         <NA>         2023-03-29        2023-04-01     24.5
       95  recovered         <NA>         2023-03-27        2023-03-28       NA
-      96  recovered         <NA>         2023-03-23        2023-03-28     26.3
-      97  recovered         <NA>         2023-03-25        2023-03-29       NA
-      98       died   2023-04-06         2023-03-26        2023-03-28       NA
-      99  recovered         <NA>         2023-04-02        2023-04-07     26.3
-      100 recovered         <NA>         2023-04-03        2023-04-06       NA
-      101 recovered         <NA>         2023-03-31        2023-04-03     26.3
-      102      died   2023-05-01         2023-03-28        2023-04-01       NA
+      96  recovered         <NA>         2023-03-23        2023-03-28     24.5
+      97  recovered         <NA>         2023-03-25        2023-03-29     24.5
+      98  recovered         <NA>         2023-03-26        2023-03-28     24.5
+      99  recovered         <NA>         2023-04-02        2023-04-07       NA
+      100 recovered         <NA>         2023-04-03        2023-04-06     24.5
+      101 recovered         <NA>         2023-03-31        2023-04-03       NA
+      102 recovered         <NA>         2023-03-28        2023-04-01       NA
       103 recovered         <NA>         2023-03-24        2023-03-29       NA
       104 recovered         <NA>         2023-03-28        2023-04-01       NA
-      105 recovered         <NA>         2023-03-30        2023-04-06     26.3
-      106      died   2023-04-17         2023-04-03        2023-04-05       NA
-      107      died   2023-05-03         2023-04-07        2023-04-08       NA
-      108      died   2023-05-09         2023-04-08        2023-04-08       NA
+      105      died   2023-04-12         2023-03-30        2023-04-06       NA
+      106 recovered         <NA>         2023-04-03        2023-04-05     24.5
+      107      died   2023-04-14         2023-04-07        2023-04-08     24.5
+      108      died   2023-04-28         2023-04-08        2023-04-08       NA
       109 recovered         <NA>         2023-04-06        2023-04-06       NA
-      110 recovered         <NA>         2023-04-01        2023-04-05     26.3
-      111 recovered         <NA>         2023-04-03        2023-04-06     26.3
+      110 recovered         <NA>         2023-04-01        2023-04-05     24.5
+      111 recovered         <NA>         2023-04-03        2023-04-06     24.5
       112 recovered         <NA>         2023-04-01        2023-04-04       NA
-      113 recovered         <NA>         2023-04-11        2023-04-16     26.3
-      114 recovered         <NA>         2023-04-09        2023-04-12       NA
-      115 recovered         <NA>         2023-04-05        2023-04-06       NA
-      116 recovered         <NA>         2023-04-01        2023-04-03       NA
-      117 recovered         <NA>         2023-04-01        2023-04-09       NA
-      118 recovered         <NA>         2023-04-04        2023-04-08     26.3
-      119      died   2023-04-24         2023-04-12        2023-04-13     26.3
-      120      died   2023-05-02         2023-04-14        2023-04-17       NA
-      121 recovered         <NA>         2023-04-03        2023-04-05     26.3
-      122 recovered         <NA>         2023-04-09        2023-04-12     26.3
+      113 recovered         <NA>         2023-04-11        2023-04-16     24.5
+      114 recovered         <NA>         2023-04-09        2023-04-12     24.5
+      115 recovered         <NA>         2023-04-05        2023-04-06     24.5
+      116 recovered         <NA>         2023-04-01        2023-04-03     24.5
+      117      died   2023-04-18         2023-04-01        2023-04-09     24.5
+      118 recovered         <NA>         2023-04-04        2023-04-08       NA
+      119 recovered         <NA>         2023-04-12        2023-04-13     24.5
+      120      died   2023-04-22         2023-04-14        2023-04-17     24.5
+      121 recovered         <NA>         2023-04-03        2023-04-05       NA
+      122 recovered         <NA>         2023-04-09        2023-04-12     24.5
       123 recovered         <NA>         2023-04-10        2023-04-16       NA
       124 recovered         <NA>         2023-04-06        2023-04-11       NA
-      125 recovered         <NA>         2023-04-07        2023-04-12     26.3
-      126 recovered         <NA>         2023-04-04        2023-04-11     26.3
+      125 recovered         <NA>         2023-04-07        2023-04-12     24.5
+      126 recovered         <NA>         2023-04-04        2023-04-11     24.5
       127 recovered         <NA>         2023-04-10        2023-04-11       NA
-      128 recovered         <NA>         2023-04-13        2023-04-16     26.3
-      129 recovered         <NA>         2023-04-14        2023-04-18     26.3
-      130 recovered         <NA>         2023-04-13        2023-04-14       NA
-      131 recovered         <NA>         2023-04-15        2023-04-18       NA
-      132 recovered         <NA>         2023-04-14        2023-04-14     26.3
-      133 recovered         <NA>         2023-04-12        2023-04-21       NA
-      134 recovered         <NA>         2023-04-16        2023-04-21     26.3
-      135 recovered         <NA>         2023-04-19        2023-04-25     26.3
-      136      died   2023-05-04         2023-04-23        2023-04-25     26.3
-      137 recovered         <NA>         2023-04-11        2023-04-15     26.3
+      128 recovered         <NA>         2023-04-13        2023-04-16       NA
+      129 recovered         <NA>         2023-04-14        2023-04-18       NA
+      130 recovered         <NA>         2023-04-13        2023-04-14     24.5
+      131 recovered         <NA>         2023-04-15        2023-04-18     24.5
+      132      died   2023-05-02         2023-04-14        2023-04-14     24.5
+      133 recovered         <NA>         2023-04-12        2023-04-21     24.5
+      134 recovered         <NA>         2023-04-16        2023-04-21     24.5
+      135 recovered         <NA>         2023-04-19        2023-04-25     24.5
+      136      died   2023-05-05         2023-04-23        2023-04-25     24.5
+      137 recovered         <NA>         2023-04-11        2023-04-15       NA
       138 recovered         <NA>         2023-04-23        2023-04-26       NA
-      139      died   2023-05-07         2023-04-21        2023-04-22       NA
-      140 recovered         <NA>         2023-04-18        2023-04-22       NA
-      141 recovered         <NA>         2023-04-21        2023-04-25     26.3
-      142 recovered         <NA>         2023-05-05        2023-05-06     26.3
+      139 recovered         <NA>         2023-04-21        2023-04-22       NA
+      140 recovered         <NA>         2023-04-18        2023-04-22     24.5
+      141 recovered         <NA>         2023-04-21        2023-04-25     24.5
+      142 recovered         <NA>         2023-05-05        2023-05-06       NA
       143 recovered         <NA>         2023-04-28        2023-04-29       NA
-      144      died   2023-05-28         2023-04-19        2023-04-21     26.3
-      145 recovered         <NA>         2023-04-21        2023-04-23     26.3
-      146 recovered         <NA>         2023-05-03        2023-05-05       NA
-      147 recovered         <NA>         2023-05-06        2023-05-08       NA
-      148 recovered         <NA>         2023-05-01        2023-05-03     26.3
-      149 recovered         <NA>         2023-04-25        2023-04-27       NA
-      150 recovered         <NA>         2023-04-20        2023-04-25     26.3
-      151 recovered         <NA>         2023-05-08        2023-05-10     26.3
-      152 recovered         <NA>         2023-04-28        2023-05-04     26.3
-      153 recovered         <NA>         2023-04-19        2023-04-25     26.3
-      154 recovered         <NA>         2023-04-25        2023-04-26     26.3
-      155 recovered         <NA>         2023-04-25        2023-04-29       NA
-      156 recovered         <NA>         2023-05-05        2023-05-08     26.3
-      157 recovered         <NA>         2023-04-22        2023-04-28       NA
-      158      died   2023-05-22         2023-05-01        2023-05-03       NA
+      144 recovered         <NA>         2023-04-19        2023-04-21     24.5
+      145 recovered         <NA>         2023-04-21        2023-04-23       NA
+      146 recovered         <NA>         2023-05-03        2023-05-05     24.5
+      147 recovered         <NA>         2023-05-06        2023-05-08     24.5
+      148 recovered         <NA>         2023-05-01        2023-05-03     24.5
+      149 recovered         <NA>         2023-04-25        2023-04-27     24.5
+      150 recovered         <NA>         2023-04-20        2023-04-25       NA
+      151 recovered         <NA>         2023-05-08        2023-05-10     24.5
+      152 recovered         <NA>         2023-04-28        2023-05-04     24.5
+      153 recovered         <NA>         2023-04-19        2023-04-25     24.5
+      154 recovered         <NA>         2023-04-25        2023-04-26       NA
+      155 recovered         <NA>         2023-04-25        2023-04-29     24.5
+      156 recovered         <NA>         2023-05-05        2023-05-08     24.5
+      157 recovered         <NA>         2023-04-22        2023-04-28     24.5
+      158      died   2023-05-17         2023-05-01        2023-05-03       NA
       
       $contacts
-                              from                       to age sex
-      1             Dylan Quintana             Briana Owens  90   f
-      2             Dylan Quintana          Elaine Phillips   4   f
-      3               Briana Owens           Noori el-Abbas  86   m
-      4               Briana Owens            Justin Farley  29   m
-      5            Elaine Phillips         Sadeeda el-Obeid  14   f
-      6            Elaine Phillips           Mouneek Israel  85   f
-      7            Elaine Phillips          Joseph Petersen  18   m
-      8              Justin Farley               Steven Dye  59   m
-      9           Sadeeda el-Obeid             Taylor Jones  25   m
-      10          Sadeeda el-Obeid             Theresa Wurm  34   f
-      11          Sadeeda el-Obeid Brianna Villalobos Nunez  89   f
-      12          Sadeeda el-Obeid              Jahnee Ward   5   f
-      13            Mouneek Israel         Ayyoob al-Younis  63   m
-      14              Theresa Wurm             Michael Moon  50   m
-      15              Theresa Wurm        Aaron Albershardt   5   m
-      16              Theresa Wurm        Jennifer Muenchow  89   f
-      17  Brianna Villalobos Nunez        Muneer al-Abdalla  74   m
-      18          Ayyoob al-Younis            Sara Schwindt  34   f
-      19          Ayyoob al-Younis     Dylan Mancinas Ramos  47   m
-      20          Ayyoob al-Younis           Douglas Miller  85   m
-      21          Ayyoob al-Younis           Katherine Phan  29   f
-      22         Muneer al-Abdalla        Lawrence Mitchell  24   m
-      23             Sara Schwindt       Kimberly Valentine  46   f
-      24             Sara Schwindt        Denzel Washington  63   m
-      25             Sara Schwindt            Awad al-Islam  19   m
-      26             Sara Schwindt            Ty'Ese Porter  24   f
-      27            Katherine Phan             Joshua Shire   9   m
-      28            Katherine Phan           Courtnee Miles  41   f
-      29            Katherine Phan             Alexah Stott  72   f
-      30            Katherine Phan         Labeeb el-Saadeh   6   m
-      31        Kimberly Valentine          Alondra Mendoza   9   f
-      32             Ty'Ese Porter        Gunther Rodriguez  61   m
-      33             Ty'Ese Porter           Aqeela el-Akel  44   f
-      34            Courtnee Miles              Mayra Vigil  71   f
-      35            Courtnee Miles             Travis Mckee  34   m
-      36            Courtnee Miles              Daniel Chen  75   m
-      37            Courtnee Miles              Shane Binol  69   m
-      38            Courtnee Miles            Travis Atwood  61   m
-      39            Courtnee Miles            Donovan Lopez  67   m
-      40              Alexah Stott              Monique Yoo  64   f
-      41              Alexah Stott              Alaina Moua  11   f
-      42              Alexah Stott         Khawla al-Hannan  59   f
-      43          Labeeb el-Saadeh             Joseph Bruce  61   m
-      44          Labeeb el-Saadeh        Khaira el-Ibrahim  66   f
-      45            Aqeela el-Akel              Zoe Garrett  16   f
-      46               Mayra Vigil           Desmond Garnes  81   m
-      47               Mayra Vigil           Isaac Cisneros  88   m
-      48             Travis Atwood               Hogan Tong  53   m
-      49             Travis Atwood           Myles Wakasugi  53   m
-      50               Monique Yoo            Joshua Moreno  45   m
-      51               Monique Yoo                Emily Lam  42   f
-      52               Monique Yoo    Normajeanne Walker Jr  42   f
-      53               Monique Yoo          Miles Cournoyer  78   m
-      54              Joseph Bruce   Alec Thompson-Brashear  35   m
-      55              Joseph Bruce        Zakiyya al-Meskin  54   f
-      56              Joseph Bruce           Julianna Mazza  54   f
-      57         Khaira el-Ibrahim              Joel Curtis  68   m
-      58         Khaira el-Ibrahim             Ryan Stolley   3   m
-      59         Khaira el-Ibrahim             Misael Giron  44   m
-      60            Desmond Garnes      Mercedes Drinkwater  35   f
-      61            Myles Wakasugi        Saalima al-Moradi  23   f
-      62            Myles Wakasugi           Talaal al-Kazi  62   m
-      63            Myles Wakasugi          Naazim el-Ishak  35   m
-      64             Joshua Moreno         Angelique Lobato  90   f
-      65             Joshua Moreno        Carousel Franklin  25   f
-      66           Miles Cournoyer Attily Haywood-Morimitsu  41   f
-      67         Zakiyya al-Meskin         Vianca Rodriguez  17   f
-      68         Zakiyya al-Meskin               Sarah Ford  26   f
-      69               Joel Curtis           Tyvonn Skinner  61   m
-      70               Joel Curtis           Alvina Tunnell  46   f
-      71              Ryan Stolley    Jamya Mosby-Beckworth  57   f
-      72              Misael Giron          Zumruda el-Dada   8   f
-      73              Misael Giron          Bryanna Kushner  11   f
-      74            Talaal al-Kazi           Qais el-Nasser  56   m
-      75           Naazim el-Ishak           Tanaree Nguyen  32   f
-      76           Naazim el-Ishak          Trent Hernandez  63   m
-      77           Naazim el-Ishak          Shelby Marshall  54   f
-      78           Naazim el-Ishak         Demetrius Mcneal  22   m
-      79         Carousel Franklin            Savanna Smith  67   f
-      80         Carousel Franklin         Luqmaan el-Nasir  83   m
-      81         Carousel Franklin           Alexa Buccieri  16   f
-      82         Carousel Franklin          Haley Robertson  38   f
-      83            Alvina Tunnell             Zaira Garcia  19   f
-      84           Zumruda el-Dada           Justin Vallejo  37   m
-      85           Zumruda el-Dada             Rayven Smith  46   f
-      86           Zumruda el-Dada        Waheeda al-Farhat  64   f
-      87           Trent Hernandez          Muneeb al-Latif  73   m
-      88           Trent Hernandez         Laquinn Sengdara  13   m
-      89           Shelby Marshall        Vanessa Blackmore  72   f
-      90           Shelby Marshall            Emily Lechman  12   f
-      91             Savanna Smith           Terhesa Litvak  52   f
-      92             Savanna Smith    Robert Ruschmeyer III  61   m
-      93             Savanna Smith           Jamileth Salas   9   f
-      94             Savanna Smith         Estephania Pinon   9   f
-      95             Savanna Smith          Brittany Nguyen  42   f
-      96            Justin Vallejo               Atif Redai  22   m
-      97           Muneeb al-Latif         Alexandra Devere  29   f
-      98          Laquinn Sengdara            Kylyn Letzler  15   f
-      99          Laquinn Sengdara           Jasmine Mathis  69   f
-      100         Laquinn Sengdara        Samuel Heinselman  17   m
-      101         Laquinn Sengdara          Abigail Johnson  21   f
-      102         Laquinn Sengdara           Elizabeth Mora  54   f
-      103         Laquinn Sengdara           Nataya Braxton  20   f
-      104         Laquinn Sengdara          Jameel el-Nazar   9   m
-      105    Robert Ruschmeyer III             Erin Crocker  26   f
-      106    Robert Ruschmeyer III            Jessica Hoang  80   f
-      107    Robert Ruschmeyer III              Kelvin Soto  71   m
-      108    Robert Ruschmeyer III          Deaijah Threats  57   f
-      109    Robert Ruschmeyer III                Emily Lim  77   f
-      110         Alexandra Devere             Meghan Acker  90   f
-      111        Samuel Heinselman              Sana Merlan  58   f
-      112        Samuel Heinselman             Justin Brown  23   m
-      113              Kelvin Soto        Yasmeen Fields II  35   f
-      114             Meghan Acker         Danielle Cintora  66   f
-      115             Justin Brown            Matthew Crowe  62   m
-      116             Justin Brown           Tony Fernandez  62   m
-      117             Justin Brown            Ronald Dalton  34   m
-      118             Justin Brown               Rosa Vigil  57   f
-      119        Yasmeen Fields II            Justin Aldava  44   f
-      120        Yasmeen Fields II            Colton Rogers  22   m
-      121            Matthew Crowe         Rosalio Aguinaga  57   m
-      122            Matthew Crowe       Aaron D Alessandro  63   m
-      123               Rosa Vigil         Samantha Hagerty   7   f
-      124               Rosa Vigil       Chykeiljah Purdham  46   f
-      125               Rosa Vigil        Mamdooh el-Salame  66   m
-      126            Justin Aldava       Joshua Vera-Flores   4   m
-      127            Justin Aldava          Scott Trousdale  10   m
-      128         Rosalio Aguinaga        Dylan Stolzenburg  68   m
-      129         Rosalio Aguinaga         Michael Robinson  68   m
-      130         Rosalio Aguinaga           Phillip Medina  12   m
-      131       Aaron D Alessandro            Israa el-Abdi  51   f
-      132       Aaron D Alessandro            Natalia Phung  51   f
-      133       Chykeiljah Purdham           Theodore Coons   8   m
-      134        Mamdooh el-Salame         Brittany Briseno  55   f
-      135         Michael Robinson            Cidney Miller  77   m
-      136         Michael Robinson           Kurstin Hodapp  22   f
-      137           Phillip Medina        Jocilynn Shumpert   2   f
-      138           Phillip Medina            Troy Leighton  53   m
-      139            Natalia Phung        Muzaina al-Baccus  31   f
-      140            Natalia Phung         Sameeha al-Javid  77   f
-      141            Natalia Phung     Canteskuya Lestenkof  76   f
-      142            Natalia Phung          Isaac Rodriguez  82   m
-      143            Natalia Phung               Brian Wang  12   m
-      144        Jocilynn Shumpert          Arnasya Wigfall  25   f
-      145        Jocilynn Shumpert       Brittany Alvizures  76   f
-      146            Troy Leighton      Shaelumiel Phillips  14   m
-      147            Troy Leighton         Karanveer Wilson  31   m
-      148            Troy Leighton          Ahlaam al-Aslam  90   f
-      149            Troy Leighton             Kelsey Dille  76   f
-      150     Canteskuya Lestenkof             Samuel Sands  30   m
-      151          Isaac Rodriguez             Bridgit Jobe  32   f
-      152          Arnasya Wigfall            Riley Piontek  78   m
-      153          Arnasya Wigfall            Vanessa Rojas  75   f
-      154          Arnasya Wigfall        Rasheeqa el-Abbas  76   f
-      155       Brittany Alvizures              Steven Lehi  88   m
-      156      Shaelumiel Phillips          Aarifa al-Nouri  80   f
-      157      Shaelumiel Phillips          Kelsi Dominguez  41   f
-      158      Shaelumiel Phillips    Maria Karlson-Pacheco  78   f
-      159      Shaelumiel Phillips                John Alam  11   m
-      160      Shaelumiel Phillips          Aqeela al-Pasha  57   f
-      161             Kelsey Dille Jonathan Knodel-Eldridge  79   m
-      162            Riley Piontek         Reymundo Herrera  28   m
-      163            Riley Piontek             Mariah Black   2   f
-      164            Vanessa Rojas           Trenice Pender  16   f
-      165        Rasheeqa el-Abbas               Bella Boss  82   f
-      166          Aarifa al-Nouri          Griselda Garcia  51   f
-      167          Aarifa al-Nouri            Reno Hoffmann  54   f
-      168          Kelsi Dominguez              Molly Wells  76   f
-      169          Kelsi Dominguez            Kayly Woehrel  56   f
-      170          Kelsi Dominguez               David Moak   5   m
-      171    Maria Karlson-Pacheco          Jazmyn Gallegos   1   f
-      172         Reymundo Herrera          Carl Levi Sharp  44   m
-      173         Reymundo Herrera          Yusri al-Khatib  76   m
-      174               Bella Boss          Jeffrey Donegan   3   m
-      175               David Moak           William Delger  15   m
-      176               David Moak               Dyami Polk  19   m
-      177               David Moak        Samantha Lockhart  76   f
-      178          Jazmyn Gallegos              Kylee Kelly  12   f
-      179          Yusri al-Khatib            Jose Escudero  43   m
-      180          Yusri al-Khatib        Huraira el-Masood   9   m
-      181          Yusri al-Khatib     Dominic Robinson III  90   m
-      182          Yusri al-Khatib          Daleel al-Sahli   7   m
-      183          Jeffrey Donegan    Badruddeen al-Bacchus  15   m
-      184          Jeffrey Donegan          Suhaa al-Moussa  54   f
-      185               Dyami Polk     Oscar Rodriguez Loya  64   m
-      186               Dyami Polk       Shaddaad el-Firman  21   m
-      187               Dyami Polk  Crystal Medina Castillo  37   f
-      188               Dyami Polk          Widdad al-Jamal  35   f
-      189               Dyami Polk            Lizeth Stapel  70   f
-      190        Samantha Lockhart          Paul Watkins Jr  70   m
-      191        Samantha Lockhart             Tione Dupont  59   f
-      192        Samantha Lockhart        Giovanni Sterling  77   m
-      193        Samantha Lockhart          Bandar al-Nouri  75   m
-      194        Samantha Lockhart       Annaliese Freiburg  84   f
-      195     Dominic Robinson III          Muhsin el-Irani  18   m
-      196     Dominic Robinson III            Briana Eshima  79   f
-      197     Oscar Rodriguez Loya       Aubreylin Deguzman  14   f
-      198     Oscar Rodriguez Loya               Elise Bugh  49   f
-      199     Oscar Rodriguez Loya        Erin Riley Doudna  56   f
-      200     Oscar Rodriguez Loya            Brianna Price  76   f
-      201          Widdad al-Jamal       Manuel Archambault  41   m
-      202          Widdad al-Jamal           Sham'a el-Arif  16   f
-      203          Widdad al-Jamal             Winston Pham   3   m
-      204       Annaliese Freiburg             Jaelyn Moore  29   f
-      205       Annaliese Freiburg         Trey-Logan Smith  89   m
-      206       Annaliese Freiburg            Caleb Ramirez  24   m
-      207       Annaliese Freiburg           Karen Sandoval  31   f
-      208          Muhsin el-Irani              Aaron Davis  39   m
-      209          Muhsin el-Irani         Timothy Schwartz  32   m
-      210          Muhsin el-Irani               Eric Okoye   9   m
-      211            Briana Eshima              Awf el-Rais  82   m
-      212               Elise Bugh              Cindy Cheng  39   f
-      213        Erin Riley Doudna       Patrick Paton-Ilse  12   m
-      214            Brianna Price             Jocelyn Diaz  54   f
-      215            Brianna Price          Elijah Anguiano  68   m
-      216       Manuel Archambault     Alexandra Kanchanlal  73   f
-      217       Manuel Archambault         Oghenemairo Ware  85   f
-      218       Manuel Archambault          Christian Ingle  52   m
-      219       Manuel Archambault          Timothy Seifert   3   m
-      220             Jaelyn Moore           Kimberly Leung  22   f
-      221             Jaelyn Moore           Kayla Isabelle   5   f
-      222              Aaron Davis           Baylen Wheeler  66   m
-      223              Aaron Davis             Jaliya Smith  68   f
-      224         Timothy Schwartz            Jay Goodstein  38   m
-      225         Timothy Schwartz            Tyler Garhart  57   m
-      226         Timothy Schwartz            Kibori Cooper  48   m
-      227               Eric Okoye           Farha el-Saidi  75   f
-      228              Cindy Cheng       Nabeel al-Mohammad   8   m
-      229          Christian Ingle             Alicia Vigil  28   f
-      230          Christian Ingle        Annnees al-Elamin  21   m
-      231           Kimberly Leung               Aqil Davis   2   m
-      232           Kimberly Leung         Zachary Mckenney  84   m
-      233             Jaliya Smith             Angeline Kim  52   f
-      234             Jaliya Smith            Pierce Parent  58   m
-      235             Jaliya Smith           Brenna Brockel  29   f
-      236            Tyler Garhart         Dalton Dickerson   7   m
-      237       Nabeel al-Mohammad        Hasana el-Hussein  30   f
-      238       Nabeel al-Mohammad        Jameela al-Salaam  11   f
-      239               Aqil Davis            Donald Dunlap  71   m
-      240               Aqil Davis           Alisha Crocker  50   f
-      241         Zachary Mckenney            Taylor Oblack  77   f
-      242         Zachary Mckenney             Jarnell Shah  43   m
-      243         Zachary Mckenney             Naomi Wilson  19   f
-      244         Zachary Mckenney            Elijah Reaves  40   m
-      245         Zachary Mckenney          Aasiya el-Malak  49   f
-      246         Zachary Mckenney         Redmond Arellano  11   m
-      247         Zachary Mckenney           Jawaad el-Sala  15   m
-      248         Zachary Mckenney          Ikram el-Khalil  61   m
-      249           Brenna Brockel             Eric Gilmore  46   m
-      250           Brenna Brockel          Arshad al-Sadri  69   m
-      251           Brenna Brockel          Rif'a al-Naderi  69   f
-      252           Brenna Brockel  Oswaldo Thomas Trujillo  38   m
-      253        Hasana el-Hussein        Muntasir al-Sayed  28   m
-      254        Hasana el-Hussein          Sabri al-Ismail  82   m
-      255            Donald Dunlap          Zaaid al-Jabbar  45   m
-      256            Donald Dunlap               David Bell  47   m
-      257             Jarnell Shah               Tylee Vang  19   f
-      258            Elijah Reaves            Amanda Garcia  85   f
-      259             Eric Gilmore          Margarita Terry  24   f
-      260             Eric Gilmore            Sidqi el-Naim  46   m
-      261          Arshad al-Sadri          Amber Autterson  71   f
-      262          Arshad al-Sadri            Austin Mulder  69   m
-      263          Rif'a al-Naderi        Alexandra Blalock   4   f
-      264          Rif'a al-Naderi             Joshua Jones  31   m
-      265  Oswaldo Thomas Trujillo           Mutee'a al-Aly  18   f
-      266  Oswaldo Thomas Trujillo            Vanessa Lopez  16   f
-      267  Oswaldo Thomas Trujillo        Christian Vaquera  53   m
-      268        Muntasir al-Sayed               Syed Nagai  62   m
-      269        Muntasir al-Sayed          Shelby Muhammad  87   m
-      270          Sabri al-Ismail          Nu'ma al-Arafat  28   f
-      271          Sabri al-Ismail        Shaheer al-Firman  42   m
-      272               Tylee Vang            Samara Bryant  42   f
-      273            Sidqi el-Naim             Linda Parker  84   f
-      274            Sidqi el-Naim        Hilaal el-Abdella  29   m
-      275          Amber Autterson         Kaleem al-Khalid  47   m
-      276          Amber Autterson               Ivan Perez  14   m
-      277        Alexandra Blalock     Angelica Orta Zepeda  48   f
-      278            Vanessa Lopez              Raul Chavez  89   m
-      279            Vanessa Lopez           Germaine Ealom  39   m
-      280            Vanessa Lopez           Gabriella Pont  17   f
-      281        Christian Vaquera             Tyler Wilson  20   m
-      282        Christian Vaquera       Almaasa al-Mustafa  61   f
-      283               Ivan Perez            Maris Manning   6   f
-      284     Angelica Orta Zepeda      Candace Plenty Wolf  28   f
-      285              Raul Chavez           Abiel Trujillo  83   m
-      286              Raul Chavez             Latha Wasson  68   m
-      287              Raul Chavez            Yadiel Malone  47   m
-      288             Tyler Wilson            Korren Harper  73   f
-      289             Tyler Wilson          Victoria Romero  24   f
-      290             Tyler Wilson             Avery Nguyen  42   m
-      291             Tyler Wilson        Maariya el-Younis  71   f
-      292            Maris Manning           Heather Orlady   9   f
-      293            Maris Manning         Giovana Monclova  78   f
-      294      Candace Plenty Wolf               Laura Ball  24   f
-      295      Candace Plenty Wolf      Brenda Molina-Brown  61   f
-      296             Avery Nguyen            Megan Cushing  49   f
-      297             Avery Nguyen         Tareef el-Naderi  53   m
-      298             Avery Nguyen       Mushtaaqa el-Qadir  63   f
-      299        Maariya el-Younis              Alana Weiss  29   f
-      300        Maariya el-Younis                  Tina Le  76   f
-      301        Maariya el-Younis          Precious Malloy  69   f
-      302           Heather Orlady       Sabaaha el-Sultana  63   f
-      303           Heather Orlady           Elias Martinez  50   m
-      304           Heather Orlady                Ziru Cung  58   f
-      305         Tareef el-Naderi      Tyrell Thomas-Moore  88   m
-      306         Tareef el-Naderi           Destiny Turner   7   f
-      307         Tareef el-Naderi           Kendrick Brown  51   m
-      308                  Tina Le                 Andy Kim  47   m
-      309                  Tina Le        Brittney Morrison  45   f
-      310                  Tina Le           Nathaniel Lone  83   m
-      311                  Tina Le            Brianna Nocon  30   f
-      312          Precious Malloy             Rachel Pruet  41   f
-      313           Elias Martinez            Matthew Trang  15   m
-      314           Elias Martinez           Sharron Cooper  27   f
-      315           Elias Martinez               Amy Tandon  88   f
-      316           Destiny Turner          Genessis Chacon  74   f
-      317        Brittney Morrison              Nakita Diaz   1   f
-      318        Brittney Morrison         Wasmaaa el-Hares  84   f
-      319           Nathaniel Lone                Nico Shea  79   m
-      320             Rachel Pruet       Tayyiba el-Khawaja  54   f
-      321             Rachel Pruet           Maurice Morgan  24   m
-      322             Rachel Pruet    Joey Hernandez Correa  37   m
-      323               Amy Tandon             Monica Glade   3   f
-      324               Amy Tandon           Anthony Deleon  48   m
-      325                Nico Shea           Brenden Hughes  82   m
-      326           Brenden Hughes             Avani Ansari  30   f
+                               from                        to age sex
+      1        Marquione Currington        Ghaaliba el-Hassen  90   f
+      2        Marquione Currington   Leslie Morales-Gonzalez   4   f
+      3          Ghaaliba el-Hassen           Qutb el-Ghattas  86   m
+      4          Ghaaliba el-Hassen          Labeeb el-Hariri  29   m
+      5     Leslie Morales-Gonzalez               Carla Moore  14   f
+      6     Leslie Morales-Gonzalez        Saabiqa al-Hammoud  85   f
+      7     Leslie Morales-Gonzalez            Zachary Farris  18   m
+      8            Labeeb el-Hariri               Joseph Koul  59   m
+      9                 Carla Moore              Alex Voliton  25   m
+      10                Carla Moore                 Mara Gast  34   f
+      11                Carla Moore       Dasha Willis-Arvizu  89   f
+      12                Carla Moore               Laura Smith   5   f
+      13         Saabiqa al-Hammoud          Justus Goodstein  63   m
+      14                  Mara Gast            Jordan Brandon  50   m
+      15                  Mara Gast           Michael Garhart   5   m
+      16                  Mara Gast    Kayla Vazquez Barcenaz  89   f
+      17        Dasha Willis-Arvizu       Kiyontus Howard III  74   m
+      18           Justus Goodstein        Alexandria Hoshiko  34   f
+      19           Justus Goodstein           Arhab el-Mourad  47   m
+      20           Justus Goodstein           Joseph Mckenney  85   m
+      21           Justus Goodstein              Sarah Walker  29   f
+      22        Kiyontus Howard III Micael Quinteros-Renteria  24   m
+      23         Alexandria Hoshiko             Kylie Warthen  46   f
+      24         Alexandria Hoshiko             Tyler Herrera  63   m
+      25         Alexandria Hoshiko            Sergio Velotta  19   m
+      26         Alexandria Hoshiko                 Corey Mao  24   f
+      27               Sarah Walker           Dylan Dickerson   9   m
+      28               Sarah Walker              Alyce Hodges  41   f
+      29               Sarah Walker        Kimuraamor Mizelle  72   f
+      30               Sarah Walker          Christopher Bell   6   m
+      31              Kylie Warthen          Raita el-Shehata   9   f
+      32                  Corey Mao               Evan Mulder  61   m
+      33                  Corey Mao              Lauren Garza  44   f
+      34               Alyce Hodges           Mahaa al-Arshad  71   f
+      35               Alyce Hodges              Dashawn Reed  34   m
+      36               Alyce Hodges         Aabdeen al-Maroun  75   m
+      37               Alyce Hodges           Mastoor al-Azer  69   m
+      38               Alyce Hodges           Deshawn Gallion  61   m
+      39               Alyce Hodges             Andrew Gibson  67   m
+      40         Kimuraamor Mizelle Makalia Hernandez Mendoza  64   f
+      41         Kimuraamor Mizelle            Tianna Coleman  11   f
+      42         Kimuraamor Mizelle            Hayley Roberts  59   f
+      43           Christopher Bell                Lewis Tani  61   m
+      44           Christopher Bell             Shalin Decker  66   f
+      45               Lauren Garza             Nkaujzoo Tran  16   f
+      46            Mahaa al-Arshad             Alexander Bly  81   m
+      47            Mahaa al-Arshad            Neelish Thrift  88   m
+      48            Deshawn Gallion                 Alex Thao  53   m
+      49            Deshawn Gallion            Alexander Ryan  53   m
+      50  Makalia Hernandez Mendoza              Israel Downs  45   m
+      51  Makalia Hernandez Mendoza              Olivia Close  42   f
+      52  Makalia Hernandez Mendoza            Hannah Johnson  42   f
+      53  Makalia Hernandez Mendoza          Maaiz al-Harroun  78   m
+      54                 Lewis Tani            Sabri el-Pasha  35   m
+      55                 Lewis Tani         Lizabeth Anderson  54   f
+      56                 Lewis Tani            Laaiqa al-Miah  54   f
+      57              Shalin Decker             Elijah Nguyen  68   m
+      58              Shalin Decker          Hilmi al-Mustafa   3   m
+      59              Shalin Decker              Darian Ramos  44   m
+      60              Alexander Bly          Elizabeth Taylor  35   f
+      61             Alexander Ryan          Leslie Gutierrez  23   f
+      62             Alexander Ryan           Ayyoob al-Sabet  62   m
+      63             Alexander Ryan          Quraish el-Aslam  35   m
+      64               Israel Downs              Joanne Daley  90   f
+      65               Israel Downs                Erica Rupp  25   f
+      66           Maaiz al-Harroun                  Mele Vue  41   f
+      67          Lizabeth Anderson             Mayra Jackson  17   f
+      68          Lizabeth Anderson               Anna Tipoti  26   f
+      69              Elijah Nguyen           Waleed el-Saleh  61   m
+      70              Elijah Nguyen         Shantavia Barnett  46   f
+      71           Hilmi al-Mustafa             Precious King  57   f
+      72               Darian Ramos          Azeeza al-Othman   8   f
+      73               Darian Ramos            Lynsz Martinez  11   f
+      74            Ayyoob al-Sabet                David Jack  56   m
+      75           Quraish el-Aslam               Se Quintana  32   f
+      76           Quraish el-Aslam           Saamir al-Kalil  63   m
+      77           Quraish el-Aslam             Sarah Hankins  54   f
+      78           Quraish el-Aslam               Cole Ponzio  22   m
+      79                 Erica Rupp         Majeeda el-Baluch  67   f
+      80                 Erica Rupp          Andrew O'Dorisio  83   m
+      81                 Erica Rupp          Nusaiba al-Ishak  16   f
+      82                 Erica Rupp               Sarai Sells  38   f
+      83          Shantavia Barnett            Tiffani Harris  19   f
+      84           Azeeza al-Othman            Isaac Cardenas  37   m
+      85           Azeeza al-Othman           Alicia Mehrotra  46   f
+      86           Azeeza al-Othman         Shaamila al-Galla  64   f
+      87            Saamir al-Kalil            Adam Gallagher  73   m
+      88            Saamir al-Kalil              Zachary Abel  13   m
+      89              Sarah Hankins           Waleeda al-Alam  72   f
+      90              Sarah Hankins           Kelly Langcauon  12   f
+      91          Majeeda el-Baluch             Julia Storrer  52   f
+      92          Majeeda el-Baluch            Qais el-Younes  61   m
+      93          Majeeda el-Baluch            Cicely Hickson   9   f
+      94          Majeeda el-Baluch      Aimee Nakarmi Dhital   9   f
+      95          Majeeda el-Baluch            Taylor Metzger  42   f
+      96             Isaac Cardenas          Ridwaan el-Zaman  22   m
+      97             Adam Gallagher           Azeema al-Rayes  29   f
+      98               Zachary Abel               Karen Garza  15   f
+      99               Zachary Abel       Humaira el-Ghaffari  69   f
+      100              Zachary Abel            Subhi al-Qasim  17   m
+      101              Zachary Abel      Brittany Habtemicael  21   f
+      102              Zachary Abel                Amy Nguyen  54   f
+      103              Zachary Abel           Alyssa Enriquez  20   f
+      104              Zachary Abel             Jose Sandoval   9   m
+      105            Qais el-Younes              Maya Bunting  26   f
+      106            Qais el-Younes        Mubaaraka al-Habib  80   f
+      107            Qais el-Younes               Luis Chacon  71   m
+      108            Qais el-Younes              Asia Osborne  57   f
+      109            Qais el-Younes             Caitlyn Kirby  77   f
+      110           Azeema al-Rayes             Marley Wilson  90   f
+      111            Subhi al-Qasim              Bryanna Diaz  58   f
+      112            Subhi al-Qasim            Mondray Thomas  23   m
+      113               Luis Chacon         Humaina al-Habeeb  35   f
+      114             Marley Wilson           Paige Mendicino  66   f
+      115            Mondray Thomas             Ishan Kumagai  62   m
+      116            Mondray Thomas             Arnold Madera  62   m
+      117            Mondray Thomas            Vincent Murphy  34   m
+      118            Mondray Thomas             Joanna Guerra  57   f
+      119         Humaina al-Habeeb           Dashelle Milner  44   f
+      120         Humaina al-Habeeb               Te Hamilton  22   m
+      121             Ishan Kumagai             Derek Cooksey  57   m
+      122             Ishan Kumagai           Suhaib al-Hoque  63   m
+      123             Joanna Guerra         Joelle Valenzuela   7   f
+      124             Joanna Guerra           Christine Bajwa  46   f
+      125             Joanna Guerra       Jalen Herrera-Vigil  66   m
+      126           Dashelle Milner              Sir Williams   4   m
+      127           Dashelle Milner               Anthony Fox  10   m
+      128             Derek Cooksey         Dong-Keun Puentes  68   m
+      129             Derek Cooksey                   Alex Vu  68   m
+      130             Derek Cooksey          Alexander Nakata  12   m
+      131           Suhaib al-Hoque          Naqiyya al-Nawaz  51   f
+      132           Suhaib al-Hoque            Alia Archuleta  51   f
+      133           Christine Bajwa       Benjamin Cunningham   8   m
+      134       Jalen Herrera-Vigil           Mai Jing Eshima  55   f
+      135                   Alex Vu               Joshua Ward  77   m
+      136                   Alex Vu             Kalika Bostic  22   f
+      137          Alexander Nakata           Maazina el-Amin   2   f
+      138          Alexander Nakata             Albert Marley  53   m
+      139            Alia Archuleta                Nhi Arvelo  31   f
+      140            Alia Archuleta             Shania Wilson  77   f
+      141            Alia Archuleta          Mackenzie Conley  76   f
+      142            Alia Archuleta              Angel Silvas  82   m
+      143            Alia Archuleta       Jeremiah Whiteplume  12   m
+      144           Maazina el-Amin             Keyona Dydell  25   f
+      145           Maazina el-Amin                Laura Sher  76   f
+      146             Albert Marley         Tuvshinbayar Tran  14   m
+      147             Albert Marley               Joseph Heng  31   m
+      148             Albert Marley            Essence Neloms  90   f
+      149             Albert Marley            Maiya Hazelman  76   f
+      150          Mackenzie Conley              Tucker Manis  30   m
+      151              Angel Silvas Shayla Hernandez Martinez  32   f
+      152             Keyona Dydell                  Mori Hsu  78   m
+      153             Keyona Dydell           Gretchen Prieto  75   f
+      154             Keyona Dydell           Kameela al-Zaki  76   f
+      155                Laura Sher           Siddeeqi el-Aly  88   m
+      156         Tuvshinbayar Tran         Zumruda al-Arshad  80   f
+      157         Tuvshinbayar Tran              Nimesha Kane  41   f
+      158         Tuvshinbayar Tran               Jennifer An  78   f
+      159         Tuvshinbayar Tran           Jaeson Malhotra  11   m
+      160         Tuvshinbayar Tran       Brittanyclaire Neff  57   f
+      161            Maiya Hazelman     Julian Garcia-Barrios  79   m
+      162                  Mori Hsu            Matthew Welter  28   m
+      163                  Mori Hsu            Kendall Rhoads   2   f
+      164           Gretchen Prieto              Lashay Barry  16   f
+      165           Kameela al-Zaki           Antaiaja Cromer  82   f
+      166         Zumruda al-Arshad            Jazmen Johnson  51   f
+      167         Zumruda al-Arshad        Angelina Hernandez  54   f
+      168              Nimesha Kane               Alysia King  76   f
+      169              Nimesha Kane              Stevie Jaime  56   f
+      170              Nimesha Kane            Fikri al-Amara   5   m
+      171               Jennifer An       Gabriella Two  Crow   1   f
+      172            Matthew Welter              Yutitham Tan  44   m
+      173            Matthew Welter         Ramalaan el-Zafar  76   m
+      174           Antaiaja Cromer    Carlo Ceazar Phanekham   3   m
+      175            Fikri al-Amara            Brandon Bailey  15   m
+      176            Fikri al-Amara         Mu'taz al-Shabazz  19   m
+      177            Fikri al-Amara               Ana Guijosa  76   f
+      178       Gabriella Two  Crow          Jaylynn Gonzalez  12   f
+      179         Ramalaan el-Zafar        Shukri el-Mohammed  43   m
+      180         Ramalaan el-Zafar   Abdul Ghafoor al-Farooq   9   m
+      181         Ramalaan el-Zafar              Ethan Turner  90   m
+      182         Ramalaan el-Zafar            James Colligan   7   m
+      183    Carlo Ceazar Phanekham       Treyvon Stadelbauer  15   m
+      184    Carlo Ceazar Phanekham               Courtni Day  54   f
+      185         Mu'taz al-Shabazz       Raashid el-Shehadeh  64   m
+      186         Mu'taz al-Shabazz            Kristian Palma  21   m
+      187         Mu'taz al-Shabazz               Ellen Lopez  37   f
+      188         Mu'taz al-Shabazz             Nuzha el-Ally  35   f
+      189         Mu'taz al-Shabazz             Serena Gaiser  70   f
+      190               Ana Guijosa            Taamir al-Kaba  70   m
+      191               Ana Guijosa             Crystal Mares  59   f
+      192               Ana Guijosa           Faaris el-Sarah  77   m
+      193               Ana Guijosa              Utkarsh Ngan  75   m
+      194               Ana Guijosa           Tiffany Lenahan  84   f
+      195              Ethan Turner            Joshua Sanchez  18   m
+      196              Ethan Turner          Lolette Robinson  79   f
+      197       Raashid el-Shehadeh           Hannah Williams  14   f
+      198       Raashid el-Shehadeh            Mariah Simmons  49   f
+      199       Raashid el-Shehadeh              Dawna Beeton  56   f
+      200       Raashid el-Shehadeh                 Mia Lumba  76   f
+      201             Nuzha el-Ally            David Reichman  41   m
+      202             Nuzha el-Ally             Anisa Hatcher  16   f
+      203             Nuzha el-Ally            Khongmong Tong   3   m
+      204           Tiffany Lenahan        Mackenzie Mcmullen  29   f
+      205           Tiffany Lenahan             Thomas Mosher  89   m
+      206           Tiffany Lenahan           Nawaar al-Amiri  24   m
+      207           Tiffany Lenahan             Sade Phillips  31   f
+      208            Joshua Sanchez            Michael Navajo  39   m
+      209            Joshua Sanchez           Ernesto Cachola  32   m
+      210            Joshua Sanchez           Emmanuel Ibarra   9   m
+      211          Lolette Robinson            Shane Santiago  82   m
+      212            Mariah Simmons           Rachel Mcdonald  39   f
+      213              Dawna Beeton          Saleet al-Rahimi  12   m
+      214                 Mia Lumba   Savanna Delatorre-Lopez  54   f
+      215                 Mia Lumba            Shuaib al-Imam  68   m
+      216            David Reichman           Whitney Qureshi  73   f
+      217            David Reichman          Chanise Armbrust  85   f
+      218            David Reichman            Jamaal el-Reza  52   m
+      219            David Reichman         Trever Feuerstein   3   m
+      220        Mackenzie Mcmullen           Dalicia Wilkins  22   f
+      221        Mackenzie Mcmullen          Ramla al-Massoud   5   f
+      222            Michael Navajo        Mu,Aawiya al-Murad  66   m
+      223            Michael Navajo          Jameela al-Rahim  68   f
+      224           Ernesto Cachola          Taaj al-Siddique  38   m
+      225           Ernesto Cachola              James Morgan  57   m
+      226           Ernesto Cachola            Pedro Sendejas  48   m
+      227           Emmanuel Ibarra          Sameeha al-Zaher  75   f
+      228           Rachel Mcdonald            Desmond Castro   8   m
+      229            Jamaal el-Reza               Elijah Ross  28   f
+      230            Jamaal el-Reza             Tucker Flores  21   m
+      231           Dalicia Wilkins              Yuvorn Ahmad   2   m
+      232           Dalicia Wilkins           Jericho Powless  84   m
+      233          Jameela al-Rahim               Claire Osse  52   f
+      234          Jameela al-Rahim           Dearee Scurlock  58   m
+      235          Jameela al-Rahim            Hafsa el-Pasha  29   f
+      236              James Morgan        Cornelius Maryland   7   m
+      237            Desmond Castro           Danielle Finken  30   f
+      238            Desmond Castro              Itzel Zamora  11   f
+      239              Yuvorn Ahmad           Yusri al-Salame  71   m
+      240              Yuvorn Ahmad     Nelly Aviles Montalvo  50   f
+      241           Jericho Powless        Qamraaa al-Shaheed  77   f
+      242           Jericho Powless               Cody Parker  43   m
+      243           Jericho Powless    Nakrista Kelly-Corichi  19   f
+      244           Jericho Powless               Connor Hahs  40   m
+      245           Jericho Powless              Eraina Smith  49   f
+      246           Jericho Powless          Orville Trammell  11   m
+      247           Jericho Powless              Edward Lopez  15   m
+      248           Jericho Powless          Sidqi al-Hussein  61   m
+      249            Hafsa el-Pasha               Kevin Huang  46   m
+      250            Hafsa el-Pasha               Yusuf Shahi  69   m
+      251            Hafsa el-Pasha             Ruby Martinez  69   f
+      252            Hafsa el-Pasha             Jameel Curtis  38   m
+      253           Danielle Finken              Ryan Sorrell  28   m
+      254           Danielle Finken              Otoniel Huff  82   m
+      255           Yusri al-Salame         Mastoor al-Shaker  45   m
+      256           Yusri al-Salame      Marco Gomez-Buchanan  47   m
+      257               Cody Parker      Nafeesa el-Mohiuddin  19   f
+      258               Connor Hahs         Exzinia O'Donnell  85   f
+      259               Kevin Huang           Caroline Garcia  24   f
+      260               Kevin Huang          Muhaajir al-Ozer  46   m
+      261               Yusuf Shahi             Jazmine Mcgee  71   f
+      262               Yusuf Shahi      Jumail al-Salahuddin  69   m
+      263             Ruby Martinez        Nawwaara al-Hammad   4   f
+      264             Ruby Martinez           Trevor Videtzky  31   m
+      265             Jameel Curtis              Kimiko Smith  18   f
+      266             Jameel Curtis          Ghaaliya al-Azzi  16   f
+      267             Jameel Curtis          Mansoor el-Salem  53   m
+      268              Ryan Sorrell          Nizaam al-Akbari  62   m
+      269              Ryan Sorrell                 Micah Cha  87   m
+      270              Otoniel Huff         Carmelita Baldwin  28   f
+      271              Otoniel Huff       Christian Rodriguez  42   m
+      272      Nafeesa el-Mohiuddin          Laraena Sturgeon  42   f
+      273          Muhaajir al-Ozer         Kashauna Thompson  84   f
+      274          Muhaajir al-Ozer                 Daniel La  29   m
+      275             Jazmine Mcgee             Austin Powell  47   m
+      276             Jazmine Mcgee             Russell Stott  14   m
+      277        Nawwaara al-Hammad             Diksha Javaid  48   f
+      278          Ghaaliya al-Azzi            Ronnie Labadie  89   m
+      279          Ghaaliya al-Azzi        Alexander Mitchell  39   m
+      280          Ghaaliya al-Azzi            Shamari Batson  17   f
+      281          Mansoor el-Salem          Brandon Marchman  20   m
+      282          Mansoor el-Salem               Medhavi Tan  61   f
+      283             Russell Stott            Jasmine Thomas   6   f
+      284             Diksha Javaid           De'Chelle Yorks  28   f
+      285            Ronnie Labadie          Keeman Martzloff  83   m
+      286            Ronnie Labadie              Henry Arnick  68   m
+      287            Ronnie Labadie              Cairra Woods  47   m
+      288          Brandon Marchman                Monica Chu  73   f
+      289          Brandon Marchman           Gloria Sandoval  24   f
+      290          Brandon Marchman   Alexander Rangel Mendez  42   m
+      291          Brandon Marchman          Taylor Pickering  71   f
+      292            Jasmine Thomas      Cheyanna Bear-Flores   9   f
+      293            Jasmine Thomas          Brittany Shaheen  78   f
+      294           De'Chelle Yorks               Alexis Wall  24   f
+      295           De'Chelle Yorks        Rhiannon Aviado II  61   f
+      296   Alexander Rangel Mendez             Isabella Sena  49   f
+      297   Alexander Rangel Mendez                Samuel San  53   m
+      298   Alexander Rangel Mendez         Nadheera el-Ahmad  63   f
+      299          Taylor Pickering             Alicia Nguyen  29   f
+      300          Taylor Pickering              Lafaith Bean  76   f
+      301          Taylor Pickering          Morgan Tollivoro  69   f
+      302      Cheyanna Bear-Flores             Deisha Cooper  63   f
+      303      Cheyanna Bear-Flores            Weston Henzler  50   m
+      304      Cheyanna Bear-Flores              Shelby Jiron  58   f
+      305                Samuel San            Mathurin Baker  88   m
+      306                Samuel San           Hissa el-Yassin   7   f
+      307                Samuel San  Collin Valencia Anchondo  51   m
+      308              Lafaith Bean            Rida al-Firman  47   m
+      309              Lafaith Bean            Afaaf el-Anwar  45   f
+      310              Lafaith Bean             Joshua Molina  83   m
+      311              Lafaith Bean            Rebekah Norman  30   f
+      312          Morgan Tollivoro         Nichole Scharnell  41   f
+      313            Weston Henzler              Shawn Miller  15   m
+      314            Weston Henzler          Habeeba al-Salam  27   f
+      315            Weston Henzler              Renae Mcadoo  88   f
+      316           Hissa el-Yassin          Bertha Andreatta  74   f
+      317            Afaaf el-Anwar           Aliyya al-Abdoo   1   f
+      318            Afaaf el-Anwar         Chandel Caramillo  84   f
+      319             Joshua Molina  Jeremy Montelongo Declay  79   m
+      320         Nichole Scharnell           Mikayla Hopkins  54   f
+      321         Nichole Scharnell           Markese Conners  24   m
+      322         Nichole Scharnell        Christian Espinosa  37   m
+      323              Renae Mcadoo          Rashele Freeland   3   f
+      324              Renae Mcadoo             Qaaid al-Sala  48   m
+      325  Jeremy Montelongo Declay           Jez-Mas Powells  82   m
+      326           Jez-Mas Powells            Cassandra Long  30   f
           date_first_contact date_last_contact was_case           status
       1           2022-12-31        2023-01-05        Y             case
       2           2022-12-30        2023-01-01        Y             case
-      3           2023-01-02        2023-01-04        N          unknown
+      3           2023-01-02        2023-01-04        N lost_to_followup
       4           2023-01-05        2023-01-05        Y             case
       5           2023-01-07        2023-01-08        Y             case
       6           2023-01-03        2023-01-06        Y             case
       7           2023-01-02        2023-01-04        N   under_followup
-      8           2023-01-02        2023-01-06        N   under_followup
+      8           2023-01-02        2023-01-06        N          unknown
       9           2023-01-06        2023-01-06        Y             case
       10          2023-01-01        2023-01-06        Y             case
       11          2023-01-06        2023-01-08        Y             case
-      12          2023-01-05        2023-01-07        N   under_followup
+      12          2023-01-05        2023-01-07        N          unknown
       13          2023-01-02        2023-01-08        Y             case
-      14          2023-01-14        2023-01-17        N lost_to_followup
-      15          2023-01-10        2023-01-13        N          unknown
+      14          2023-01-14        2023-01-17        N          unknown
+      15          2023-01-10        2023-01-13        N lost_to_followup
       16          2023-01-07        2023-01-13        N lost_to_followup
       17          2023-01-12        2023-01-17        Y             case
       18          2023-01-09        2023-01-11        Y             case
       19          2023-01-11        2023-01-15        N   under_followup
-      20          2023-01-12        2023-01-15        N          unknown
+      20          2023-01-12        2023-01-15        N   under_followup
       21          2023-01-12        2023-01-14        Y             case
       22          2023-01-12        2023-01-16        N   under_followup
       23          2023-01-10        2023-01-16        Y             case
       24          2023-01-12        2023-01-14        N   under_followup
       25          2023-01-13        2023-01-16        N   under_followup
       26          2023-01-11        2023-01-13        Y             case
-      27          2023-01-15        2023-01-16        N          unknown
+      27          2023-01-15        2023-01-16        N   under_followup
       28          2023-01-11        2023-01-15        Y             case
       29          2023-01-14        2023-01-17        Y             case
       30          2023-01-14        2023-01-16        Y             case
-      31          2023-01-17        2023-01-18        N   under_followup
+      31          2023-01-17        2023-01-18        N lost_to_followup
       32          2023-01-12        2023-01-16        Y             case
       33          2023-01-13        2023-01-17        Y             case
       34          2023-01-22        2023-01-23        Y             case
-      35          2023-01-19        2023-01-23        N lost_to_followup
+      35          2023-01-19        2023-01-23        N   under_followup
       36          2023-01-26        2023-01-26        N   under_followup
       37          2023-01-20        2023-01-22        Y             case
       38          2023-01-19        2023-01-23        Y             case
-      39          2023-01-21        2023-01-23        N lost_to_followup
+      39          2023-01-21        2023-01-23        N   under_followup
       40          2023-01-19        2023-01-22        Y             case
-      41          2023-01-15        2023-01-20        N lost_to_followup
-      42          2023-01-19        2023-01-21        N   under_followup
+      41          2023-01-15        2023-01-20        N   under_followup
+      42          2023-01-19        2023-01-21        N          unknown
       43          2023-01-23        2023-01-24        Y             case
       44          2023-01-23        2023-01-25        Y             case
       45          2023-01-15        2023-01-16        N   under_followup
       46          2023-01-23        2023-01-28        Y             case
       47          2023-01-25        2023-01-29        N   under_followup
-      48          2023-01-26        2023-01-27        N   under_followup
+      48          2023-01-26        2023-01-27        N lost_to_followup
       49          2023-01-22        2023-01-24        Y             case
       50          2023-01-23        2023-01-28        Y             case
-      51          2023-01-22        2023-01-27        N   under_followup
+      51          2023-01-22        2023-01-27        N          unknown
       52          2023-01-25        2023-01-26        Y             case
       53          2023-01-24        2023-01-26        Y             case
       54          2023-01-23        2023-01-26        Y             case
       55          2023-01-18        2023-01-23        Y             case
-      56          2023-01-25        2023-01-27        N lost_to_followup
+      56          2023-01-25        2023-01-27        N   under_followup
       57          2023-01-19        2023-01-23        Y             case
       58          2023-01-22        2023-01-26        Y             case
       59          2023-01-27        2023-01-27        Y             case
       60          2023-02-04        2023-02-04        N   under_followup
-      61          2023-01-29        2023-01-30        N lost_to_followup
+      61          2023-01-29        2023-01-30        N          unknown
       62          2023-01-26        2023-01-28        Y             case
       63          2023-01-25        2023-01-30        Y             case
       64          2023-01-27        2023-01-30        Y             case
@@ -725,8 +725,8 @@
       71          2023-01-20        2023-01-25        N   under_followup
       72          2023-02-01        2023-02-04        Y             case
       73          2023-01-29        2023-01-31        N   under_followup
-      74          2023-01-31        2023-02-04        N lost_to_followup
-      75          2023-01-24        2023-01-30        N lost_to_followup
+      74          2023-01-31        2023-02-04        N   under_followup
+      75          2023-01-24        2023-01-30        N   under_followup
       76          2023-01-28        2023-02-02        Y             case
       77          2023-01-27        2023-02-02        Y             case
       78          2023-01-29        2023-02-01        N   under_followup
@@ -734,7 +734,7 @@
       80          2023-01-31        2023-02-05        N   under_followup
       81          2023-02-01        2023-02-02        N   under_followup
       82          2023-02-01        2023-02-04        N   under_followup
-      83          2023-02-01        2023-02-02        N   under_followup
+      83          2023-02-01        2023-02-02        N          unknown
       84          2023-02-01        2023-02-03        Y             case
       85          2023-01-28        2023-02-01        N   under_followup
       86          2023-01-30        2023-02-03        N   under_followup
@@ -744,54 +744,54 @@
       90          2023-01-31        2023-02-04        N   under_followup
       91          2023-01-28        2023-02-04        N   under_followup
       92          2023-01-30        2023-02-04        Y             case
-      93          2023-02-01        2023-02-06        N   under_followup
-      94          2023-02-01        2023-02-03        N lost_to_followup
+      93          2023-02-01        2023-02-06        N lost_to_followup
+      94          2023-02-01        2023-02-03        N   under_followup
       95          2023-01-31        2023-02-04        N   under_followup
       96          2023-02-04        2023-02-06        Y             case
       97          2023-02-03        2023-02-05        Y             case
       98          2023-02-02        2023-02-04        N   under_followup
       99          2023-02-02        2023-02-05        N   under_followup
       100         2023-01-30        2023-02-04        Y             case
-      101         2023-02-04        2023-02-08        N          unknown
+      101         2023-02-04        2023-02-08        N   under_followup
       102         2023-01-31        2023-02-07        N   under_followup
       103         2023-02-05        2023-02-06        N   under_followup
-      104         2023-01-30        2023-02-04        N lost_to_followup
-      105         2023-02-01        2023-02-04        N   under_followup
+      104         2023-01-30        2023-02-04        N   under_followup
+      105         2023-02-01        2023-02-04        N lost_to_followup
       106         2023-02-01        2023-02-06        N   under_followup
       107         2023-02-05        2023-02-08        Y             case
       108         2023-02-04        2023-02-10        N   under_followup
       109         2023-02-02        2023-02-08        N   under_followup
       110         2023-02-06        2023-02-08        Y             case
-      111         2023-02-08        2023-02-12        N   under_followup
+      111         2023-02-08        2023-02-12        N lost_to_followup
       112         2023-02-10        2023-02-11        Y             case
       113         2023-02-14        2023-02-19        Y             case
       114         2023-02-11        2023-02-12        N   under_followup
       115         2023-02-13        2023-02-16        Y             case
       116         2023-02-10        2023-02-13        N   under_followup
-      117         2023-02-15        2023-02-16        N lost_to_followup
+      117         2023-02-15        2023-02-16        N   under_followup
       118         2023-02-10        2023-02-13        Y             case
       119         2023-02-16        2023-02-18        Y             case
       120         2023-02-18        2023-02-18        N   under_followup
       121         2023-03-02        2023-03-02        Y             case
       122         2023-02-26        2023-03-03        Y             case
-      123         2023-02-18        2023-02-23        N   under_followup
+      123         2023-02-18        2023-02-23        N lost_to_followup
       124         2023-02-24        2023-02-26        Y             case
       125         2023-02-17        2023-02-23        Y             case
       126         2023-02-18        2023-02-21        N   under_followup
       127         2023-02-16        2023-02-19        N   under_followup
-      128         2023-03-01        2023-03-05        N   under_followup
+      128         2023-03-01        2023-03-05        N lost_to_followup
       129         2023-03-06        2023-03-07        Y             case
       130         2023-03-03        2023-03-04        Y             case
       131         2023-03-04        2023-03-09        N   under_followup
       132         2023-03-07        2023-03-09        Y             case
-      133         2023-02-27        2023-03-02        N lost_to_followup
+      133         2023-02-27        2023-03-02        N   under_followup
       134         2023-03-02        2023-03-07        N   under_followup
-      135         2023-03-08        2023-03-10        N   under_followup
-      136         2023-03-02        2023-03-09        N lost_to_followup
+      135         2023-03-08        2023-03-10        N          unknown
+      136         2023-03-02        2023-03-09        N   under_followup
       137         2023-03-06        2023-03-11        Y             case
       138         2023-03-07        2023-03-11        Y             case
       139         2023-03-16        2023-03-18        N   under_followup
-      140         2023-03-14        2023-03-18        N lost_to_followup
+      140         2023-03-14        2023-03-18        N   under_followup
       141         2023-03-18        2023-03-23        Y             case
       142         2023-03-20        2023-03-20        Y             case
       143         2023-03-19        2023-03-21        N   under_followup
@@ -801,21 +801,21 @@
       147         2023-03-08        2023-03-12        N   under_followup
       148         2023-03-07        2023-03-09        N   under_followup
       149         2023-03-10        2023-03-11        Y             case
-      150         2023-03-26        2023-03-29        N          unknown
+      150         2023-03-26        2023-03-29        N   under_followup
       151         2023-03-23        2023-03-27        N   under_followup
       152         2023-03-16        2023-03-21        Y             case
       153         2023-03-16        2023-03-19        Y             case
       154         2023-03-12        2023-03-19        Y             case
-      155         2023-03-10        2023-03-14        N lost_to_followup
+      155         2023-03-10        2023-03-14        N   under_followup
       156         2023-03-13        2023-03-14        Y             case
       157         2023-03-12        2023-03-14        Y             case
       158         2023-03-12        2023-03-17        Y             case
-      159         2023-03-15        2023-03-18        N lost_to_followup
-      160         2023-03-10        2023-03-15        N lost_to_followup
+      159         2023-03-15        2023-03-18        N   under_followup
+      160         2023-03-10        2023-03-15        N          unknown
       161         2023-03-06        2023-03-12        N   under_followup
       162         2023-03-12        2023-03-17        Y             case
       163         2023-03-15        2023-03-18        Y             case
-      164         2023-03-26        2023-03-29        N   under_followup
+      164         2023-03-26        2023-03-29        N lost_to_followup
       165         2023-03-21        2023-03-25        Y             case
       166         2023-03-16        2023-03-19        N   under_followup
       167         2023-03-20        2023-03-22        N   under_followup
@@ -831,24 +831,24 @@
       177         2023-03-19        2023-03-24        Y             case
       178         2023-03-23        2023-03-24        N   under_followup
       179         2023-03-20        2023-03-21        N   under_followup
-      180         2023-03-20        2023-03-20        N          unknown
+      180         2023-03-20        2023-03-20        N lost_to_followup
       181         2023-03-20        2023-03-20        Y             case
-      182         2023-03-11        2023-03-17        N   under_followup
-      183         2023-03-28        2023-04-02        N   under_followup
-      184         2023-04-01        2023-04-02        N   under_followup
+      182         2023-03-11        2023-03-17        N lost_to_followup
+      183         2023-03-28        2023-04-02        N lost_to_followup
+      184         2023-04-01        2023-04-02        N lost_to_followup
       185         2023-03-29        2023-04-01        Y             case
       186         2023-03-24        2023-03-26        N   under_followup
       187         2023-03-27        2023-03-29        N   under_followup
       188         2023-03-27        2023-03-28        Y             case
-      189         2023-03-27        2023-03-30        N lost_to_followup
+      189         2023-03-27        2023-03-30        N   under_followup
       190         2023-03-25        2023-03-29        N   under_followup
-      191         2023-03-25        2023-03-27        N   under_followup
+      191         2023-03-25        2023-03-27        N lost_to_followup
       192         2023-03-23        2023-03-27        N          unknown
       193         2023-03-24        2023-03-29        N   under_followup
       194         2023-03-23        2023-03-28        Y             case
       195         2023-03-25        2023-03-29        Y             case
       196         2023-03-26        2023-03-28        Y             case
-      197         2023-04-08        2023-04-08        N lost_to_followup
+      197         2023-04-08        2023-04-08        N   under_followup
       198         2023-04-02        2023-04-07        Y             case
       199         2023-04-03        2023-04-06        Y             case
       200         2023-03-31        2023-04-03        Y             case
@@ -857,28 +857,28 @@
       203         2023-03-28        2023-04-01        N   under_followup
       204         2023-03-24        2023-03-29        Y             case
       205         2023-03-27        2023-03-27        N   under_followup
-      206         2023-03-24        2023-03-30        N lost_to_followup
-      207         2023-03-26        2023-03-28        N lost_to_followup
+      206         2023-03-24        2023-03-30        N   under_followup
+      207         2023-03-26        2023-03-28        N          unknown
       208         2023-03-28        2023-04-01        Y             case
       209         2023-03-30        2023-04-06        Y             case
       210         2023-04-03        2023-04-05        Y             case
-      211         2023-03-28        2023-04-01        N lost_to_followup
+      211         2023-03-28        2023-04-01        N   under_followup
       212         2023-04-07        2023-04-08        Y             case
       213         2023-04-08        2023-04-08        Y             case
       214         2023-04-07        2023-04-10        N   under_followup
       215         2023-04-10        2023-04-10        N   under_followup
-      216         2023-04-02        2023-04-03        N   under_followup
+      216         2023-04-02        2023-04-03        N          unknown
       217         2023-04-02        2023-04-06        N   under_followup
       218         2023-04-06        2023-04-06        Y             case
       219         2023-04-04        2023-04-07        N   under_followup
       220         2023-04-01        2023-04-05        Y             case
-      221         2023-03-31        2023-04-05        N   under_followup
+      221         2023-03-31        2023-04-05        N lost_to_followup
       222         2023-04-04        2023-04-06        N   under_followup
       223         2023-04-03        2023-04-06        Y             case
-      224         2023-04-03        2023-04-05        N          unknown
+      224         2023-04-03        2023-04-05        N   under_followup
       225         2023-04-01        2023-04-04        Y             case
-      226         2023-04-02        2023-04-04        N          unknown
-      227         2023-04-04        2023-04-07        N   under_followup
+      226         2023-04-02        2023-04-04        N   under_followup
+      227         2023-04-04        2023-04-07        N lost_to_followup
       228         2023-04-11        2023-04-16        Y             case
       229         2023-04-09        2023-04-12        Y             case
       230         2023-04-11        2023-04-12        N   under_followup
@@ -891,10 +891,10 @@
       237         2023-04-14        2023-04-17        Y             case
       238         2023-04-11        2023-04-13        N          unknown
       239         2023-04-03        2023-04-05        Y             case
-      240         2023-04-03        2023-04-06        N          unknown
+      240         2023-04-03        2023-04-06        N lost_to_followup
       241         2023-04-06        2023-04-12        N   under_followup
       242         2023-04-09        2023-04-12        Y             case
-      243         2023-04-09        2023-04-14        N          unknown
+      243         2023-04-09        2023-04-14        N   under_followup
       244         2023-04-10        2023-04-16        Y             case
       245         2023-04-09        2023-04-11        N   under_followup
       246         2023-04-07        2023-04-10        N   under_followup
@@ -906,8 +906,8 @@
       252         2023-04-10        2023-04-11        Y             case
       253         2023-04-13        2023-04-16        Y             case
       254         2023-04-14        2023-04-18        Y             case
-      255         2023-04-17        2023-04-18        N lost_to_followup
-      256         2023-04-11        2023-04-16        N   under_followup
+      255         2023-04-17        2023-04-18        N   under_followup
+      256         2023-04-11        2023-04-16        N lost_to_followup
       257         2023-04-13        2023-04-14        Y             case
       258         2023-04-15        2023-04-16        N   under_followup
       259         2023-04-11        2023-04-18        N   under_followup
@@ -916,41 +916,41 @@
       262         2023-04-09        2023-04-14        N lost_to_followup
       263         2023-04-12        2023-04-21        Y             case
       264         2023-04-16        2023-04-21        Y             case
-      265         2023-04-24        2023-04-26        N   under_followup
+      265         2023-04-24        2023-04-26        N          unknown
       266         2023-04-19        2023-04-25        Y             case
       267         2023-04-23        2023-04-25        Y             case
-      268         2023-04-10        2023-04-17        N   under_followup
+      268         2023-04-10        2023-04-17        N lost_to_followup
       269         2023-04-13        2023-04-16        N   under_followup
-      270         2023-04-16        2023-04-19        N          unknown
+      270         2023-04-16        2023-04-19        N   under_followup
       271         2023-04-13        2023-04-18        N   under_followup
       272         2023-04-16        2023-04-17        N   under_followup
-      273         2023-04-25        2023-04-28        N lost_to_followup
+      273         2023-04-25        2023-04-28        N   under_followup
       274         2023-04-25        2023-04-27        N   under_followup
-      275         2023-04-16        2023-04-16        N          unknown
+      275         2023-04-16        2023-04-16        N   under_followup
       276         2023-04-11        2023-04-15        Y             case
       277         2023-04-23        2023-04-26        Y             case
       278         2023-04-21        2023-04-22        Y             case
       279         2023-04-18        2023-04-22        Y             case
       280         2023-04-21        2023-04-25        N          unknown
       281         2023-04-21        2023-04-25        Y             case
-      282         2023-04-26        2023-04-27        N          unknown
+      282         2023-04-26        2023-04-27        N lost_to_followup
       283         2023-05-05        2023-05-06        Y             case
       284         2023-04-28        2023-04-29        Y             case
-      285         2023-04-28        2023-04-28        N lost_to_followup
-      286         2023-04-27        2023-04-30        N lost_to_followup
+      285         2023-04-28        2023-04-28        N   under_followup
+      286         2023-04-27        2023-04-30        N          unknown
       287         2023-04-26        2023-04-28        N   under_followup
-      288         2023-04-22        2023-04-24        N   under_followup
-      289         2023-04-22        2023-04-23        N   under_followup
+      288         2023-04-22        2023-04-24        N lost_to_followup
+      289         2023-04-22        2023-04-23        N lost_to_followup
       290         2023-04-19        2023-04-21        Y             case
       291         2023-04-21        2023-04-23        Y             case
       292         2023-05-03        2023-05-05        Y             case
       293         2023-05-07        2023-05-08        N   under_followup
-      294         2023-05-03        2023-05-09        N   under_followup
+      294         2023-05-03        2023-05-09        N          unknown
       295         2023-05-06        2023-05-08        Y             case
-      296         2023-05-03        2023-05-04        N   under_followup
+      296         2023-05-03        2023-05-04        N lost_to_followup
       297         2023-05-01        2023-05-03        Y             case
-      298         2023-04-28        2023-05-01        N lost_to_followup
-      299         2023-04-25        2023-04-29        N   under_followup
+      298         2023-04-28        2023-05-01        N   under_followup
+      299         2023-04-25        2023-04-29        N          unknown
       300         2023-04-25        2023-04-27        Y             case
       301         2023-04-20        2023-04-25        Y             case
       302         2023-04-30        2023-05-09        N   under_followup
@@ -958,18 +958,18 @@
       304         2023-05-04        2023-05-07        N   under_followup
       305         2023-05-04        2023-05-06        N   under_followup
       306         2023-04-28        2023-05-04        Y             case
-      307         2023-05-03        2023-05-06        N          unknown
-      308         2023-04-26        2023-04-30        N   under_followup
+      307         2023-05-03        2023-05-06        N   under_followup
+      308         2023-04-26        2023-04-30        N          unknown
       309         2023-04-19        2023-04-25        Y             case
       310         2023-04-25        2023-04-26        Y             case
       311         2023-04-24        2023-04-27        N   under_followup
       312         2023-04-25        2023-04-29        Y             case
-      313         2023-05-08        2023-05-08        N lost_to_followup
-      314         2023-05-04        2023-05-08        N          unknown
+      313         2023-05-08        2023-05-08        N   under_followup
+      314         2023-05-04        2023-05-08        N   under_followup
       315         2023-05-05        2023-05-08        Y             case
       316         2023-05-07        2023-05-10        N   under_followup
       317         2023-04-23        2023-04-26        N   under_followup
-      318         2023-04-25        2023-04-25        N          unknown
+      318         2023-04-25        2023-04-25        N lost_to_followup
       319         2023-04-22        2023-04-28        Y             case
       320         2023-04-22        2023-04-29        N   under_followup
       321         2023-04-27        2023-04-30        N   under_followup

--- a/tests/testthat/_snaps/sim_outbreak.md
+++ b/tests/testthat/_snaps/sim_outbreak.md
@@ -1,3 +1,985 @@
+# sim_outbreak works as expected with defaults
+
+    Code
+      sim_outbreak()
+    Output
+      $linelist
+           id                case_name case_type sex age date_onset date_admission
+      1     1           Dylan Quintana confirmed   m  59 2023-01-01           <NA>
+      2     2             Briana Owens confirmed   f  90 2023-01-01     2023-01-06
+      3     3          Elaine Phillips  probable   f   4 2023-01-02     2023-01-08
+      4     5            Justin Farley  probable   m  29 2023-01-04           <NA>
+      5     6         Sadeeda el-Obeid suspected   f  14 2023-01-05           <NA>
+      6     7           Mouneek Israel  probable   f  85 2023-01-06           <NA>
+      7    10             Taylor Jones confirmed   m  25 2023-01-13           <NA>
+      8    11             Theresa Wurm confirmed   f  34 2023-01-11           <NA>
+      9    12 Brianna Villalobos Nunez  probable   f  89 2023-01-13           <NA>
+      10   14         Ayyoob al-Younis confirmed   m  63 2023-01-11           <NA>
+      11   18        Muneer al-Abdalla confirmed   m  74 2023-01-14     2023-01-19
+      12   19            Sara Schwindt confirmed   f  34 2023-01-12           <NA>
+      13   22           Katherine Phan confirmed   f  29 2023-01-12           <NA>
+      14   24       Kimberly Valentine  probable   f  46 2023-01-13           <NA>
+      15   27            Ty'Ese Porter  probable   f  24 2023-01-14           <NA>
+      16   29           Courtnee Miles suspected   f  41 2023-01-21           <NA>
+      17   30             Alexah Stott confirmed   f  72 2023-01-19           <NA>
+      18   31         Labeeb el-Saadeh confirmed   m   6 2023-01-20           <NA>
+      19   33        Gunther Rodriguez confirmed   m  61 2023-01-14           <NA>
+      20   34           Aqeela el-Akel confirmed   f  44 2023-01-14           <NA>
+      21   35              Mayra Vigil confirmed   f  71 2023-01-27           <NA>
+      22   38              Shane Binol suspected   m  69 2023-01-23           <NA>
+      23   39            Travis Atwood confirmed   m  61 2023-01-23           <NA>
+      24   41              Monique Yoo  probable   f  64 2023-01-24           <NA>
+      25   44             Joseph Bruce confirmed   m  61 2023-01-22           <NA>
+      26   45        Khaira el-Ibrahim  probable   f  66 2023-01-22           <NA>
+      27   47           Desmond Garnes confirmed   m  81 2023-01-28           <NA>
+      28   50           Myles Wakasugi confirmed   m  53 2023-01-28           <NA>
+      29   51            Joshua Moreno confirmed   m  45 2023-01-29           <NA>
+      30   53    Normajeanne Walker Jr suspected   f  42 2023-02-02           <NA>
+      31   54          Miles Cournoyer confirmed   m  78 2023-02-03           <NA>
+      32   55   Alec Thompson-Brashear confirmed   m  35 2023-01-24           <NA>
+      33   56        Zakiyya al-Meskin confirmed   f  54 2023-01-26           <NA>
+      34   58              Joel Curtis confirmed   m  68 2023-01-25           <NA>
+      35   59             Ryan Stolley  probable   m   3 2023-01-23           <NA>
+      36   60             Misael Giron  probable   m  44 2023-01-29     2023-02-02
+      37   63           Talaal al-Kazi confirmed   m  62 2023-01-31     2023-02-09
+      38   64          Naazim el-Ishak confirmed   m  35 2023-01-29           <NA>
+      39   65         Angelique Lobato suspected   f  90 2023-02-03           <NA>
+      40   66        Carousel Franklin  probable   f  25 2023-02-01           <NA>
+      41   71           Alvina Tunnell confirmed   f  46 2023-01-29           <NA>
+      42   73          Zumruda el-Dada confirmed   f   8 2023-02-01     2023-02-05
+      43   77          Trent Hernandez confirmed   m  63 2023-01-30           <NA>
+      44   78          Shelby Marshall  probable   f  54 2023-01-29           <NA>
+      45   80            Savanna Smith  probable   f  67 2023-02-03           <NA>
+      46   85           Justin Vallejo confirmed   m  37 2023-02-02           <NA>
+      47   88          Muneeb al-Latif confirmed   m  73 2023-01-30     2023-02-05
+      48   89         Laquinn Sengdara suspected   m  13 2023-02-02     2023-02-07
+      49   90        Vanessa Blackmore confirmed   f  72 2023-02-01     2023-02-03
+      50   93    Robert Ruschmeyer III confirmed   m  61 2023-02-04     2023-02-10
+      51   97               Atif Redai confirmed   m  22 2023-02-05           <NA>
+      52   98         Alexandra Devere suspected   f  29 2023-02-04           <NA>
+      53  101        Samuel Heinselman  probable   m  17 2023-02-07     2023-02-10
+      54  108              Kelvin Soto confirmed   m  71 2023-02-14           <NA>
+      55  111             Meghan Acker  probable   f  90 2023-02-09           <NA>
+      56  113             Justin Brown confirmed   m  23 2023-02-12           <NA>
+      57  114        Yasmeen Fields II  probable   f  35 2023-02-16     2023-02-19
+      58  116            Matthew Crowe suspected   m  62 2023-02-24     2023-02-28
+      59  119               Rosa Vigil  probable   f  57 2023-02-23           <NA>
+      60  120            Justin Aldava suspected   f  44 2023-02-18           <NA>
+      61  122         Rosalio Aguinaga suspected   m  57 2023-03-02           <NA>
+      62  123       Aaron D Alessandro confirmed   m  63 2023-03-08           <NA>
+      63  125       Chykeiljah Purdham confirmed   f  46 2023-02-28           <NA>
+      64  126        Mamdooh el-Salame suspected   m  66 2023-02-26           <NA>
+      65  130         Michael Robinson  probable   m  68 2023-03-07           <NA>
+      66  131           Phillip Medina confirmed   m  12 2023-03-09           <NA>
+      67  133            Natalia Phung confirmed   f  51 2023-03-18           <NA>
+      68  138        Jocilynn Shumpert confirmed   f   2 2023-03-10           <NA>
+      69  139            Troy Leighton confirmed   m  53 2023-03-09           <NA>
+      70  142     Canteskuya Lestenkof  probable   f  76 2023-03-23           <NA>
+      71  143          Isaac Rodriguez suspected   m  82 2023-03-21           <NA>
+      72  145          Arnasya Wigfall suspected   f  25 2023-03-15     2023-03-17
+      73  146       Brittany Alvizures  probable   f  76 2023-03-13           <NA>
+      74  147      Shaelumiel Phillips suspected   m  14 2023-03-13     2023-03-17
+      75  150             Kelsey Dille suspected   f  76 2023-03-11     2023-03-13
+      76  153            Riley Piontek suspected   m  78 2023-03-15           <NA>
+      77  154            Vanessa Rojas suspected   f  75 2023-03-24           <NA>
+      78  155        Rasheeqa el-Abbas suspected   f  76 2023-03-24           <NA>
+      79  157          Aarifa al-Nouri confirmed   f  80 2023-03-18     2023-03-24
+      80  158          Kelsi Dominguez confirmed   f  41 2023-03-18           <NA>
+      81  159    Maria Karlson-Pacheco confirmed   f  78 2023-03-19           <NA>
+      82  163         Reymundo Herrera confirmed   m  28 2023-03-15           <NA>
+      83  164             Mariah Black suspected   f   2 2023-03-21           <NA>
+      84  166               Bella Boss confirmed   f  82 2023-03-26           <NA>
+      85  171               David Moak suspected   m   5 2023-03-22     2023-03-25
+      86  172          Jazmyn Gallegos suspected   f   1 2023-03-20           <NA>
+      87  173          Carl Levi Sharp suspected   m  44 2023-03-19           <NA>
+      88  174          Yusri al-Khatib confirmed   m  76 2023-03-16           <NA>
+      89  175          Jeffrey Donegan confirmed   m   3 2023-03-29           <NA>
+      90  176           William Delger suspected   m  15 2023-03-25           <NA>
+      91  177               Dyami Polk  probable   m  19 2023-03-26           <NA>
+      92  178        Samantha Lockhart confirmed   f  76 2023-03-25           <NA>
+      93  182     Dominic Robinson III  probable   m  90 2023-03-27           <NA>
+      94  186     Oscar Rodriguez Loya confirmed   m  64 2023-04-03           <NA>
+      95  189          Widdad al-Jamal  probable   f  35 2023-03-29           <NA>
+      96  195       Annaliese Freiburg confirmed   f  84 2023-03-27           <NA>
+      97  196          Muhsin el-Irani  probable   m  18 2023-03-30           <NA>
+      98  197            Briana Eshima  probable   f  79 2023-03-28           <NA>
+      99  199               Elise Bugh confirmed   f  49 2023-04-07           <NA>
+      100 200        Erin Riley Doudna suspected   f  56 2023-04-05           <NA>
+      101 201            Brianna Price confirmed   f  76 2023-04-07           <NA>
+      102 202       Manuel Archambault suspected   m  41 2023-04-03     2023-04-10
+      103 205             Jaelyn Moore  probable   f  29 2023-04-01           <NA>
+      104 209              Aaron Davis  probable   m  39 2023-04-05           <NA>
+      105 210         Timothy Schwartz confirmed   m  32 2023-04-01           <NA>
+      106 211               Eric Okoye suspected   m   9 2023-04-06     2023-04-09
+      107 213              Cindy Cheng  probable   f  39 2023-04-11     2023-04-13
+      108 214       Patrick Paton-Ilse  probable   m  12 2023-04-17           <NA>
+      109 219          Christian Ingle  probable   m  52 2023-04-10     2023-04-13
+      110 221           Kimberly Leung confirmed   f  22 2023-04-02           <NA>
+      111 224             Jaliya Smith confirmed   f  68 2023-04-08           <NA>
+      112 226            Tyler Garhart  probable   m  57 2023-04-06           <NA>
+      113 229       Nabeel al-Mohammad confirmed   m   8 2023-04-12     2023-04-15
+      114 230             Alicia Vigil suspected   f  28 2023-04-12     2023-04-22
+      115 232               Aqil Davis  probable   m   2 2023-04-02           <NA>
+      116 233         Zachary Mckenney  probable   m  84 2023-04-09           <NA>
+      117 234             Angeline Kim suspected   f  52 2023-04-09           <NA>
+      118 235            Pierce Parent confirmed   m  58 2023-04-12     2023-04-17
+      119 236           Brenna Brockel confirmed   f  29 2023-04-10     2023-04-17
+      120 238        Hasana el-Hussein  probable   f  30 2023-04-14           <NA>
+      121 240            Donald Dunlap confirmed   m  71 2023-04-15           <NA>
+      122 243             Jarnell Shah confirmed   m  43 2023-04-13     2023-04-15
+      123 245            Elijah Reaves suspected   m  40 2023-04-15           <NA>
+      124 250             Eric Gilmore suspected   m  46 2023-04-16           <NA>
+      125 251          Arshad al-Sadri confirmed   m  69 2023-04-11           <NA>
+      126 252          Rif'a al-Naderi confirmed   f  69 2023-04-20           <NA>
+      127 253  Oswaldo Thomas Trujillo suspected   m  38 2023-04-20           <NA>
+      128 254        Muntasir al-Sayed confirmed   m  28 2023-04-16     2023-04-20
+      129 255          Sabri al-Ismail confirmed   m  82 2023-04-16           <NA>
+      130 258               Tylee Vang suspected   f  19 2023-04-14           <NA>
+      131 261            Sidqi el-Naim  probable   m  46 2023-04-26           <NA>
+      132 262          Amber Autterson confirmed   f  71 2023-04-13           <NA>
+      133 264        Alexandra Blalock  probable   f   4 2023-04-25     2023-04-27
+      134 265             Joshua Jones confirmed   m  31 2023-04-25           <NA>
+      135 267            Vanessa Lopez confirmed   f  16 2023-04-20           <NA>
+      136 268        Christian Vaquera confirmed   m  53 2023-04-21           <NA>
+      137 277               Ivan Perez confirmed   m  14 2023-05-01           <NA>
+      138 278     Angelica Orta Zepeda suspected   f  48 2023-04-28           <NA>
+      139 279              Raul Chavez  probable   m  89 2023-04-25     2023-05-01
+      140 280           Germaine Ealom  probable   m  39 2023-04-26           <NA>
+      141 282             Tyler Wilson confirmed   m  20 2023-04-21           <NA>
+      142 284            Maris Manning confirmed   f   6 2023-05-03           <NA>
+      143 285      Candace Plenty Wolf  probable   f  28 2023-05-05           <NA>
+      144 291             Avery Nguyen confirmed   m  42 2023-05-01     2023-05-10
+      145 292        Maariya el-Younis confirmed   f  71 2023-04-23           <NA>
+      146 293           Heather Orlady suspected   f   9 2023-05-05           <NA>
+      147 296      Brenda Molina-Brown suspected   f  61 2023-05-06           <NA>
+      148 298         Tareef el-Naderi confirmed   m  53 2023-05-02           <NA>
+      149 301                  Tina Le suspected   f  76 2023-04-23           <NA>
+      150 302          Precious Malloy confirmed   f  69 2023-04-26           <NA>
+      151 304           Elias Martinez confirmed   m  50 2023-05-07           <NA>
+      152 307           Destiny Turner confirmed   f   7 2023-05-09           <NA>
+      153 310        Brittney Morrison confirmed   f  45 2023-04-24           <NA>
+      154 311           Nathaniel Lone confirmed   m  83 2023-04-25           <NA>
+      155 313             Rachel Pruet  probable   f  41 2023-04-27           <NA>
+      156 316               Amy Tandon confirmed   f  88 2023-05-10           <NA>
+      157 320                Nico Shea suspected   m  79 2023-05-01           <NA>
+      158 326           Brenden Hughes  probable   m  82 2023-05-08     2023-05-21
+            outcome date_outcome date_first_contact date_last_contact ct_value
+      1   recovered         <NA>               <NA>              <NA>     26.3
+      2        died   2023-01-19         2022-12-31        2023-01-05     26.3
+      3        died   2023-01-08         2022-12-30        2023-01-01       NA
+      4   recovered         <NA>         2023-01-05        2023-01-05       NA
+      5   recovered         <NA>         2023-01-07        2023-01-08       NA
+      6        died   2023-01-15         2023-01-03        2023-01-06       NA
+      7   recovered         <NA>         2023-01-06        2023-01-06     26.3
+      8   recovered         <NA>         2023-01-01        2023-01-06     26.3
+      9   recovered         <NA>         2023-01-06        2023-01-08       NA
+      10  recovered         <NA>         2023-01-02        2023-01-08     26.3
+      11  recovered         <NA>         2023-01-12        2023-01-17     26.3
+      12       died   2023-03-02         2023-01-09        2023-01-11     26.3
+      13  recovered         <NA>         2023-01-12        2023-01-14     26.3
+      14  recovered         <NA>         2023-01-10        2023-01-16       NA
+      15  recovered         <NA>         2023-01-11        2023-01-13       NA
+      16  recovered         <NA>         2023-01-11        2023-01-15       NA
+      17  recovered         <NA>         2023-01-14        2023-01-17     26.3
+      18  recovered         <NA>         2023-01-14        2023-01-16     26.3
+      19  recovered         <NA>         2023-01-12        2023-01-16     26.3
+      20  recovered         <NA>         2023-01-13        2023-01-17     26.3
+      21  recovered         <NA>         2023-01-22        2023-01-23     26.3
+      22       died   2023-01-28         2023-01-20        2023-01-22       NA
+      23  recovered         <NA>         2023-01-19        2023-01-23     26.3
+      24  recovered         <NA>         2023-01-19        2023-01-22       NA
+      25  recovered         <NA>         2023-01-23        2023-01-24     26.3
+      26  recovered         <NA>         2023-01-23        2023-01-25       NA
+      27  recovered         <NA>         2023-01-23        2023-01-28     26.3
+      28  recovered         <NA>         2023-01-22        2023-01-24     26.3
+      29  recovered         <NA>         2023-01-23        2023-01-28     26.3
+      30  recovered         <NA>         2023-01-25        2023-01-26       NA
+      31  recovered         <NA>         2023-01-24        2023-01-26     26.3
+      32  recovered         <NA>         2023-01-23        2023-01-26     26.3
+      33  recovered         <NA>         2023-01-18        2023-01-23     26.3
+      34  recovered         <NA>         2023-01-19        2023-01-23     26.3
+      35  recovered         <NA>         2023-01-22        2023-01-26       NA
+      36       died   2023-02-14         2023-01-27        2023-01-27       NA
+      37       died   2023-02-17         2023-01-26        2023-01-28     26.3
+      38  recovered         <NA>         2023-01-25        2023-01-30     26.3
+      39  recovered         <NA>         2023-01-27        2023-01-30       NA
+      40  recovered         <NA>         2023-01-27        2023-01-31       NA
+      41  recovered         <NA>         2023-01-30        2023-01-31     26.3
+      42       died   2023-02-10         2023-02-01        2023-02-04     26.3
+      43  recovered         <NA>         2023-01-28        2023-02-02     26.3
+      44  recovered         <NA>         2023-01-27        2023-02-02       NA
+      45  recovered         <NA>         2023-02-03        2023-02-04       NA
+      46  recovered         <NA>         2023-02-01        2023-02-03     26.3
+      47  recovered         <NA>         2023-01-31        2023-02-01     26.3
+      48  recovered         <NA>         2023-01-30        2023-02-02       NA
+      49  recovered         <NA>         2023-01-31        2023-01-31     26.3
+      50  recovered         <NA>         2023-01-30        2023-02-04     26.3
+      51       died   2023-02-18         2023-02-04        2023-02-06     26.3
+      52  recovered         <NA>         2023-02-03        2023-02-05       NA
+      53  recovered         <NA>         2023-01-30        2023-02-04       NA
+      54  recovered         <NA>         2023-02-05        2023-02-08     26.3
+      55  recovered         <NA>         2023-02-06        2023-02-08       NA
+      56  recovered         <NA>         2023-02-10        2023-02-11     26.3
+      57  recovered         <NA>         2023-02-14        2023-02-19       NA
+      58       died   2023-03-28         2023-02-13        2023-02-16       NA
+      59  recovered         <NA>         2023-02-10        2023-02-13       NA
+      60  recovered         <NA>         2023-02-16        2023-02-18       NA
+      61  recovered         <NA>         2023-03-02        2023-03-02       NA
+      62  recovered         <NA>         2023-02-26        2023-03-03     26.3
+      63  recovered         <NA>         2023-02-24        2023-02-26     26.3
+      64  recovered         <NA>         2023-02-17        2023-02-23       NA
+      65  recovered         <NA>         2023-03-06        2023-03-07       NA
+      66  recovered         <NA>         2023-03-03        2023-03-04     26.3
+      67  recovered         <NA>         2023-03-07        2023-03-09     26.3
+      68  recovered         <NA>         2023-03-06        2023-03-11     26.3
+      69  recovered         <NA>         2023-03-07        2023-03-11     26.3
+      70  recovered         <NA>         2023-03-18        2023-03-23       NA
+      71  recovered         <NA>         2023-03-20        2023-03-20       NA
+      72       died   2023-03-28         2023-03-07        2023-03-12       NA
+      73  recovered         <NA>         2023-03-10        2023-03-14       NA
+      74       died   2023-04-11         2023-03-06        2023-03-11       NA
+      75       died   2023-03-21         2023-03-10        2023-03-11       NA
+      76  recovered         <NA>         2023-03-16        2023-03-21       NA
+      77  recovered         <NA>         2023-03-16        2023-03-19       NA
+      78  recovered         <NA>         2023-03-12        2023-03-19       NA
+      79       died   2023-04-02         2023-03-13        2023-03-14     26.3
+      80  recovered         <NA>         2023-03-12        2023-03-14     26.3
+      81  recovered         <NA>         2023-03-12        2023-03-17     26.3
+      82  recovered         <NA>         2023-03-12        2023-03-17     26.3
+      83  recovered         <NA>         2023-03-15        2023-03-18       NA
+      84  recovered         <NA>         2023-03-21        2023-03-25     26.3
+      85       died   2023-03-30         2023-03-16        2023-03-20       NA
+      86  recovered         <NA>         2023-03-18        2023-03-21       NA
+      87  recovered         <NA>         2023-03-17        2023-03-18       NA
+      88  recovered         <NA>         2023-03-20        2023-03-21     26.3
+      89  recovered         <NA>         2023-03-26        2023-03-27     26.3
+      90       died   2023-04-11         2023-03-24        2023-03-24       NA
+      91  recovered         <NA>         2023-03-22        2023-03-24       NA
+      92  recovered         <NA>         2023-03-19        2023-03-24     26.3
+      93  recovered         <NA>         2023-03-20        2023-03-20       NA
+      94  recovered         <NA>         2023-03-29        2023-04-01     26.3
+      95  recovered         <NA>         2023-03-27        2023-03-28       NA
+      96  recovered         <NA>         2023-03-23        2023-03-28     26.3
+      97  recovered         <NA>         2023-03-25        2023-03-29       NA
+      98       died   2023-04-06         2023-03-26        2023-03-28       NA
+      99  recovered         <NA>         2023-04-02        2023-04-07     26.3
+      100 recovered         <NA>         2023-04-03        2023-04-06       NA
+      101 recovered         <NA>         2023-03-31        2023-04-03     26.3
+      102      died   2023-05-01         2023-03-28        2023-04-01       NA
+      103 recovered         <NA>         2023-03-24        2023-03-29       NA
+      104 recovered         <NA>         2023-03-28        2023-04-01       NA
+      105 recovered         <NA>         2023-03-30        2023-04-06     26.3
+      106      died   2023-04-17         2023-04-03        2023-04-05       NA
+      107      died   2023-05-03         2023-04-07        2023-04-08       NA
+      108      died   2023-05-09         2023-04-08        2023-04-08       NA
+      109 recovered         <NA>         2023-04-06        2023-04-06       NA
+      110 recovered         <NA>         2023-04-01        2023-04-05     26.3
+      111 recovered         <NA>         2023-04-03        2023-04-06     26.3
+      112 recovered         <NA>         2023-04-01        2023-04-04       NA
+      113 recovered         <NA>         2023-04-11        2023-04-16     26.3
+      114 recovered         <NA>         2023-04-09        2023-04-12       NA
+      115 recovered         <NA>         2023-04-05        2023-04-06       NA
+      116 recovered         <NA>         2023-04-01        2023-04-03       NA
+      117 recovered         <NA>         2023-04-01        2023-04-09       NA
+      118 recovered         <NA>         2023-04-04        2023-04-08     26.3
+      119      died   2023-04-24         2023-04-12        2023-04-13     26.3
+      120      died   2023-05-02         2023-04-14        2023-04-17       NA
+      121 recovered         <NA>         2023-04-03        2023-04-05     26.3
+      122 recovered         <NA>         2023-04-09        2023-04-12     26.3
+      123 recovered         <NA>         2023-04-10        2023-04-16       NA
+      124 recovered         <NA>         2023-04-06        2023-04-11       NA
+      125 recovered         <NA>         2023-04-07        2023-04-12     26.3
+      126 recovered         <NA>         2023-04-04        2023-04-11     26.3
+      127 recovered         <NA>         2023-04-10        2023-04-11       NA
+      128 recovered         <NA>         2023-04-13        2023-04-16     26.3
+      129 recovered         <NA>         2023-04-14        2023-04-18     26.3
+      130 recovered         <NA>         2023-04-13        2023-04-14       NA
+      131 recovered         <NA>         2023-04-15        2023-04-18       NA
+      132 recovered         <NA>         2023-04-14        2023-04-14     26.3
+      133 recovered         <NA>         2023-04-12        2023-04-21       NA
+      134 recovered         <NA>         2023-04-16        2023-04-21     26.3
+      135 recovered         <NA>         2023-04-19        2023-04-25     26.3
+      136      died   2023-05-04         2023-04-23        2023-04-25     26.3
+      137 recovered         <NA>         2023-04-11        2023-04-15     26.3
+      138 recovered         <NA>         2023-04-23        2023-04-26       NA
+      139      died   2023-05-07         2023-04-21        2023-04-22       NA
+      140 recovered         <NA>         2023-04-18        2023-04-22       NA
+      141 recovered         <NA>         2023-04-21        2023-04-25     26.3
+      142 recovered         <NA>         2023-05-05        2023-05-06     26.3
+      143 recovered         <NA>         2023-04-28        2023-04-29       NA
+      144      died   2023-05-28         2023-04-19        2023-04-21     26.3
+      145 recovered         <NA>         2023-04-21        2023-04-23     26.3
+      146 recovered         <NA>         2023-05-03        2023-05-05       NA
+      147 recovered         <NA>         2023-05-06        2023-05-08       NA
+      148 recovered         <NA>         2023-05-01        2023-05-03     26.3
+      149 recovered         <NA>         2023-04-25        2023-04-27       NA
+      150 recovered         <NA>         2023-04-20        2023-04-25     26.3
+      151 recovered         <NA>         2023-05-08        2023-05-10     26.3
+      152 recovered         <NA>         2023-04-28        2023-05-04     26.3
+      153 recovered         <NA>         2023-04-19        2023-04-25     26.3
+      154 recovered         <NA>         2023-04-25        2023-04-26     26.3
+      155 recovered         <NA>         2023-04-25        2023-04-29       NA
+      156 recovered         <NA>         2023-05-05        2023-05-08     26.3
+      157 recovered         <NA>         2023-04-22        2023-04-28       NA
+      158      died   2023-05-22         2023-05-01        2023-05-03       NA
+      
+      $contacts
+                              from                       to age sex
+      1             Dylan Quintana             Briana Owens  90   f
+      2             Dylan Quintana          Elaine Phillips   4   f
+      3               Briana Owens           Noori el-Abbas  86   m
+      4               Briana Owens            Justin Farley  29   m
+      5            Elaine Phillips         Sadeeda el-Obeid  14   f
+      6            Elaine Phillips           Mouneek Israel  85   f
+      7            Elaine Phillips          Joseph Petersen  18   m
+      8              Justin Farley               Steven Dye  59   m
+      9           Sadeeda el-Obeid             Taylor Jones  25   m
+      10          Sadeeda el-Obeid             Theresa Wurm  34   f
+      11          Sadeeda el-Obeid Brianna Villalobos Nunez  89   f
+      12          Sadeeda el-Obeid              Jahnee Ward   5   f
+      13            Mouneek Israel         Ayyoob al-Younis  63   m
+      14              Theresa Wurm             Michael Moon  50   m
+      15              Theresa Wurm        Aaron Albershardt   5   m
+      16              Theresa Wurm        Jennifer Muenchow  89   f
+      17  Brianna Villalobos Nunez        Muneer al-Abdalla  74   m
+      18          Ayyoob al-Younis            Sara Schwindt  34   f
+      19          Ayyoob al-Younis     Dylan Mancinas Ramos  47   m
+      20          Ayyoob al-Younis           Douglas Miller  85   m
+      21          Ayyoob al-Younis           Katherine Phan  29   f
+      22         Muneer al-Abdalla        Lawrence Mitchell  24   m
+      23             Sara Schwindt       Kimberly Valentine  46   f
+      24             Sara Schwindt        Denzel Washington  63   m
+      25             Sara Schwindt            Awad al-Islam  19   m
+      26             Sara Schwindt            Ty'Ese Porter  24   f
+      27            Katherine Phan             Joshua Shire   9   m
+      28            Katherine Phan           Courtnee Miles  41   f
+      29            Katherine Phan             Alexah Stott  72   f
+      30            Katherine Phan         Labeeb el-Saadeh   6   m
+      31        Kimberly Valentine          Alondra Mendoza   9   f
+      32             Ty'Ese Porter        Gunther Rodriguez  61   m
+      33             Ty'Ese Porter           Aqeela el-Akel  44   f
+      34            Courtnee Miles              Mayra Vigil  71   f
+      35            Courtnee Miles             Travis Mckee  34   m
+      36            Courtnee Miles              Daniel Chen  75   m
+      37            Courtnee Miles              Shane Binol  69   m
+      38            Courtnee Miles            Travis Atwood  61   m
+      39            Courtnee Miles            Donovan Lopez  67   m
+      40              Alexah Stott              Monique Yoo  64   f
+      41              Alexah Stott              Alaina Moua  11   f
+      42              Alexah Stott         Khawla al-Hannan  59   f
+      43          Labeeb el-Saadeh             Joseph Bruce  61   m
+      44          Labeeb el-Saadeh        Khaira el-Ibrahim  66   f
+      45            Aqeela el-Akel              Zoe Garrett  16   f
+      46               Mayra Vigil           Desmond Garnes  81   m
+      47               Mayra Vigil           Isaac Cisneros  88   m
+      48             Travis Atwood               Hogan Tong  53   m
+      49             Travis Atwood           Myles Wakasugi  53   m
+      50               Monique Yoo            Joshua Moreno  45   m
+      51               Monique Yoo                Emily Lam  42   f
+      52               Monique Yoo    Normajeanne Walker Jr  42   f
+      53               Monique Yoo          Miles Cournoyer  78   m
+      54              Joseph Bruce   Alec Thompson-Brashear  35   m
+      55              Joseph Bruce        Zakiyya al-Meskin  54   f
+      56              Joseph Bruce           Julianna Mazza  54   f
+      57         Khaira el-Ibrahim              Joel Curtis  68   m
+      58         Khaira el-Ibrahim             Ryan Stolley   3   m
+      59         Khaira el-Ibrahim             Misael Giron  44   m
+      60            Desmond Garnes      Mercedes Drinkwater  35   f
+      61            Myles Wakasugi        Saalima al-Moradi  23   f
+      62            Myles Wakasugi           Talaal al-Kazi  62   m
+      63            Myles Wakasugi          Naazim el-Ishak  35   m
+      64             Joshua Moreno         Angelique Lobato  90   f
+      65             Joshua Moreno        Carousel Franklin  25   f
+      66           Miles Cournoyer Attily Haywood-Morimitsu  41   f
+      67         Zakiyya al-Meskin         Vianca Rodriguez  17   f
+      68         Zakiyya al-Meskin               Sarah Ford  26   f
+      69               Joel Curtis           Tyvonn Skinner  61   m
+      70               Joel Curtis           Alvina Tunnell  46   f
+      71              Ryan Stolley    Jamya Mosby-Beckworth  57   f
+      72              Misael Giron          Zumruda el-Dada   8   f
+      73              Misael Giron          Bryanna Kushner  11   f
+      74            Talaal al-Kazi           Qais el-Nasser  56   m
+      75           Naazim el-Ishak           Tanaree Nguyen  32   f
+      76           Naazim el-Ishak          Trent Hernandez  63   m
+      77           Naazim el-Ishak          Shelby Marshall  54   f
+      78           Naazim el-Ishak         Demetrius Mcneal  22   m
+      79         Carousel Franklin            Savanna Smith  67   f
+      80         Carousel Franklin         Luqmaan el-Nasir  83   m
+      81         Carousel Franklin           Alexa Buccieri  16   f
+      82         Carousel Franklin          Haley Robertson  38   f
+      83            Alvina Tunnell             Zaira Garcia  19   f
+      84           Zumruda el-Dada           Justin Vallejo  37   m
+      85           Zumruda el-Dada             Rayven Smith  46   f
+      86           Zumruda el-Dada        Waheeda al-Farhat  64   f
+      87           Trent Hernandez          Muneeb al-Latif  73   m
+      88           Trent Hernandez         Laquinn Sengdara  13   m
+      89           Shelby Marshall        Vanessa Blackmore  72   f
+      90           Shelby Marshall            Emily Lechman  12   f
+      91             Savanna Smith           Terhesa Litvak  52   f
+      92             Savanna Smith    Robert Ruschmeyer III  61   m
+      93             Savanna Smith           Jamileth Salas   9   f
+      94             Savanna Smith         Estephania Pinon   9   f
+      95             Savanna Smith          Brittany Nguyen  42   f
+      96            Justin Vallejo               Atif Redai  22   m
+      97           Muneeb al-Latif         Alexandra Devere  29   f
+      98          Laquinn Sengdara            Kylyn Letzler  15   f
+      99          Laquinn Sengdara           Jasmine Mathis  69   f
+      100         Laquinn Sengdara        Samuel Heinselman  17   m
+      101         Laquinn Sengdara          Abigail Johnson  21   f
+      102         Laquinn Sengdara           Elizabeth Mora  54   f
+      103         Laquinn Sengdara           Nataya Braxton  20   f
+      104         Laquinn Sengdara          Jameel el-Nazar   9   m
+      105    Robert Ruschmeyer III             Erin Crocker  26   f
+      106    Robert Ruschmeyer III            Jessica Hoang  80   f
+      107    Robert Ruschmeyer III              Kelvin Soto  71   m
+      108    Robert Ruschmeyer III          Deaijah Threats  57   f
+      109    Robert Ruschmeyer III                Emily Lim  77   f
+      110         Alexandra Devere             Meghan Acker  90   f
+      111        Samuel Heinselman              Sana Merlan  58   f
+      112        Samuel Heinselman             Justin Brown  23   m
+      113              Kelvin Soto        Yasmeen Fields II  35   f
+      114             Meghan Acker         Danielle Cintora  66   f
+      115             Justin Brown            Matthew Crowe  62   m
+      116             Justin Brown           Tony Fernandez  62   m
+      117             Justin Brown            Ronald Dalton  34   m
+      118             Justin Brown               Rosa Vigil  57   f
+      119        Yasmeen Fields II            Justin Aldava  44   f
+      120        Yasmeen Fields II            Colton Rogers  22   m
+      121            Matthew Crowe         Rosalio Aguinaga  57   m
+      122            Matthew Crowe       Aaron D Alessandro  63   m
+      123               Rosa Vigil         Samantha Hagerty   7   f
+      124               Rosa Vigil       Chykeiljah Purdham  46   f
+      125               Rosa Vigil        Mamdooh el-Salame  66   m
+      126            Justin Aldava       Joshua Vera-Flores   4   m
+      127            Justin Aldava          Scott Trousdale  10   m
+      128         Rosalio Aguinaga        Dylan Stolzenburg  68   m
+      129         Rosalio Aguinaga         Michael Robinson  68   m
+      130         Rosalio Aguinaga           Phillip Medina  12   m
+      131       Aaron D Alessandro            Israa el-Abdi  51   f
+      132       Aaron D Alessandro            Natalia Phung  51   f
+      133       Chykeiljah Purdham           Theodore Coons   8   m
+      134        Mamdooh el-Salame         Brittany Briseno  55   f
+      135         Michael Robinson            Cidney Miller  77   m
+      136         Michael Robinson           Kurstin Hodapp  22   f
+      137           Phillip Medina        Jocilynn Shumpert   2   f
+      138           Phillip Medina            Troy Leighton  53   m
+      139            Natalia Phung        Muzaina al-Baccus  31   f
+      140            Natalia Phung         Sameeha al-Javid  77   f
+      141            Natalia Phung     Canteskuya Lestenkof  76   f
+      142            Natalia Phung          Isaac Rodriguez  82   m
+      143            Natalia Phung               Brian Wang  12   m
+      144        Jocilynn Shumpert          Arnasya Wigfall  25   f
+      145        Jocilynn Shumpert       Brittany Alvizures  76   f
+      146            Troy Leighton      Shaelumiel Phillips  14   m
+      147            Troy Leighton         Karanveer Wilson  31   m
+      148            Troy Leighton          Ahlaam al-Aslam  90   f
+      149            Troy Leighton             Kelsey Dille  76   f
+      150     Canteskuya Lestenkof             Samuel Sands  30   m
+      151          Isaac Rodriguez             Bridgit Jobe  32   f
+      152          Arnasya Wigfall            Riley Piontek  78   m
+      153          Arnasya Wigfall            Vanessa Rojas  75   f
+      154          Arnasya Wigfall        Rasheeqa el-Abbas  76   f
+      155       Brittany Alvizures              Steven Lehi  88   m
+      156      Shaelumiel Phillips          Aarifa al-Nouri  80   f
+      157      Shaelumiel Phillips          Kelsi Dominguez  41   f
+      158      Shaelumiel Phillips    Maria Karlson-Pacheco  78   f
+      159      Shaelumiel Phillips                John Alam  11   m
+      160      Shaelumiel Phillips          Aqeela al-Pasha  57   f
+      161             Kelsey Dille Jonathan Knodel-Eldridge  79   m
+      162            Riley Piontek         Reymundo Herrera  28   m
+      163            Riley Piontek             Mariah Black   2   f
+      164            Vanessa Rojas           Trenice Pender  16   f
+      165        Rasheeqa el-Abbas               Bella Boss  82   f
+      166          Aarifa al-Nouri          Griselda Garcia  51   f
+      167          Aarifa al-Nouri            Reno Hoffmann  54   f
+      168          Kelsi Dominguez              Molly Wells  76   f
+      169          Kelsi Dominguez            Kayly Woehrel  56   f
+      170          Kelsi Dominguez               David Moak   5   m
+      171    Maria Karlson-Pacheco          Jazmyn Gallegos   1   f
+      172         Reymundo Herrera          Carl Levi Sharp  44   m
+      173         Reymundo Herrera          Yusri al-Khatib  76   m
+      174               Bella Boss          Jeffrey Donegan   3   m
+      175               David Moak           William Delger  15   m
+      176               David Moak               Dyami Polk  19   m
+      177               David Moak        Samantha Lockhart  76   f
+      178          Jazmyn Gallegos              Kylee Kelly  12   f
+      179          Yusri al-Khatib            Jose Escudero  43   m
+      180          Yusri al-Khatib        Huraira el-Masood   9   m
+      181          Yusri al-Khatib     Dominic Robinson III  90   m
+      182          Yusri al-Khatib          Daleel al-Sahli   7   m
+      183          Jeffrey Donegan    Badruddeen al-Bacchus  15   m
+      184          Jeffrey Donegan          Suhaa al-Moussa  54   f
+      185               Dyami Polk     Oscar Rodriguez Loya  64   m
+      186               Dyami Polk       Shaddaad el-Firman  21   m
+      187               Dyami Polk  Crystal Medina Castillo  37   f
+      188               Dyami Polk          Widdad al-Jamal  35   f
+      189               Dyami Polk            Lizeth Stapel  70   f
+      190        Samantha Lockhart          Paul Watkins Jr  70   m
+      191        Samantha Lockhart             Tione Dupont  59   f
+      192        Samantha Lockhart        Giovanni Sterling  77   m
+      193        Samantha Lockhart          Bandar al-Nouri  75   m
+      194        Samantha Lockhart       Annaliese Freiburg  84   f
+      195     Dominic Robinson III          Muhsin el-Irani  18   m
+      196     Dominic Robinson III            Briana Eshima  79   f
+      197     Oscar Rodriguez Loya       Aubreylin Deguzman  14   f
+      198     Oscar Rodriguez Loya               Elise Bugh  49   f
+      199     Oscar Rodriguez Loya        Erin Riley Doudna  56   f
+      200     Oscar Rodriguez Loya            Brianna Price  76   f
+      201          Widdad al-Jamal       Manuel Archambault  41   m
+      202          Widdad al-Jamal           Sham'a el-Arif  16   f
+      203          Widdad al-Jamal             Winston Pham   3   m
+      204       Annaliese Freiburg             Jaelyn Moore  29   f
+      205       Annaliese Freiburg         Trey-Logan Smith  89   m
+      206       Annaliese Freiburg            Caleb Ramirez  24   m
+      207       Annaliese Freiburg           Karen Sandoval  31   f
+      208          Muhsin el-Irani              Aaron Davis  39   m
+      209          Muhsin el-Irani         Timothy Schwartz  32   m
+      210          Muhsin el-Irani               Eric Okoye   9   m
+      211            Briana Eshima              Awf el-Rais  82   m
+      212               Elise Bugh              Cindy Cheng  39   f
+      213        Erin Riley Doudna       Patrick Paton-Ilse  12   m
+      214            Brianna Price             Jocelyn Diaz  54   f
+      215            Brianna Price          Elijah Anguiano  68   m
+      216       Manuel Archambault     Alexandra Kanchanlal  73   f
+      217       Manuel Archambault         Oghenemairo Ware  85   f
+      218       Manuel Archambault          Christian Ingle  52   m
+      219       Manuel Archambault          Timothy Seifert   3   m
+      220             Jaelyn Moore           Kimberly Leung  22   f
+      221             Jaelyn Moore           Kayla Isabelle   5   f
+      222              Aaron Davis           Baylen Wheeler  66   m
+      223              Aaron Davis             Jaliya Smith  68   f
+      224         Timothy Schwartz            Jay Goodstein  38   m
+      225         Timothy Schwartz            Tyler Garhart  57   m
+      226         Timothy Schwartz            Kibori Cooper  48   m
+      227               Eric Okoye           Farha el-Saidi  75   f
+      228              Cindy Cheng       Nabeel al-Mohammad   8   m
+      229          Christian Ingle             Alicia Vigil  28   f
+      230          Christian Ingle        Annnees al-Elamin  21   m
+      231           Kimberly Leung               Aqil Davis   2   m
+      232           Kimberly Leung         Zachary Mckenney  84   m
+      233             Jaliya Smith             Angeline Kim  52   f
+      234             Jaliya Smith            Pierce Parent  58   m
+      235             Jaliya Smith           Brenna Brockel  29   f
+      236            Tyler Garhart         Dalton Dickerson   7   m
+      237       Nabeel al-Mohammad        Hasana el-Hussein  30   f
+      238       Nabeel al-Mohammad        Jameela al-Salaam  11   f
+      239               Aqil Davis            Donald Dunlap  71   m
+      240               Aqil Davis           Alisha Crocker  50   f
+      241         Zachary Mckenney            Taylor Oblack  77   f
+      242         Zachary Mckenney             Jarnell Shah  43   m
+      243         Zachary Mckenney             Naomi Wilson  19   f
+      244         Zachary Mckenney            Elijah Reaves  40   m
+      245         Zachary Mckenney          Aasiya el-Malak  49   f
+      246         Zachary Mckenney         Redmond Arellano  11   m
+      247         Zachary Mckenney           Jawaad el-Sala  15   m
+      248         Zachary Mckenney          Ikram el-Khalil  61   m
+      249           Brenna Brockel             Eric Gilmore  46   m
+      250           Brenna Brockel          Arshad al-Sadri  69   m
+      251           Brenna Brockel          Rif'a al-Naderi  69   f
+      252           Brenna Brockel  Oswaldo Thomas Trujillo  38   m
+      253        Hasana el-Hussein        Muntasir al-Sayed  28   m
+      254        Hasana el-Hussein          Sabri al-Ismail  82   m
+      255            Donald Dunlap          Zaaid al-Jabbar  45   m
+      256            Donald Dunlap               David Bell  47   m
+      257             Jarnell Shah               Tylee Vang  19   f
+      258            Elijah Reaves            Amanda Garcia  85   f
+      259             Eric Gilmore          Margarita Terry  24   f
+      260             Eric Gilmore            Sidqi el-Naim  46   m
+      261          Arshad al-Sadri          Amber Autterson  71   f
+      262          Arshad al-Sadri            Austin Mulder  69   m
+      263          Rif'a al-Naderi        Alexandra Blalock   4   f
+      264          Rif'a al-Naderi             Joshua Jones  31   m
+      265  Oswaldo Thomas Trujillo           Mutee'a al-Aly  18   f
+      266  Oswaldo Thomas Trujillo            Vanessa Lopez  16   f
+      267  Oswaldo Thomas Trujillo        Christian Vaquera  53   m
+      268        Muntasir al-Sayed               Syed Nagai  62   m
+      269        Muntasir al-Sayed          Shelby Muhammad  87   m
+      270          Sabri al-Ismail          Nu'ma al-Arafat  28   f
+      271          Sabri al-Ismail        Shaheer al-Firman  42   m
+      272               Tylee Vang            Samara Bryant  42   f
+      273            Sidqi el-Naim             Linda Parker  84   f
+      274            Sidqi el-Naim        Hilaal el-Abdella  29   m
+      275          Amber Autterson         Kaleem al-Khalid  47   m
+      276          Amber Autterson               Ivan Perez  14   m
+      277        Alexandra Blalock     Angelica Orta Zepeda  48   f
+      278            Vanessa Lopez              Raul Chavez  89   m
+      279            Vanessa Lopez           Germaine Ealom  39   m
+      280            Vanessa Lopez           Gabriella Pont  17   f
+      281        Christian Vaquera             Tyler Wilson  20   m
+      282        Christian Vaquera       Almaasa al-Mustafa  61   f
+      283               Ivan Perez            Maris Manning   6   f
+      284     Angelica Orta Zepeda      Candace Plenty Wolf  28   f
+      285              Raul Chavez           Abiel Trujillo  83   m
+      286              Raul Chavez             Latha Wasson  68   m
+      287              Raul Chavez            Yadiel Malone  47   m
+      288             Tyler Wilson            Korren Harper  73   f
+      289             Tyler Wilson          Victoria Romero  24   f
+      290             Tyler Wilson             Avery Nguyen  42   m
+      291             Tyler Wilson        Maariya el-Younis  71   f
+      292            Maris Manning           Heather Orlady   9   f
+      293            Maris Manning         Giovana Monclova  78   f
+      294      Candace Plenty Wolf               Laura Ball  24   f
+      295      Candace Plenty Wolf      Brenda Molina-Brown  61   f
+      296             Avery Nguyen            Megan Cushing  49   f
+      297             Avery Nguyen         Tareef el-Naderi  53   m
+      298             Avery Nguyen       Mushtaaqa el-Qadir  63   f
+      299        Maariya el-Younis              Alana Weiss  29   f
+      300        Maariya el-Younis                  Tina Le  76   f
+      301        Maariya el-Younis          Precious Malloy  69   f
+      302           Heather Orlady       Sabaaha el-Sultana  63   f
+      303           Heather Orlady           Elias Martinez  50   m
+      304           Heather Orlady                Ziru Cung  58   f
+      305         Tareef el-Naderi      Tyrell Thomas-Moore  88   m
+      306         Tareef el-Naderi           Destiny Turner   7   f
+      307         Tareef el-Naderi           Kendrick Brown  51   m
+      308                  Tina Le                 Andy Kim  47   m
+      309                  Tina Le        Brittney Morrison  45   f
+      310                  Tina Le           Nathaniel Lone  83   m
+      311                  Tina Le            Brianna Nocon  30   f
+      312          Precious Malloy             Rachel Pruet  41   f
+      313           Elias Martinez            Matthew Trang  15   m
+      314           Elias Martinez           Sharron Cooper  27   f
+      315           Elias Martinez               Amy Tandon  88   f
+      316           Destiny Turner          Genessis Chacon  74   f
+      317        Brittney Morrison              Nakita Diaz   1   f
+      318        Brittney Morrison         Wasmaaa el-Hares  84   f
+      319           Nathaniel Lone                Nico Shea  79   m
+      320             Rachel Pruet       Tayyiba el-Khawaja  54   f
+      321             Rachel Pruet           Maurice Morgan  24   m
+      322             Rachel Pruet    Joey Hernandez Correa  37   m
+      323               Amy Tandon             Monica Glade   3   f
+      324               Amy Tandon           Anthony Deleon  48   m
+      325                Nico Shea           Brenden Hughes  82   m
+      326           Brenden Hughes             Avani Ansari  30   f
+          date_first_contact date_last_contact was_case           status
+      1           2022-12-31        2023-01-05        Y             case
+      2           2022-12-30        2023-01-01        Y             case
+      3           2023-01-02        2023-01-04        N          unknown
+      4           2023-01-05        2023-01-05        Y             case
+      5           2023-01-07        2023-01-08        Y             case
+      6           2023-01-03        2023-01-06        Y             case
+      7           2023-01-02        2023-01-04        N   under_followup
+      8           2023-01-02        2023-01-06        N   under_followup
+      9           2023-01-06        2023-01-06        Y             case
+      10          2023-01-01        2023-01-06        Y             case
+      11          2023-01-06        2023-01-08        Y             case
+      12          2023-01-05        2023-01-07        N   under_followup
+      13          2023-01-02        2023-01-08        Y             case
+      14          2023-01-14        2023-01-17        N lost_to_followup
+      15          2023-01-10        2023-01-13        N          unknown
+      16          2023-01-07        2023-01-13        N lost_to_followup
+      17          2023-01-12        2023-01-17        Y             case
+      18          2023-01-09        2023-01-11        Y             case
+      19          2023-01-11        2023-01-15        N   under_followup
+      20          2023-01-12        2023-01-15        N          unknown
+      21          2023-01-12        2023-01-14        Y             case
+      22          2023-01-12        2023-01-16        N   under_followup
+      23          2023-01-10        2023-01-16        Y             case
+      24          2023-01-12        2023-01-14        N   under_followup
+      25          2023-01-13        2023-01-16        N   under_followup
+      26          2023-01-11        2023-01-13        Y             case
+      27          2023-01-15        2023-01-16        N          unknown
+      28          2023-01-11        2023-01-15        Y             case
+      29          2023-01-14        2023-01-17        Y             case
+      30          2023-01-14        2023-01-16        Y             case
+      31          2023-01-17        2023-01-18        N   under_followup
+      32          2023-01-12        2023-01-16        Y             case
+      33          2023-01-13        2023-01-17        Y             case
+      34          2023-01-22        2023-01-23        Y             case
+      35          2023-01-19        2023-01-23        N lost_to_followup
+      36          2023-01-26        2023-01-26        N   under_followup
+      37          2023-01-20        2023-01-22        Y             case
+      38          2023-01-19        2023-01-23        Y             case
+      39          2023-01-21        2023-01-23        N lost_to_followup
+      40          2023-01-19        2023-01-22        Y             case
+      41          2023-01-15        2023-01-20        N lost_to_followup
+      42          2023-01-19        2023-01-21        N   under_followup
+      43          2023-01-23        2023-01-24        Y             case
+      44          2023-01-23        2023-01-25        Y             case
+      45          2023-01-15        2023-01-16        N   under_followup
+      46          2023-01-23        2023-01-28        Y             case
+      47          2023-01-25        2023-01-29        N   under_followup
+      48          2023-01-26        2023-01-27        N   under_followup
+      49          2023-01-22        2023-01-24        Y             case
+      50          2023-01-23        2023-01-28        Y             case
+      51          2023-01-22        2023-01-27        N   under_followup
+      52          2023-01-25        2023-01-26        Y             case
+      53          2023-01-24        2023-01-26        Y             case
+      54          2023-01-23        2023-01-26        Y             case
+      55          2023-01-18        2023-01-23        Y             case
+      56          2023-01-25        2023-01-27        N lost_to_followup
+      57          2023-01-19        2023-01-23        Y             case
+      58          2023-01-22        2023-01-26        Y             case
+      59          2023-01-27        2023-01-27        Y             case
+      60          2023-02-04        2023-02-04        N   under_followup
+      61          2023-01-29        2023-01-30        N lost_to_followup
+      62          2023-01-26        2023-01-28        Y             case
+      63          2023-01-25        2023-01-30        Y             case
+      64          2023-01-27        2023-01-30        Y             case
+      65          2023-01-27        2023-01-31        Y             case
+      66          2023-01-31        2023-02-04        N   under_followup
+      67          2023-01-27        2023-01-28        N   under_followup
+      68          2023-01-24        2023-01-29        N   under_followup
+      69          2023-01-26        2023-01-27        N   under_followup
+      70          2023-01-30        2023-01-31        Y             case
+      71          2023-01-20        2023-01-25        N   under_followup
+      72          2023-02-01        2023-02-04        Y             case
+      73          2023-01-29        2023-01-31        N   under_followup
+      74          2023-01-31        2023-02-04        N lost_to_followup
+      75          2023-01-24        2023-01-30        N lost_to_followup
+      76          2023-01-28        2023-02-02        Y             case
+      77          2023-01-27        2023-02-02        Y             case
+      78          2023-01-29        2023-02-01        N   under_followup
+      79          2023-02-03        2023-02-04        Y             case
+      80          2023-01-31        2023-02-05        N   under_followup
+      81          2023-02-01        2023-02-02        N   under_followup
+      82          2023-02-01        2023-02-04        N   under_followup
+      83          2023-02-01        2023-02-02        N   under_followup
+      84          2023-02-01        2023-02-03        Y             case
+      85          2023-01-28        2023-02-01        N   under_followup
+      86          2023-01-30        2023-02-03        N   under_followup
+      87          2023-01-31        2023-02-01        Y             case
+      88          2023-01-30        2023-02-02        Y             case
+      89          2023-01-31        2023-01-31        Y             case
+      90          2023-01-31        2023-02-04        N   under_followup
+      91          2023-01-28        2023-02-04        N   under_followup
+      92          2023-01-30        2023-02-04        Y             case
+      93          2023-02-01        2023-02-06        N   under_followup
+      94          2023-02-01        2023-02-03        N lost_to_followup
+      95          2023-01-31        2023-02-04        N   under_followup
+      96          2023-02-04        2023-02-06        Y             case
+      97          2023-02-03        2023-02-05        Y             case
+      98          2023-02-02        2023-02-04        N   under_followup
+      99          2023-02-02        2023-02-05        N   under_followup
+      100         2023-01-30        2023-02-04        Y             case
+      101         2023-02-04        2023-02-08        N          unknown
+      102         2023-01-31        2023-02-07        N   under_followup
+      103         2023-02-05        2023-02-06        N   under_followup
+      104         2023-01-30        2023-02-04        N lost_to_followup
+      105         2023-02-01        2023-02-04        N   under_followup
+      106         2023-02-01        2023-02-06        N   under_followup
+      107         2023-02-05        2023-02-08        Y             case
+      108         2023-02-04        2023-02-10        N   under_followup
+      109         2023-02-02        2023-02-08        N   under_followup
+      110         2023-02-06        2023-02-08        Y             case
+      111         2023-02-08        2023-02-12        N   under_followup
+      112         2023-02-10        2023-02-11        Y             case
+      113         2023-02-14        2023-02-19        Y             case
+      114         2023-02-11        2023-02-12        N   under_followup
+      115         2023-02-13        2023-02-16        Y             case
+      116         2023-02-10        2023-02-13        N   under_followup
+      117         2023-02-15        2023-02-16        N lost_to_followup
+      118         2023-02-10        2023-02-13        Y             case
+      119         2023-02-16        2023-02-18        Y             case
+      120         2023-02-18        2023-02-18        N   under_followup
+      121         2023-03-02        2023-03-02        Y             case
+      122         2023-02-26        2023-03-03        Y             case
+      123         2023-02-18        2023-02-23        N   under_followup
+      124         2023-02-24        2023-02-26        Y             case
+      125         2023-02-17        2023-02-23        Y             case
+      126         2023-02-18        2023-02-21        N   under_followup
+      127         2023-02-16        2023-02-19        N   under_followup
+      128         2023-03-01        2023-03-05        N   under_followup
+      129         2023-03-06        2023-03-07        Y             case
+      130         2023-03-03        2023-03-04        Y             case
+      131         2023-03-04        2023-03-09        N   under_followup
+      132         2023-03-07        2023-03-09        Y             case
+      133         2023-02-27        2023-03-02        N lost_to_followup
+      134         2023-03-02        2023-03-07        N   under_followup
+      135         2023-03-08        2023-03-10        N   under_followup
+      136         2023-03-02        2023-03-09        N lost_to_followup
+      137         2023-03-06        2023-03-11        Y             case
+      138         2023-03-07        2023-03-11        Y             case
+      139         2023-03-16        2023-03-18        N   under_followup
+      140         2023-03-14        2023-03-18        N lost_to_followup
+      141         2023-03-18        2023-03-23        Y             case
+      142         2023-03-20        2023-03-20        Y             case
+      143         2023-03-19        2023-03-21        N   under_followup
+      144         2023-03-07        2023-03-12        Y             case
+      145         2023-03-10        2023-03-14        Y             case
+      146         2023-03-06        2023-03-11        Y             case
+      147         2023-03-08        2023-03-12        N   under_followup
+      148         2023-03-07        2023-03-09        N   under_followup
+      149         2023-03-10        2023-03-11        Y             case
+      150         2023-03-26        2023-03-29        N          unknown
+      151         2023-03-23        2023-03-27        N   under_followup
+      152         2023-03-16        2023-03-21        Y             case
+      153         2023-03-16        2023-03-19        Y             case
+      154         2023-03-12        2023-03-19        Y             case
+      155         2023-03-10        2023-03-14        N lost_to_followup
+      156         2023-03-13        2023-03-14        Y             case
+      157         2023-03-12        2023-03-14        Y             case
+      158         2023-03-12        2023-03-17        Y             case
+      159         2023-03-15        2023-03-18        N lost_to_followup
+      160         2023-03-10        2023-03-15        N lost_to_followup
+      161         2023-03-06        2023-03-12        N   under_followup
+      162         2023-03-12        2023-03-17        Y             case
+      163         2023-03-15        2023-03-18        Y             case
+      164         2023-03-26        2023-03-29        N   under_followup
+      165         2023-03-21        2023-03-25        Y             case
+      166         2023-03-16        2023-03-19        N   under_followup
+      167         2023-03-20        2023-03-22        N   under_followup
+      168         2023-03-17        2023-03-20        N   under_followup
+      169         2023-03-21        2023-03-22        N   under_followup
+      170         2023-03-16        2023-03-20        Y             case
+      171         2023-03-18        2023-03-21        Y             case
+      172         2023-03-17        2023-03-18        Y             case
+      173         2023-03-20        2023-03-21        Y             case
+      174         2023-03-26        2023-03-27        Y             case
+      175         2023-03-24        2023-03-24        Y             case
+      176         2023-03-22        2023-03-24        Y             case
+      177         2023-03-19        2023-03-24        Y             case
+      178         2023-03-23        2023-03-24        N   under_followup
+      179         2023-03-20        2023-03-21        N   under_followup
+      180         2023-03-20        2023-03-20        N          unknown
+      181         2023-03-20        2023-03-20        Y             case
+      182         2023-03-11        2023-03-17        N   under_followup
+      183         2023-03-28        2023-04-02        N   under_followup
+      184         2023-04-01        2023-04-02        N   under_followup
+      185         2023-03-29        2023-04-01        Y             case
+      186         2023-03-24        2023-03-26        N   under_followup
+      187         2023-03-27        2023-03-29        N   under_followup
+      188         2023-03-27        2023-03-28        Y             case
+      189         2023-03-27        2023-03-30        N lost_to_followup
+      190         2023-03-25        2023-03-29        N   under_followup
+      191         2023-03-25        2023-03-27        N   under_followup
+      192         2023-03-23        2023-03-27        N          unknown
+      193         2023-03-24        2023-03-29        N   under_followup
+      194         2023-03-23        2023-03-28        Y             case
+      195         2023-03-25        2023-03-29        Y             case
+      196         2023-03-26        2023-03-28        Y             case
+      197         2023-04-08        2023-04-08        N lost_to_followup
+      198         2023-04-02        2023-04-07        Y             case
+      199         2023-04-03        2023-04-06        Y             case
+      200         2023-03-31        2023-04-03        Y             case
+      201         2023-03-28        2023-04-01        Y             case
+      202         2023-03-30        2023-03-31        N   under_followup
+      203         2023-03-28        2023-04-01        N   under_followup
+      204         2023-03-24        2023-03-29        Y             case
+      205         2023-03-27        2023-03-27        N   under_followup
+      206         2023-03-24        2023-03-30        N lost_to_followup
+      207         2023-03-26        2023-03-28        N lost_to_followup
+      208         2023-03-28        2023-04-01        Y             case
+      209         2023-03-30        2023-04-06        Y             case
+      210         2023-04-03        2023-04-05        Y             case
+      211         2023-03-28        2023-04-01        N lost_to_followup
+      212         2023-04-07        2023-04-08        Y             case
+      213         2023-04-08        2023-04-08        Y             case
+      214         2023-04-07        2023-04-10        N   under_followup
+      215         2023-04-10        2023-04-10        N   under_followup
+      216         2023-04-02        2023-04-03        N   under_followup
+      217         2023-04-02        2023-04-06        N   under_followup
+      218         2023-04-06        2023-04-06        Y             case
+      219         2023-04-04        2023-04-07        N   under_followup
+      220         2023-04-01        2023-04-05        Y             case
+      221         2023-03-31        2023-04-05        N   under_followup
+      222         2023-04-04        2023-04-06        N   under_followup
+      223         2023-04-03        2023-04-06        Y             case
+      224         2023-04-03        2023-04-05        N          unknown
+      225         2023-04-01        2023-04-04        Y             case
+      226         2023-04-02        2023-04-04        N          unknown
+      227         2023-04-04        2023-04-07        N   under_followup
+      228         2023-04-11        2023-04-16        Y             case
+      229         2023-04-09        2023-04-12        Y             case
+      230         2023-04-11        2023-04-12        N   under_followup
+      231         2023-04-05        2023-04-06        Y             case
+      232         2023-04-01        2023-04-03        Y             case
+      233         2023-04-01        2023-04-09        Y             case
+      234         2023-04-04        2023-04-08        Y             case
+      235         2023-04-12        2023-04-13        Y             case
+      236         2023-04-05        2023-04-08        N   under_followup
+      237         2023-04-14        2023-04-17        Y             case
+      238         2023-04-11        2023-04-13        N          unknown
+      239         2023-04-03        2023-04-05        Y             case
+      240         2023-04-03        2023-04-06        N          unknown
+      241         2023-04-06        2023-04-12        N   under_followup
+      242         2023-04-09        2023-04-12        Y             case
+      243         2023-04-09        2023-04-14        N          unknown
+      244         2023-04-10        2023-04-16        Y             case
+      245         2023-04-09        2023-04-11        N   under_followup
+      246         2023-04-07        2023-04-10        N   under_followup
+      247         2023-04-07        2023-04-10        N   under_followup
+      248         2023-04-12        2023-04-14        N   under_followup
+      249         2023-04-06        2023-04-11        Y             case
+      250         2023-04-07        2023-04-12        Y             case
+      251         2023-04-04        2023-04-11        Y             case
+      252         2023-04-10        2023-04-11        Y             case
+      253         2023-04-13        2023-04-16        Y             case
+      254         2023-04-14        2023-04-18        Y             case
+      255         2023-04-17        2023-04-18        N lost_to_followup
+      256         2023-04-11        2023-04-16        N   under_followup
+      257         2023-04-13        2023-04-14        Y             case
+      258         2023-04-15        2023-04-16        N   under_followup
+      259         2023-04-11        2023-04-18        N   under_followup
+      260         2023-04-15        2023-04-18        Y             case
+      261         2023-04-14        2023-04-14        Y             case
+      262         2023-04-09        2023-04-14        N lost_to_followup
+      263         2023-04-12        2023-04-21        Y             case
+      264         2023-04-16        2023-04-21        Y             case
+      265         2023-04-24        2023-04-26        N   under_followup
+      266         2023-04-19        2023-04-25        Y             case
+      267         2023-04-23        2023-04-25        Y             case
+      268         2023-04-10        2023-04-17        N   under_followup
+      269         2023-04-13        2023-04-16        N   under_followup
+      270         2023-04-16        2023-04-19        N          unknown
+      271         2023-04-13        2023-04-18        N   under_followup
+      272         2023-04-16        2023-04-17        N   under_followup
+      273         2023-04-25        2023-04-28        N lost_to_followup
+      274         2023-04-25        2023-04-27        N   under_followup
+      275         2023-04-16        2023-04-16        N          unknown
+      276         2023-04-11        2023-04-15        Y             case
+      277         2023-04-23        2023-04-26        Y             case
+      278         2023-04-21        2023-04-22        Y             case
+      279         2023-04-18        2023-04-22        Y             case
+      280         2023-04-21        2023-04-25        N          unknown
+      281         2023-04-21        2023-04-25        Y             case
+      282         2023-04-26        2023-04-27        N          unknown
+      283         2023-05-05        2023-05-06        Y             case
+      284         2023-04-28        2023-04-29        Y             case
+      285         2023-04-28        2023-04-28        N lost_to_followup
+      286         2023-04-27        2023-04-30        N lost_to_followup
+      287         2023-04-26        2023-04-28        N   under_followup
+      288         2023-04-22        2023-04-24        N   under_followup
+      289         2023-04-22        2023-04-23        N   under_followup
+      290         2023-04-19        2023-04-21        Y             case
+      291         2023-04-21        2023-04-23        Y             case
+      292         2023-05-03        2023-05-05        Y             case
+      293         2023-05-07        2023-05-08        N   under_followup
+      294         2023-05-03        2023-05-09        N   under_followup
+      295         2023-05-06        2023-05-08        Y             case
+      296         2023-05-03        2023-05-04        N   under_followup
+      297         2023-05-01        2023-05-03        Y             case
+      298         2023-04-28        2023-05-01        N lost_to_followup
+      299         2023-04-25        2023-04-29        N   under_followup
+      300         2023-04-25        2023-04-27        Y             case
+      301         2023-04-20        2023-04-25        Y             case
+      302         2023-04-30        2023-05-09        N   under_followup
+      303         2023-05-08        2023-05-10        Y             case
+      304         2023-05-04        2023-05-07        N   under_followup
+      305         2023-05-04        2023-05-06        N   under_followup
+      306         2023-04-28        2023-05-04        Y             case
+      307         2023-05-03        2023-05-06        N          unknown
+      308         2023-04-26        2023-04-30        N   under_followup
+      309         2023-04-19        2023-04-25        Y             case
+      310         2023-04-25        2023-04-26        Y             case
+      311         2023-04-24        2023-04-27        N   under_followup
+      312         2023-04-25        2023-04-29        Y             case
+      313         2023-05-08        2023-05-08        N lost_to_followup
+      314         2023-05-04        2023-05-08        N          unknown
+      315         2023-05-05        2023-05-08        Y             case
+      316         2023-05-07        2023-05-10        N   under_followup
+      317         2023-04-23        2023-04-26        N   under_followup
+      318         2023-04-25        2023-04-25        N          unknown
+      319         2023-04-22        2023-04-28        Y             case
+      320         2023-04-22        2023-04-29        N   under_followup
+      321         2023-04-27        2023-04-30        N   under_followup
+      322         2023-04-29        2023-05-02        N   under_followup
+      323         2023-05-10        2023-05-12        N   under_followup
+      324         2023-05-15        2023-05-16        N   under_followup
+      325         2023-05-01        2023-05-03        Y             case
+      326         2023-05-09        2023-05-14        N   under_followup
+      
+
 # sim_outbreak works as expected
 
     Code

--- a/tests/testthat/test-sim_contacts.R
+++ b/tests/testthat/test-sim_contacts.R
@@ -1,3 +1,8 @@
+test_that("sim_contacts works as expected with defaults", {
+  set.seed(1)
+  expect_snapshot(sim_contacts())
+})
+
 suppressMessages({
   contact_distribution <- epiparameter::epidist(
     disease = "COVID-19",

--- a/tests/testthat/test-sim_linelist.R
+++ b/tests/testthat/test-sim_linelist.R
@@ -295,10 +295,8 @@ test_that("sim_linelist warns when risks are given by onset-to-event is NULL", {
       onset_to_death = NULL,
       hosp_death_risk = 0.5
     ),
-    regexp = paste0(
-      "(onset_to_death is set to NULL)*(hosp_death_risk is being ignored)*",
-      "(non_hosp_death_risk is being ignored)"
-    )
+    regexp =
+      "(onset_to_death is set to NULL)*(hosp_death_risk is being ignored)"
   )
   expect_warning(
     sim_linelist(
@@ -309,9 +307,49 @@ test_that("sim_linelist warns when risks are given by onset-to-event is NULL", {
       onset_to_death = NULL,
       non_hosp_death_risk = 0.02
     ),
-    regexp = paste0(
-      "(onset_to_death is set to NULL)*(hosp_death_risk is being ignored)*",
-      "(non_hosp_death_risk is being ignored)"
+    regexp =
+      "(onset_to_death is set to NULL)*(non_hosp_death_risk is being ignored)"
+  )
+})
+
+test_that("sim_linelist is silent when onset is NULL and risk is off", {
+  set.seed(1)
+  expect_silent(
+    sim_linelist(
+      contact_distribution = contact_distribution,
+      infectious_period = infectious_period,
+      prob_infection = 0.5,
+      onset_to_hosp = NULL,
+      onset_to_death = onset_to_death
+    )
+  )
+  expect_silent(
+    sim_linelist(
+      contact_distribution = contact_distribution,
+      infectious_period = infectious_period,
+      prob_infection = 0.5,
+      onset_to_hosp = NULL,
+      onset_to_death = onset_to_death,
+      hosp_risk = NULL
+    )
+  )
+  expect_silent(
+    sim_linelist(
+      contact_distribution = contact_distribution,
+      infectious_period = infectious_period,
+      prob_infection = 0.5,
+      onset_to_hosp = onset_to_hosp,
+      onset_to_death = NULL,
+    )
+  )
+  expect_silent(
+    sim_linelist(
+      contact_distribution = contact_distribution,
+      infectious_period = infectious_period,
+      prob_infection = 0.5,
+      onset_to_hosp = onset_to_hosp,
+      onset_to_death = NULL,
+      non_hosp_death_risk = NULL
     )
   )
 })
@@ -337,7 +375,8 @@ test_that("sim_linelist fails when onset-to-event are given by risk is NULL", {
       onset_to_death = onset_to_death,
       hosp_death_risk = NULL
     ),
-    regexp = "(hosp_death_risk is set to NULL but hosp_risk and onset_to_death)"
+    regexp =
+      "(hosp_death_risk is set to NULL but onset_to_hosp and onset_to_death)"
   )
   expect_error(
     sim_linelist(

--- a/tests/testthat/test-sim_linelist.R
+++ b/tests/testthat/test-sim_linelist.R
@@ -1,3 +1,8 @@
+test_that("sim_linelist works as expected with defaults", {
+  set.seed(1)
+  expect_snapshot(sim_linelist())
+})
+
 suppressMessages({
   contact_distribution <- epiparameter::epidist(
     disease = "COVID-19",

--- a/tests/testthat/test-sim_outbreak.R
+++ b/tests/testthat/test-sim_outbreak.R
@@ -1,3 +1,8 @@
+test_that("sim_outbreak works as expected with defaults", {
+  set.seed(1)
+  expect_snapshot(sim_outbreak())
+})
+
 suppressMessages({
   contact_distribution <- epiparameter::epidist(
     disease = "COVID-19",

--- a/vignettes/simulist.Rmd
+++ b/vignettes/simulist.Rmd
@@ -222,7 +222,28 @@ The `sim_*()` functions, by default, use an excess degree distribution to accoun
 
 ## Using functions for distributions instead of `<epidist>`
 
-It is possible to use an [anonymous function](https://en.wikipedia.org/wiki/Anonymous_function) instead of an `<epidist>` object when specifying the parameters of the delay and contact distributions. We recommend using the `<epidist>` objects but here outline the alternative approach.
+The `contact_distribution`, `infectious_period`, `onset_to_hosp`, `onset_to_death` and `onset_to_recovery` arguments can accept either an `<epidist>` object (as shown above), or can accept a function. It is possible to use a predefined function or an [anonymous function](https://en.wikipedia.org/wiki/Anonymous_function). Here we'll demonstrate how to use both.
+
+### Predefined functions
+
+```{r, sim-outbreak-func}
+contact_distribution <- function(x) dpois(x = x, lambda = 2)
+infectious_period <- function(x) rgamma(n = x, shape = 2, scale = 2)
+onset_to_hosp <- function(x) rlnorm(n = x, meanlog = 1.5, sdlog = 0.5)
+onset_to_death <- function(x) rweibull(n = x, shape = 0.5, scale = 0.2)
+
+outbreak <- sim_outbreak(
+  contact_distribution = contact_distribution,
+  infectious_period = infectious_period,
+  prob_infection = 0.5,
+  onset_to_hosp = onset_to_hosp,
+  onset_to_death = onset_to_death
+)
+head(outbreak$linelist)
+head(outbreak$contacts)
+```
+
+### Anonymous functions
 
 ```{r, sim-outbreak-anon-func}
 outbreak <- sim_outbreak(


### PR DESCRIPTION
This PR addresses #120 and #145 (_#146 has also been resolved in this PR, see comment below_) by adding defaults to the arguments in `sim_linelist()`, `sim_contacts()` and `sim_outbreaks()` that were previously missing. 

This now enables these functions to be run without the user specifying any arguments, e.g. `linelist <- sim_linelist()`.

The documentation for the arguments has also be improved as suggested in #145. In combination with the argument documentation, the README, vignettes and function examples have also been added to. These now cover using a simple function call without specifying any arguments (in the README and function examples), using predefined and anonymous functions (in the `simulist.Rmd` vignette). 

Regression unit tests have been added for the new simpler function calls for `sim_*()` functions. 

Documentation for several internal function is also updated (mainly because of inheriting documentation from `sim_*()` functions). 