### PR TITLE
Updates to work with {pkgdown} >= 2.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,6 @@ Imports:
     rlang,
     stats
 Suggests: 
-    bookdown,
     dplyr,
     epicontacts (>= 1.1.3),
     ggplot2,

--- a/README.Rmd
+++ b/README.Rmd
@@ -67,7 +67,7 @@ linelist <- sim_linelist()
 head(linelist)
 ```
 
-However, to simulate a more realistic line list using epidemiological parameters estimated for a infectious disease we can use previously estimated epidemiological parameters. These can be from the `{epiparameter}` R package if available, or if these are not in the `{epiparameter}` database yet (such as the contact distribution for COVID-19) we can define them ourselves. Here we define a contact distribution, period of infectiousness, onset-to-hospitalisation delay, and onset-to-death delay. 
+However, to simulate a more realistic line list using epidemiological parameters estimated for an infectious disease outbreak we can use previously estimated epidemiological parameters. These can be from the `{epiparameter}` R package if available, or if these are not in the `{epiparameter}` database yet (such as the contact distribution for COVID-19) we can define them ourselves. Here we define a contact distribution, period of infectiousness, onset-to-hospitalisation delay, and onset-to-death delay. 
 
 ```{r load-epiparameter}
 library(epiparameter)

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ head(linelist)
 ```
 
 However, to simulate a more realistic line list using epidemiological
-parameters estimated for a infectious disease we can use previously
-estimated epidemiological parameters. These can be from the
+parameters estimated for an infectious disease outbreak we can use
+previously estimated epidemiological parameters. These can be from the
 `{epiparameter}` R package if available, or if these are not in the
 `{epiparameter}` database yet (such as the contact distribution for
 COVID-19) we can define them ourselves. Here we define a contact
@@ -107,9 +107,6 @@ contact_distribution <- epiparameter::epidist(
   prob_distribution_params = c(mean = 2)
 )
 #> Citation cannot be created as author, year, journal or title is missing
-```
-
-``` r
 
 # create COVID-19 infectious period
 infectious_period <- epiparameter::epidist(
@@ -119,9 +116,6 @@ infectious_period <- epiparameter::epidist(
   prob_distribution_params = c(shape = 1, scale = 1)
 )
 #> Citation cannot be created as author, year, journal or title is missing
-```
-
-``` r
 
 # get onset to hospital admission from {epiparameter} database
 onset_to_hosp <- epiparameter::epidist_db(
@@ -136,9 +130,6 @@ onset_to_hosp <- epiparameter::epidist_db(
 #> Case Data." _Journal of Clinical Medicine_. doi:10.3390/jcm9020538
 #> <https://doi.org/10.3390/jcm9020538>.. 
 #> To retrieve the citation use the 'get_citation' function
-```
-
-``` r
 
 # get onset to death from {epiparameter} database
 onset_to_death <- epiparameter::epidist_db(
@@ -290,9 +281,6 @@ head(outbreak$linelist)
 #> 4   2023-01-21         2023-01-07        2023-01-08     23.9
 #> 5         <NA>         2023-01-01        2023-01-01     23.9
 #> 6         <NA>         2023-01-02        2023-01-05       NA
-```
-
-``` r
 head(outbreak$contacts)
 #>              from                 to age sex date_first_contact
 #> 1   Okatomi Reish         Jesse Lynn  44   f         2023-01-04

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,7 +5,7 @@ template:
     font_weight_base : 300
 
 development:
-  mode: auto
+  mode: unreleased
 
 reference:
   - title: Simulation functions

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -27,7 +27,6 @@ SARS
 Tidyverse
 aes
 apyramid
-bookdown
 bw
 cfr
 codecov

--- a/vignettes/age-strat-risks.Rmd
+++ b/vignettes/age-strat-risks.Rmd
@@ -3,8 +3,6 @@ title: "Age-stratified hospitalisation and death risks"
 output: 
   bookdown::html_vignette2:
     code_folding: show
-pkgdown:
-  as_is: true
 vignette: >
   %\VignetteIndexEntry{Age-stratified hospitalisation and death risks}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/age-strat-risks.Rmd
+++ b/vignettes/age-strat-risks.Rmd
@@ -1,8 +1,6 @@
 ---
 title: "Age-stratified hospitalisation and death risks"
-output: 
-  rmarkdown::html_vignette:
-    code_folding: show
+output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Age-stratified hospitalisation and death risks}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/age-strat-risks.Rmd
+++ b/vignettes/age-strat-risks.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Age-stratified hospitalisation and death risks"
 output: 
-  bookdown::html_vignette2:
+  rmarkdown::html_vignette:
     code_folding: show
 vignette: >
   %\VignetteIndexEntry{Age-stratified hospitalisation and death risks}

--- a/vignettes/age-struct-pop.Rmd
+++ b/vignettes/age-struct-pop.Rmd
@@ -3,8 +3,6 @@ title: "Age structured population"
 output: 
   bookdown::html_vignette2:
     code_folding: show
-pkgdown:
-  as_is: true
 vignette: >
   %\VignetteIndexEntry{Age structured population}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/age-struct-pop.Rmd
+++ b/vignettes/age-struct-pop.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Age structured population"
 output: 
-  bookdown::html_vignette2:
+  rmarkdown::html_vignette:
     code_folding: show
 vignette: >
   %\VignetteIndexEntry{Age structured population}

--- a/vignettes/age-struct-pop.Rmd
+++ b/vignettes/age-struct-pop.Rmd
@@ -91,7 +91,7 @@ head(linelist)
 
 We can plot the age distribution for individuals in the line list, binned into 5 year categories.
 
-```{r plot-age-range, class.source = 'fold-hide', fig.cap="Age distribution of individuals in a simulated line list sampled from a uniform distribution between 5 and 75.", fig.width = 8, fig.height = 5}
+```{r plot-age-range, fig.cap="Age distribution of individuals in a simulated line list sampled from a uniform distribution between 5 and 75.", fig.width = 8, fig.height = 5}
 ggplot(linelist[, c("sex", "age")]) +
   geom_histogram(
     mapping = aes(x = age),
@@ -137,7 +137,7 @@ head(linelist)
 
 Again we can plot the age distribution to see the age structure for individuals in the line list. Given the relative uniformity of the age structure specified it is not greatly different from the uniform age structure plotted above, other than having a higher upper age limit. The data is binned into 5 year categories and facetted by sex.
 
-```{r plot-age-struct, class.source = 'fold-hide', fig.cap="Age distribution of line list cases facetted by sex", fig.width = 8, fig.height = 5}
+```{r plot-age-struct, fig.cap="Age distribution of line list cases facetted by sex", fig.width = 8, fig.height = 5}
 ggplot(linelist[, c("sex", "age")]) +
   geom_histogram(
     mapping = aes(x = age),
@@ -189,7 +189,7 @@ head(linelist)
 ```
 A common and useful method for plotting age data is in the form of age pyramids. Here we partition the data by sex and plot the age distribution.
 
-```{r plot-age-struct-young, class.source = 'fold-hide', fig.cap="Age pyramid for a simulated line list with an age structured population.", fig.width = 8, fig.height = 5}
+```{r plot-age-struct-young, fig.cap="Age pyramid for a simulated line list with an age structured population.", fig.width = 8, fig.height = 5}
 linelist_m <- subset(linelist, subset = sex == "m")
 age_cats_m <- as.data.frame(table(floor(linelist_m$age / 5) * 5))
 colnames(age_cats_m) <- c("AgeCat", "Population")

--- a/vignettes/age-struct-pop.Rmd
+++ b/vignettes/age-struct-pop.Rmd
@@ -1,8 +1,6 @@
 ---
 title: "Age structured population"
-output: 
-  rmarkdown::html_vignette:
-    code_folding: show
+output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Age structured population}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/design-principles.Rmd
+++ b/vignettes/design-principles.Rmd
@@ -36,8 +36,6 @@ The simulation functions either return a `<data.frame>` or a `list` of `<data.fr
 
 - The column names of the contact relationships (edges of the network) are called `from` and `to`. Names of the contacts table match {epicontacts} `<epicontacts>` objects. If the column names of the two contacts provided to `epicontacts::make_epicontacts()` arguments `from` and `to` are not `from` and `to` they will be silently renamed in the resulting `<epicontacts>` object. By making these column names `from` and `to` when output from `sim_contacts()` or `sim_outbreak()` it prevents any confusion when used with {epicontacts}. This naming is also preferred as they are usefully descriptive.
 
-- The [Visualising simulated data vignette](vis-linelist.html) contains interactive data visualisation when rendered to the web. This enforces some limitations. The vignette uses `output: rmarkdown::html_document()` instead of `output: bookdown::html_vignette2` and does not contain `pkgdown: as_is: true` in the yaml metadata, in order for the interactive figures to render and operate correctly. This means that the vignette figures will not automatically be numbered and start with "Figure _x_" (where _x_ is replaced by a number). Instead, it was decided for this vignette that this information would be manually written, and then manually updated if the number or order of the figures changed. This is not an ideal solution and automation is preferred, but on balance, it was decided that the addition of interactive visualisation from {epicontacts} outweighed the downside of manual figure labelling.
-
 - Exported functions that simulate data use the naming convention `sim_*()` (where `*` is the placeholder). Internal functions that simulate have a dot (`.`) prefix (e.g. `.sim_internal()`). Functions that create fixed data structures (i.e. data factory functions) have the naming convention (`create_*()` or `.create_*()`).
 
 - The use of a `config` argument in the simulation function is to reduce the number of arguments in the exported functions and provide as simple a user-interface as possible. The choice of what gets an argument in the function body and what is confined to `config` list is based on preconceived frequency of use, importance and technical detail. That is to say, settings that are unlikely to be changed by the user or if they are changed require an advanced understanding of the simulation model are placed within the `config`, and given default values with `create_config()`.
@@ -69,12 +67,11 @@ The soft dependencies (and their minimum version requirements) are:
 * [{epicontacts}](https://CRAN.R-project.org/package=epicontacts) (>= 1.1.3)
 * [{knitr}](https://CRAN.R-project.org/package=knitr)
 * [{ggplot2}](https://CRAN.R-project.org/package=ggplot2)
-* [{bookdown}](https://CRAN.R-project.org/package=bookdown)
 * [{rmarkdown}](https://CRAN.R-project.org/package=rmarkdown)
 * [{spelling}](https://CRAN.R-project.org/package=spelling)
 * [{testthat}](https://CRAN.R-project.org/package=testthat) (>= 3.0.0)
 
-{knitr}, {bookdown}, {rmarkdown}, are all used for generating documentation. {spelling} and {testthat} are used for testing the code base. {ggplot2} is used for plotting within the vignettes. {incidence2} and {epicontacts} are used in vignettes to demonstrate interoperability with downstream packages, with a focus on data visualisation.
+{knitr}, {rmarkdown}, are all used for generating documentation. {spelling} and {testthat} are used for testing the code base. {ggplot2} is used for plotting within the vignettes. {incidence2} and {epicontacts} are used in vignettes to demonstrate interoperability with downstream packages, with a focus on data visualisation.
 
 ## Contribute
 

--- a/vignettes/simulist.Rmd
+++ b/vignettes/simulist.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Getting Started with {simulist}"
 output: 
-  bookdown::html_vignette2:
+  rmarkdown::html_vignette:
     code_folding: show
 vignette: >
   %\VignetteIndexEntry{Getting Started with {simulist}}

--- a/vignettes/simulist.Rmd
+++ b/vignettes/simulist.Rmd
@@ -3,8 +3,6 @@ title: "Getting Started with {simulist}"
 output: 
   bookdown::html_vignette2:
     code_folding: show
-pkgdown:
-  as_is: true
 vignette: >
   %\VignetteIndexEntry{Getting Started with {simulist}}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/simulist.Rmd
+++ b/vignettes/simulist.Rmd
@@ -1,8 +1,6 @@
 ---
 title: "Getting Started with {simulist}"
-output: 
-  rmarkdown::html_vignette:
-    code_folding: show
+output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Getting Started with {simulist}}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/time-varying-cfr.Rmd
+++ b/vignettes/time-varying-cfr.Rmd
@@ -207,7 +207,7 @@ config <- create_config(
 
 Here we set the case fatality risk to exponentially decrease through time. This will provide a shallow (monotonic) decline of case fatality through the simulated epidemic. 
 
-```{r, plot-exponential-dist, class.source = 'fold-hide', fig.cap="The time-varying hospitalised case fatality risk function (`config$time_varying_death_risk`) throughout the epidemic. In this case the hospitalised risks (`hosp_death_risk`) are at their maximum value at day 0 and decline through time, with risk approaching zero at around day 100.", fig.width = 8, fig.height = 5}
+```{r, plot-exponential-dist, fig.cap="The time-varying hospitalised case fatality risk function (`config$time_varying_death_risk`) throughout the epidemic. In this case the hospitalised risks (`hosp_death_risk`) are at their maximum value at day 0 and decline through time, with risk approaching zero at around day 100.", fig.width = 8, fig.height = 5}
 exp_df <- data.frame(
   time = 1:150,
   value = config$time_varying_death_risk(risk = 0.9, time = 1:150)
@@ -286,7 +286,7 @@ config <- create_config(
 # nolint end
 ```
 
-```{r, plot-stepwise-dist, class.source = 'fold-hide', fig.cap="The time-varying case fatality risk function (`config$time_varying_death_risk`) for the hospitalised death risk (`hosp_death_risk`) and non-hospitalised death risk (`non_hosp_death_risk`) throughout the epidemic. In this case the risks are at their user-supplied values from day 0 to day 60, and then become 0 onwards.", fig.width = 8, fig.height = 5}
+```{r, plot-stepwise-dist, fig.cap="The time-varying case fatality risk function (`config$time_varying_death_risk`) for the hospitalised death risk (`hosp_death_risk`) and non-hospitalised death risk (`non_hosp_death_risk`) throughout the epidemic. In this case the risks are at their user-supplied values from day 0 to day 60, and then become 0 onwards.", fig.width = 8, fig.height = 5}
 stepwise_df <- data.frame(
   time = 1:150,
   value = config$time_varying_death_risk(risk = 0.9, time = 1:150)
@@ -351,7 +351,7 @@ config <- create_config(
 )
 ```
 
-```{r, plot-stepwise-dist-window, class.source = 'fold-hide', fig.cap="The time-varying case fatality risk function (`config$time_varying_death_risk`) which scales the hospitalised death risk (`hosp_death_risk`) and non-hospitalised death risk (`non_hosp_death_risk`) throughout the epidemic. In this case the risks are at their maximum, user-supplied, values from day 0 to day 50, and then half the risks from day 50 to day 100, and then return to their maximum value from day 100 onwards.", fig.width = 8, fig.height = 5}
+```{r, plot-stepwise-dist-window, fig.cap="The time-varying case fatality risk function (`config$time_varying_death_risk`) which scales the hospitalised death risk (`hosp_death_risk`) and non-hospitalised death risk (`non_hosp_death_risk`) throughout the epidemic. In this case the risks are at their maximum, user-supplied, values from day 0 to day 50, and then half the risks from day 50 to day 100, and then return to their maximum value from day 100 onwards.", fig.width = 8, fig.height = 5}
 stepwise_df <- data.frame(
   time = 1:150,
   value = config$time_varying_death_risk(risk = 0.9, time = 1:150)

--- a/vignettes/time-varying-cfr.Rmd
+++ b/vignettes/time-varying-cfr.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Time-varying case fatality risk"
 output: 
-  bookdown::html_vignette2:
+  rmarkdown::html_vignette:
     code_folding: show
 vignette: >
   %\VignetteIndexEntry{Time-varying case fatality risk}

--- a/vignettes/time-varying-cfr.Rmd
+++ b/vignettes/time-varying-cfr.Rmd
@@ -1,8 +1,6 @@
 ---
 title: "Time-varying case fatality risk"
-output: 
-  rmarkdown::html_vignette:
-    code_folding: show
+output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Time-varying case fatality risk}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/time-varying-cfr.Rmd
+++ b/vignettes/time-varying-cfr.Rmd
@@ -3,8 +3,6 @@ title: "Time-varying case fatality risk"
 output: 
   bookdown::html_vignette2:
     code_folding: show
-pkgdown:
-  as_is: true
 vignette: >
   %\VignetteIndexEntry{Time-varying case fatality risk}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/vis-linelist.Rmd
+++ b/vignettes/vis-linelist.Rmd
@@ -101,7 +101,7 @@ daily <- incidence(x = linelist, date_index = "date_onset", interval = "daily")
 
 It is possible that not every date had the onset of symptoms, resulting in some dates missing entries. This is taken care of by the `complete_dates()` function in {incidence2}.
 
-```{r, complete-dates, fig.cap="Figure 1: Daily incidence of cases from symptom onset including days with zero cases.", fig.width = 8, fig.height = 5}
+```{r, complete-dates, fig.cap="Daily incidence of cases from symptom onset including days with zero cases.", fig.width = 8, fig.height = 5}
 # impute for days without cases
 daily <- complete_dates(daily)
 plot(daily)
@@ -109,14 +109,14 @@ plot(daily)
 
 Alternatively, incidence can be plotting weekly:
 
-```{r plot-weekly, fig.cap="Figure 2: Weekly incidence of cases from symptom onset", fig.width = 8, fig.height = 5}
+```{r plot-weekly, fig.cap="Weekly incidence of cases from symptom onset", fig.width = 8, fig.height = 5}
 weekly <- incidence(linelist, date_index = "date_onset", interval = "isoweek")
 plot(weekly)
 ```
 
 In order to check differences between a group in the line list data, for example sex, the `<incidence2>` data object can be recreated, specifying which columns to group by.
 
-```{r, group-by-sex, fig.cap="Figure 3: Weekly incidence of cases from symptom onset facetted by sex", fig.width = 8, fig.height = 5}
+```{r, group-by-sex, fig.cap="Weekly incidence of cases from symptom onset facetted by sex", fig.width = 8, fig.height = 5}
 weekly <- incidence(
   linelist,
   date_index = "date_onset",
@@ -162,7 +162,7 @@ linelist <- linelist %>%
 
 ## {-}
  
-```{r, plot-onset-hospitalisation, fig.cap="Figure 4: Daily incidence of cases from symptom onset and incidence of hospitalisations and deaths.", fig.width = 8, fig.height = 5}
+```{r, plot-onset-hospitalisation, fig.cap="Daily incidence of cases from symptom onset and incidence of hospitalisations and deaths.", fig.width = 8, fig.height = 5}
 daily <- incidence(
   linelist,
   date_index = c(
@@ -254,7 +254,7 @@ If you are viewing this vignette on the web (or on a web browser) the graph belo
 
 :::
 
-```{r, plot-epicontacts, fig.cap="Figure 5: Contact network from infectious disease outbreak. This includes all contacts, i.e. individuals that were infected and not infected"}
+```{r, plot-epicontacts, fig.cap="Contact network from infectious disease outbreak. This includes all contacts, i.e. individuals that were infected and not infected"}
 plot(epicontacts)
 ```
 
@@ -300,7 +300,7 @@ epicontacts <- make_epicontacts(
 epicontacts
 ```
 
-```{r, plot-cases-epicontacts, fig.cap="Figure 6: Transmission chain from infectious disease outbreak. This includes only individuals that were infected, including confirmed, probable and suspected cases."}
+```{r, plot-cases-epicontacts, fig.cap="Transmission chain from infectious disease outbreak. This includes only individuals that were infected, including confirmed, probable and suspected cases."}
 plot(epicontacts)
 ```
 


### PR DESCRIPTION
This PR makes several updates to ensure maximum compatibility with the newest {pkgdown} release ([2.1.0](https://pkgdown.r-lib.org/news/index.html#pkgdown-210)).

- All vignettes now use `output: rmarkdown::html_vignette` (some vignette were previously using `bookdown::html_vignette2`), as this reduces complications with {pkgdown} rendering (https://pkgdown.r-lib.org/reference/build_articles.html#output-formats).
- Remove `pkgdown: as_is: true` from vignettes to ensure math mode renders correctly
- Change `development: mode: auto` to `mode: unreleased` to ensure online documentation is always up-to-date with GitHub package (this will be reverted when {simulist} is hosted on CRAN)
- `code_folding: show` has been removed from all vignettes as it is not supported by {pkgdown} without `as_is: true`. `class.source = 'fold-hide'` is also removed from code chunks as a result. The alternative to use `<details>` (as recommended in {pkgdown} r-lib/pkgdown#1433) is not equivalent as it also folds the output of the code chunks including plots, therefore it was decided not use it. By default all code is shown including plotting code, which was folded by default in previous versions.
- The bullet point discussing the use of `rmarkdown::html_vignette` and `bookdown::html_vignette2` and its influence on interactive plots (html widgets) has been removed as it is no longer necessary as all vignettes use `rmarkdown::html_vignette`.
- Manual figure numbering has been removed from `vis-linelist.Rmd` vignette. All other vignettes no longer have figure numbering due to removing `bookdown::html_vignette2` and `as_is: true`.