### PR TITLE
Update {epiparameter} usage

### DIFF
--- a/R/sim_contacts.R
+++ b/R/sim_contacts.R
@@ -18,14 +18,14 @@
 #'
 #' # to simulate more realistic contact tracing data load epiparameters from
 #' # {epiparameter}
-#' contact_distribution <- epiparameter::epidist(
+#' contact_distribution <- epiparameter::epiparameter(
 #'   disease = "COVID-19",
 #'   epi_dist = "contact distribution",
 #'   prob_distribution = "pois",
 #'   prob_distribution_params = c(mean = 2)
 #' )
 #'
-#' infectious_period <- epiparameter::epidist(
+#' infectious_period <- epiparameter::epiparameter(
 #'   disease = "COVID-19",
 #'   epi_dist = "infectious period",
 #'   prob_distribution = "gamma",
@@ -52,8 +52,8 @@ sim_contacts <- function(contact_distribution = function(x) stats::dpois(x = x, 
                          config = create_config()) {
   # check and convert distribution to func if needed before .check_sim_input()
   stopifnot(
-    "Input delay distributions need to be either functions or <epidist>" =
-      inherits(infectious_period, c("function", "epidist"))
+    "Input delay distributions need to be either functions or <epiparameter>" =
+      inherits(infectious_period, c("function", "epiparameter"))
   )
   contact_distribution <- as.function(
     contact_distribution, func_type = "density"

--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -20,8 +20,8 @@
 #' * `proportion`: a column with the proportion of the population that are in
 #' that age group. Proportions must sum to one.
 #'
-#' @param contact_distribution A `function` or an `<epidist>` object to generate
-#' the number of contacts per infection.
+#' @param contact_distribution A `function` or an `<epiparameter>` object to
+#' generate the number of contacts per infection.
 #'
 #' The function can be defined or anonymous. The function must have a single
 #' argument in the form of an `integer` vector with elements representing the
@@ -33,13 +33,13 @@
 #' of observing zero contacts, the second element is the probability of
 #' observing one contact, etc.
 #'
-#' An `<epidist>` can be provided. This will be converted into a probability
-#' mass function internally.
+#' An `<epiparameter>` can be provided. This will be converted into a
+#' probability mass function internally.
 #'
 #' The default is an anonymous function with a Poisson probability mass function
 #' ([dpois()]) with a mean (\eqn{\lambda}) of 2 contacts per infection.
 #'
-#' @param infectious_period A `function` or an `<epidist>` object for the
+#' @param infectious_period A `function` or an `<epiparameter>` object for the
 #' infectious period. This defines the duration from becoming infectious to
 #' no longer infectious. In the simulation, individuals are assumed to
 #' become infectious immediately after being infected (the latency period is
@@ -52,8 +52,8 @@
 #' The function must have a single argument, the number of random infectious
 #' periods to generate.
 #'
-#' An `<epidist>` can be provided. This will be converted into random number
-#' generator internally.
+#' An `<epiparameter>` can be provided. This will be converted into random
+#' number generator internally.
 #'
 #' The default is an anonymous function with a lognormal distribution random
 #' number generator ([rlnorm()]) with `meanlog = 2` and `sdlog = 0.5`.
@@ -61,7 +61,7 @@
 #' @param prob_infection A single `numeric` for the probability of a secondary
 #' contact being infected by an infected primary contact.
 #'
-#' @param onset_to_hosp A `function` or an `<epidist>` object for the
+#' @param onset_to_hosp A `function` or an `<epiparameter>` object for the
 #' onset-to-hospitalisation delay distribution. `onset_to_hosp` can also be
 #' set to `NULL` to not simulate hospitalisation (admission) dates.
 #'
@@ -69,8 +69,8 @@
 #' of `numeric`s for the length of the onset-to-hospitalisation delay. The
 #' function must have a single argument.
 #'
-#' An `<epidist>` can be provided. This will be converted into a random number
-#' generator internally.
+#' An `<epiparameter>` can be provided. This will be converted into a random
+#' number generator internally.
 #'
 #' The default is an anonymous function with a lognormal distribution random
 #' number generator ([rlnorm()]) with `meanlog = 1.5` and `sdlog = 0.5`.
@@ -78,7 +78,7 @@
 #' If `onset_to_hosp` is set to `NULL` then `hosp_risk` and `hosp_death_risk`
 #' will be automatically set to `NULL` if not manually specified.
 #'
-#' @param onset_to_death A `function` or an `<epidist>` object for the
+#' @param onset_to_death A `function` or an `<epiparameter>` object for the
 #' onset-to-death delay distribution. `onset_to_death` can also be set to
 #' `NULL` to not simulate dates for individuals that died.
 #'
@@ -86,8 +86,8 @@
 #' of `numeric`s for the length of the onset-to-death delay. The function must
 #' have a single argument.
 #'
-#' An `<epidist>` can be provided. This will be converted into a random number
-#' generator internally.
+#' An `<epiparameter>` can be provided. This will be converted into a random
+#' number generator internally.
 #'
 #' The default is an anonymous function with a lognormal distribution random
 #' number generator ([rlnorm()]) with `meanlog = 2.5` and `sdlog = 0.5`.
@@ -96,7 +96,7 @@
 #' `hosp_death_risk` will be automatically set to `NULL` if not manually
 #' specified.
 #'
-#' @param onset_to_recovery A `function` or an `<epidist>` object for the
+#' @param onset_to_recovery A `function` or an `<epiparameter>` object for the
 #' onset-to-recovery delay distribution. `onset_to_recovery` can also be `NULL`
 #' to not simulate dates for individuals that recovered.
 #'
@@ -104,8 +104,8 @@
 #' of `numeric`s for the length of the onset-to-recovery delay. The function
 #' must have a single argument.
 #'
-#' An `<epidist>` can be provided. This will be converted into a random number
-#' generator internally.
+#' An `<epiparameter>` can be provided. This will be converted into a random
+#' number generator internally.
 #'
 #' The default is `NULL` so by default cases that recover get an `NA` in the
 #' `$date_outcome` line list column.
@@ -180,14 +180,14 @@
 #'
 #' # to simulate a more realistic line list load epiparameters from
 #' # {epiparameter}
-#' contact_distribution <- epiparameter::epidist(
+#' contact_distribution <- epiparameter::epiparameter(
 #'   disease = "COVID-19",
 #'   epi_dist = "contact distribution",
 #'   prob_distribution = "pois",
 #'   prob_distribution_params = c(mean = 2)
 #' )
 #'
-#' infectious_period <- epiparameter::epidist(
+#' infectious_period <- epiparameter::epiparameter(
 #'   disease = "COVID-19",
 #'   epi_dist = "infectious period",
 #'   prob_distribution = "gamma",
@@ -195,17 +195,17 @@
 #' )
 #'
 #' # get onset to hospital admission from {epiparameter} database
-#' onset_to_hosp <- epiparameter::epidist_db(
+#' onset_to_hosp <- epiparameter::epiparameter_db(
 #'   disease = "COVID-19",
 #'   epi_dist = "onset to hospitalisation",
-#'   single_epidist = TRUE
+#'   single_epiparameter = TRUE
 #' )
 #'
 #' # get onset to death from {epiparameter} database
-#' onset_to_death <- epiparameter::epidist_db(
+#' onset_to_death <- epiparameter::epiparameter_db(
 #'   disease = "COVID-19",
 #'   epi_dist = "onset to death",
-#'   single_epidist = TRUE
+#'   single_epiparameter = TRUE
 #' )
 #' # example with single hospitalisation risk for entire population
 #' linelist <- sim_linelist(

--- a/R/sim_outbreak.R
+++ b/R/sim_outbreak.R
@@ -23,14 +23,14 @@
 #'
 #' # to simulate a more realistic outbreak load epiparameters from
 #' # {epiparameter}
-#' contact_distribution <- epiparameter::epidist(
+#' contact_distribution <- epiparameter::epiparameter(
 #'   disease = "COVID-19",
 #'   epi_dist = "contact distribution",
 #'   prob_distribution = "pois",
 #'   prob_distribution_params = c(mean = 2)
 #' )
 #'
-#' infectious_period <- epiparameter::epidist(
+#' infectious_period <- epiparameter::epiparameter(
 #'   disease = "COVID-19",
 #'   epi_dist = "infectious period",
 #'   prob_distribution = "gamma",
@@ -38,17 +38,17 @@
 #' )
 #'
 #' # get onset to hospital admission from {epiparameter} database
-#' onset_to_hosp <- epiparameter::epidist_db(
+#' onset_to_hosp <- epiparameter::epiparameter_db(
 #'   disease = "COVID-19",
 #'   epi_dist = "onset to hospitalisation",
-#'   single_epidist = TRUE
+#'   single_epiparameter = TRUE
 #' )
 #'
 #' # get onset to death from {epiparameter} database
-#' onset_to_death <- epiparameter::epidist_db(
+#' onset_to_death <- epiparameter::epiparameter_db(
 #'   disease = "COVID-19",
 #'   epi_dist = "onset to death",
-#'   single_epidist = TRUE
+#'   single_epiparameter = TRUE
 #' )
 #'
 #' outbreak <- sim_outbreak(

--- a/R/simulist-package.R
+++ b/R/simulist-package.R
@@ -10,6 +10,6 @@ NULL
 # nocov start
 # fix for R CMD check from https://github.com/hadley/r-pkgs/issues/828
 ignore_unused_imports <- function() {
-  epiparameter::epidist
+  epiparameter::epiparameter
 }
 # nocov end

--- a/R/utils.R
+++ b/R/utils.R
@@ -120,7 +120,7 @@
   out
 }
 
-#' Convert `<epidist>` or `NULL` to function
+#' Convert `<epiparameter>` or `NULL` to function
 #'
 #' @description
 #' An extension to [as.function()], particularly the \pkg{epiparameter}
@@ -132,25 +132,26 @@
 #' If a function is already passed to `as_function` it will be returned
 #' unchanged.
 #'
-#' There is also input checking to error if input is not an `<epidist>`,
+#' There is also input checking to error if input is not an `<epiparameter>`,
 #' `function` ([closure]), or for onset-to-event distributions `NULL`.
 #'
-#' @param x A named list containing either `<epidist>`, `function` or `NULL`.
-#' Named list elements are: `"contact_distribution"`, `"infectious_period"`,
-#' `"onset_to_hosp"`, `"onset_to_death"`, `"onset_to_recovery".`
+#' @param x A named list containing either `<epiparameter>`, `function` or
+#' `NULL`. Named list elements are: `"contact_distribution"`,
+#' `"infectious_period"`, `"onset_to_hosp"`, `"onset_to_death"`,
+#' `"onset_to_recovery".`
 #'
 #' @return A list of `function`s.
 #' @keywords internal
 as_function <- function(x) {
   stopifnot(
-    "Input delay distributions need to be either functions or <epidist>" =
-      inherits(x$contact_distribution, c("function", "epidist")) &&
-      inherits(x$infectious_period, c("function", "epidist")),
+    "Input delay distributions need to be either functions or <epiparameter>" =
+      inherits(x$contact_distribution, c("function", "epiparameter")) &&
+      inherits(x$infectious_period, c("function", "epiparameter")),
     "onset_to_hosp, onset_to_death and onset_to_recovery need to be a function,
-    <epidist> or NULL" =
-      (inherits(x$onset_to_hosp, c("function", "epidist")) ||
+    <epiparameter> or NULL" =
+      (inherits(x$onset_to_hosp, c("function", "epiparameter")) ||
       is.null(x$onset_to_hosp)) &&
-      (inherits(x$onset_to_death, c("function", "epidist")) ||
+      (inherits(x$onset_to_death, c("function", "epiparameter")) ||
       is.null(x$onset_to_death))
   )
   contact_distribution <- as.function(

--- a/README.Rmd
+++ b/README.Rmd
@@ -75,7 +75,7 @@ library(epiparameter)
 
 ```{r create-epidists}
 # create COVID-19 contact distribution
-contact_distribution <- epiparameter::epidist(
+contact_distribution <- epiparameter::epiparameter(
   disease = "COVID-19", 
   epi_dist = "contact distribution", 
   prob_distribution = "pois", 
@@ -83,7 +83,7 @@ contact_distribution <- epiparameter::epidist(
 )
 
 # create COVID-19 infectious period
-infectious_period <- epiparameter::epidist(
+infectious_period <- epiparameter::epiparameter(
   disease = "COVID-19",
   epi_dist = "infectious period",
   prob_distribution = "gamma",
@@ -91,17 +91,17 @@ infectious_period <- epiparameter::epidist(
 )
 
 # get onset to hospital admission from {epiparameter} database
-onset_to_hosp <- epiparameter::epidist_db(
+onset_to_hosp <- epiparameter::epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to hospitalisation",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 
 # get onset to death from {epiparameter} database
-onset_to_death <- epiparameter::epidist_db(
+onset_to_death <- epiparameter::epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to death",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ library(epiparameter)
 
 ``` r
 # create COVID-19 contact distribution
-contact_distribution <- epiparameter::epidist(
+contact_distribution <- epiparameter::epiparameter(
   disease = "COVID-19", 
   epi_dist = "contact distribution", 
   prob_distribution = "pois", 
@@ -109,7 +109,7 @@ contact_distribution <- epiparameter::epidist(
 #> Citation cannot be created as author, year, journal or title is missing
 
 # create COVID-19 infectious period
-infectious_period <- epiparameter::epidist(
+infectious_period <- epiparameter::epiparameter(
   disease = "COVID-19",
   epi_dist = "infectious period",
   prob_distribution = "gamma",
@@ -118,10 +118,10 @@ infectious_period <- epiparameter::epidist(
 #> Citation cannot be created as author, year, journal or title is missing
 
 # get onset to hospital admission from {epiparameter} database
-onset_to_hosp <- epiparameter::epidist_db(
+onset_to_hosp <- epiparameter::epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to hospitalisation",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 #> Using Linton N, Kobayashi T, Yang Y, Hayashi K, Akhmetzhanov A, Jung S, Yuan
 #> B, Kinoshita R, Nishiura H (2020). "Incubation Period and Other
@@ -132,10 +132,10 @@ onset_to_hosp <- epiparameter::epidist_db(
 #> To retrieve the citation use the 'get_citation' function
 
 # get onset to death from {epiparameter} database
-onset_to_death <- epiparameter::epidist_db(
+onset_to_death <- epiparameter::epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to death",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 #> Using Linton N, Kobayashi T, Yang Y, Hayashi K, Akhmetzhanov A, Jung S, Yuan
 #> B, Kinoshita R, Nishiura H (2020). "Incubation Period and Other

--- a/man/as_function.Rd
+++ b/man/as_function.Rd
@@ -2,14 +2,15 @@
 % Please edit documentation in R/utils.R
 \name{as_function}
 \alias{as_function}
-\title{Convert \verb{<epidist>} or \code{NULL} to function}
+\title{Convert \verb{<epiparameter>} or \code{NULL} to function}
 \usage{
 as_function(x)
 }
 \arguments{
-\item{x}{A named list containing either \verb{<epidist>}, \code{function} or \code{NULL}.
-Named list elements are: \code{"contact_distribution"}, \code{"infectious_period"},
-\code{"onset_to_hosp"}, \code{"onset_to_death"}, \verb{"onset_to_recovery".}}
+\item{x}{A named list containing either \verb{<epiparameter>}, \code{function} or
+\code{NULL}. Named list elements are: \code{"contact_distribution"},
+\code{"infectious_period"}, \code{"onset_to_hosp"}, \code{"onset_to_death"},
+\verb{"onset_to_recovery".}}
 }
 \value{
 A list of \code{function}s.
@@ -24,7 +25,7 @@ the generator functions output from
 If a function is already passed to \code{as_function} it will be returned
 unchanged.
 
-There is also input checking to error if input is not an \verb{<epidist>},
+There is also input checking to error if input is not an \verb{<epiparameter>},
 \code{function} (\link{closure}), or for onset-to-event distributions \code{NULL}.
 }
 \keyword{internal}

--- a/man/dot-add_cols.Rd
+++ b/man/dot-add_cols.Rd
@@ -49,7 +49,7 @@ given in the \code{distribution} argument.}
 
 \item{outbreak_start_date}{A \code{date} for the start of the outbreak.}
 
-\item{onset_to_hosp}{A \code{function} or an \verb{<epidist>} object for the
+\item{onset_to_hosp}{A \code{function} or an \verb{<epiparameter>} object for the
 onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
 set to \code{NULL} to not simulate hospitalisation (admission) dates.
 
@@ -57,8 +57,8 @@ The function can be defined or anonymous. The function must return a vector
 of \code{numeric}s for the length of the onset-to-hospitalisation delay. The
 function must have a single argument.
 
-An \verb{<epidist>} can be provided. This will be converted into a random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.
@@ -73,7 +73,7 @@ population. If the \code{onset_to_hosp} argument is set to \code{NULL} this argu
 will automatically be set to \code{NULL} if not specified or can be manually
 set to \code{NULL}. See details and examples for more information.}
 
-\item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
+\item{onset_to_death}{A \code{function} or an \verb{<epiparameter>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
 \code{NULL} to not simulate dates for individuals that died.
 
@@ -81,8 +81,8 @@ The function can be defined or anonymous. The function must return a vector
 of \code{numeric}s for the length of the onset-to-death delay. The function must
 have a single argument.
 
-An \verb{<epidist>} can be provided. This will be converted into a random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.
@@ -91,7 +91,7 @@ If \code{onset_to_death} is set to \code{NULL} then \code{non_hosp_death_risk} a
 \code{hosp_death_risk} will be automatically set to \code{NULL} if not manually
 specified.}
 
-\item{onset_to_recovery}{A \code{function} or an \verb{<epidist>} object for the
+\item{onset_to_recovery}{A \code{function} or an \verb{<epiparameter>} object for the
 onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
 to not simulate dates for individuals that recovered.
 
@@ -99,8 +99,8 @@ The function can be defined or anonymous. The function must return a vector
 of \code{numeric}s for the length of the onset-to-recovery delay. The function
 must have a single argument.
 
-An \verb{<epidist>} can be provided. This will be converted into a random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a random
+number generator internally.
 
 The default is \code{NULL} so by default cases that recover get an \code{NA} in the
 \verb{$date_outcome} line list column.}

--- a/man/dot-check_sim_input.Rd
+++ b/man/dot-check_sim_input.Rd
@@ -27,8 +27,8 @@
 \item{sim_type}{A \code{character} string specifying which simulation function
 this function is being called within.}
 
-\item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
-the number of contacts per infection.
+\item{contact_distribution}{A \code{function} or an \verb{<epiparameter>} object to
+generate the number of contacts per infection.
 
 The function can be defined or anonymous. The function must have a single
 argument in the form of an \code{integer} vector with elements representing the
@@ -40,13 +40,13 @@ of contacts, i.e. the first element of the output vector is the probability
 of observing zero contacts, the second element is the probability of
 observing one contact, etc.
 
-An \verb{<epidist>} can be provided. This will be converted into a probability
-mass function internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a
+probability mass function internally.
 
 The default is an anonymous function with a Poisson probability mass function
 (\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
 
-\item{infectious_period}{A \code{function} or an \verb{<epidist>} object for the
+\item{infectious_period}{A \code{function} or an \verb{<epiparameter>} object for the
 infectious period. This defines the duration from becoming infectious to
 no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
@@ -59,8 +59,8 @@ of randomly generated real numbers representing sampled infectious periods.
 The function must have a single argument, the number of random infectious
 periods to generate.
 
-An \verb{<epidist>} can be provided. This will be converted into random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \code{sdlog = 0.5}.}
@@ -81,7 +81,7 @@ many iterations (internally) then the function errors, whereas if the
 maximum outbreak size is exceeded the function returns the data early and a
 warning stating how many cases and contacts are returned.}
 
-\item{onset_to_hosp}{A \code{function} or an \verb{<epidist>} object for the
+\item{onset_to_hosp}{A \code{function} or an \verb{<epiparameter>} object for the
 onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
 set to \code{NULL} to not simulate hospitalisation (admission) dates.
 
@@ -89,8 +89,8 @@ The function can be defined or anonymous. The function must return a vector
 of \code{numeric}s for the length of the onset-to-hospitalisation delay. The
 function must have a single argument.
 
-An \verb{<epidist>} can be provided. This will be converted into a random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.
@@ -98,7 +98,7 @@ number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and
 If \code{onset_to_hosp} is set to \code{NULL} then \code{hosp_risk} and \code{hosp_death_risk}
 will be automatically set to \code{NULL} if not manually specified.}
 
-\item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
+\item{onset_to_death}{A \code{function} or an \verb{<epiparameter>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
 \code{NULL} to not simulate dates for individuals that died.
 
@@ -106,8 +106,8 @@ The function can be defined or anonymous. The function must return a vector
 of \code{numeric}s for the length of the onset-to-death delay. The function must
 have a single argument.
 
-An \verb{<epidist>} can be provided. This will be converted into a random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.
@@ -116,7 +116,7 @@ If \code{onset_to_death} is set to \code{NULL} then \code{non_hosp_death_risk} a
 \code{hosp_death_risk} will be automatically set to \code{NULL} if not manually
 specified.}
 
-\item{onset_to_recovery}{A \code{function} or an \verb{<epidist>} object for the
+\item{onset_to_recovery}{A \code{function} or an \verb{<epiparameter>} object for the
 onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
 to not simulate dates for individuals that recovered.
 
@@ -124,8 +124,8 @@ The function can be defined or anonymous. The function must return a vector
 of \code{numeric}s for the length of the onset-to-recovery delay. The function
 must have a single argument.
 
-An \verb{<epidist>} can be provided. This will be converted into a random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a random
+number generator internally.
 
 The default is \code{NULL} so by default cases that recover get an \code{NA} in the
 \verb{$date_outcome} line list column.}

--- a/man/dot-cross_check_sim_input.Rd
+++ b/man/dot-cross_check_sim_input.Rd
@@ -14,7 +14,7 @@ compatible with hospitalisation and death risks}
 )
 }
 \arguments{
-\item{onset_to_hosp}{A \code{function} or an \verb{<epidist>} object for the
+\item{onset_to_hosp}{A \code{function} or an \verb{<epiparameter>} object for the
 onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
 set to \code{NULL} to not simulate hospitalisation (admission) dates.
 
@@ -22,8 +22,8 @@ The function can be defined or anonymous. The function must return a vector
 of \code{numeric}s for the length of the onset-to-hospitalisation delay. The
 function must have a single argument.
 
-An \verb{<epidist>} can be provided. This will be converted into a random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.
@@ -31,7 +31,7 @@ number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and
 If \code{onset_to_hosp} is set to \code{NULL} then \code{hosp_risk} and \code{hosp_death_risk}
 will be automatically set to \code{NULL} if not manually specified.}
 
-\item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
+\item{onset_to_death}{A \code{function} or an \verb{<epiparameter>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
 \code{NULL} to not simulate dates for individuals that died.
 
@@ -39,8 +39,8 @@ The function can be defined or anonymous. The function must return a vector
 of \code{numeric}s for the length of the onset-to-death delay. The function must
 have a single argument.
 
-An \verb{<epidist>} can be provided. This will be converted into a random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.

--- a/man/dot-sim_internal.Rd
+++ b/man/dot-sim_internal.Rd
@@ -29,8 +29,8 @@ within \pkg{simulist}}
 \item{sim_type}{A \code{character} string specifying which simulation function
 this function is being called within.}
 
-\item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
-the number of contacts per infection.
+\item{contact_distribution}{A \code{function} or an \verb{<epiparameter>} object to
+generate the number of contacts per infection.
 
 The function can be defined or anonymous. The function must have a single
 argument in the form of an \code{integer} vector with elements representing the
@@ -42,13 +42,13 @@ of contacts, i.e. the first element of the output vector is the probability
 of observing zero contacts, the second element is the probability of
 observing one contact, etc.
 
-An \verb{<epidist>} can be provided. This will be converted into a probability
-mass function internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a
+probability mass function internally.
 
 The default is an anonymous function with a Poisson probability mass function
 (\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
 
-\item{infectious_period}{A \code{function} or an \verb{<epidist>} object for the
+\item{infectious_period}{A \code{function} or an \verb{<epiparameter>} object for the
 infectious period. This defines the duration from becoming infectious to
 no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
@@ -61,8 +61,8 @@ of randomly generated real numbers representing sampled infectious periods.
 The function must have a single argument, the number of random infectious
 periods to generate.
 
-An \verb{<epidist>} can be provided. This will be converted into random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \code{sdlog = 0.5}.}
@@ -70,7 +70,7 @@ number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \
 \item{prob_infection}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}
 
-\item{onset_to_hosp}{A \code{function} or an \verb{<epidist>} object for the
+\item{onset_to_hosp}{A \code{function} or an \verb{<epiparameter>} object for the
 onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
 set to \code{NULL} to not simulate hospitalisation (admission) dates.
 
@@ -78,8 +78,8 @@ The function can be defined or anonymous. The function must return a vector
 of \code{numeric}s for the length of the onset-to-hospitalisation delay. The
 function must have a single argument.
 
-An \verb{<epidist>} can be provided. This will be converted into a random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.
@@ -87,7 +87,7 @@ number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and
 If \code{onset_to_hosp} is set to \code{NULL} then \code{hosp_risk} and \code{hosp_death_risk}
 will be automatically set to \code{NULL} if not manually specified.}
 
-\item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
+\item{onset_to_death}{A \code{function} or an \verb{<epiparameter>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
 \code{NULL} to not simulate dates for individuals that died.
 
@@ -95,8 +95,8 @@ The function can be defined or anonymous. The function must return a vector
 of \code{numeric}s for the length of the onset-to-death delay. The function must
 have a single argument.
 
-An \verb{<epidist>} can be provided. This will be converted into a random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.
@@ -105,7 +105,7 @@ If \code{onset_to_death} is set to \code{NULL} then \code{non_hosp_death_risk} a
 \code{hosp_death_risk} will be automatically set to \code{NULL} if not manually
 specified.}
 
-\item{onset_to_recovery}{A \code{function} or an \verb{<epidist>} object for the
+\item{onset_to_recovery}{A \code{function} or an \verb{<epiparameter>} object for the
 onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
 to not simulate dates for individuals that recovered.
 
@@ -113,8 +113,8 @@ The function can be defined or anonymous. The function must return a vector
 of \code{numeric}s for the length of the onset-to-recovery delay. The function
 must have a single argument.
 
-An \verb{<epidist>} can be provided. This will be converted into a random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a random
+number generator internally.
 
 The default is \code{NULL} so by default cases that recover get an \code{NA} in the
 \verb{$date_outcome} line list column.}

--- a/man/dot-sim_network_bp.Rd
+++ b/man/dot-sim_network_bp.Rd
@@ -14,8 +14,8 @@ infection for each contact}
 )
 }
 \arguments{
-\item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
-the number of contacts per infection.
+\item{contact_distribution}{A \code{function} or an \verb{<epiparameter>} object to
+generate the number of contacts per infection.
 
 The function can be defined or anonymous. The function must have a single
 argument in the form of an \code{integer} vector with elements representing the
@@ -27,13 +27,13 @@ of contacts, i.e. the first element of the output vector is the probability
 of observing zero contacts, the second element is the probability of
 observing one contact, etc.
 
-An \verb{<epidist>} can be provided. This will be converted into a probability
-mass function internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a
+probability mass function internally.
 
 The default is an anonymous function with a Poisson probability mass function
 (\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
 
-\item{infectious_period}{A \code{function} or an \verb{<epidist>} object for the
+\item{infectious_period}{A \code{function} or an \verb{<epiparameter>} object for the
 infectious period. This defines the duration from becoming infectious to
 no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
@@ -46,8 +46,8 @@ of randomly generated real numbers representing sampled infectious periods.
 The function must have a single argument, the number of random infectious
 periods to generate.
 
-An \verb{<epidist>} can be provided. This will be converted into random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \code{sdlog = 0.5}.}

--- a/man/sim_contacts.Rd
+++ b/man/sim_contacts.Rd
@@ -18,8 +18,8 @@ sim_contacts(
 )
 }
 \arguments{
-\item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
-the number of contacts per infection.
+\item{contact_distribution}{A \code{function} or an \verb{<epiparameter>} object to
+generate the number of contacts per infection.
 
 The function can be defined or anonymous. The function must have a single
 argument in the form of an \code{integer} vector with elements representing the
@@ -31,13 +31,13 @@ of contacts, i.e. the first element of the output vector is the probability
 of observing zero contacts, the second element is the probability of
 observing one contact, etc.
 
-An \verb{<epidist>} can be provided. This will be converted into a probability
-mass function internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a
+probability mass function internally.
 
 The default is an anonymous function with a Poisson probability mass function
 (\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
 
-\item{infectious_period}{A \code{function} or an \verb{<epidist>} object for the
+\item{infectious_period}{A \code{function} or an \verb{<epiparameter>} object for the
 infectious period. This defines the duration from becoming infectious to
 no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
@@ -50,8 +50,8 @@ of randomly generated real numbers representing sampled infectious periods.
 The function must have a single argument, the number of random infectious
 periods to generate.
 
-An \verb{<epidist>} can be provided. This will be converted into random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \code{sdlog = 0.5}.}
@@ -104,14 +104,14 @@ head(contacts)
 
 # to simulate more realistic contact tracing data load epiparameters from
 # {epiparameter}
-contact_distribution <- epiparameter::epidist(
+contact_distribution <- epiparameter::epiparameter(
   disease = "COVID-19",
   epi_dist = "contact distribution",
   prob_distribution = "pois",
   prob_distribution_params = c(mean = 2)
 )
 
-infectious_period <- epiparameter::epidist(
+infectious_period <- epiparameter::epiparameter(
   disease = "COVID-19",
   epi_dist = "infectious period",
   prob_distribution = "gamma",

--- a/man/sim_linelist.Rd
+++ b/man/sim_linelist.Rd
@@ -23,8 +23,8 @@ sim_linelist(
 )
 }
 \arguments{
-\item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
-the number of contacts per infection.
+\item{contact_distribution}{A \code{function} or an \verb{<epiparameter>} object to
+generate the number of contacts per infection.
 
 The function can be defined or anonymous. The function must have a single
 argument in the form of an \code{integer} vector with elements representing the
@@ -36,13 +36,13 @@ of contacts, i.e. the first element of the output vector is the probability
 of observing zero contacts, the second element is the probability of
 observing one contact, etc.
 
-An \verb{<epidist>} can be provided. This will be converted into a probability
-mass function internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a
+probability mass function internally.
 
 The default is an anonymous function with a Poisson probability mass function
 (\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
 
-\item{infectious_period}{A \code{function} or an \verb{<epidist>} object for the
+\item{infectious_period}{A \code{function} or an \verb{<epiparameter>} object for the
 infectious period. This defines the duration from becoming infectious to
 no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
@@ -55,8 +55,8 @@ of randomly generated real numbers representing sampled infectious periods.
 The function must have a single argument, the number of random infectious
 periods to generate.
 
-An \verb{<epidist>} can be provided. This will be converted into random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \code{sdlog = 0.5}.}
@@ -64,7 +64,7 @@ number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \
 \item{prob_infection}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}
 
-\item{onset_to_hosp}{A \code{function} or an \verb{<epidist>} object for the
+\item{onset_to_hosp}{A \code{function} or an \verb{<epiparameter>} object for the
 onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
 set to \code{NULL} to not simulate hospitalisation (admission) dates.
 
@@ -72,8 +72,8 @@ The function can be defined or anonymous. The function must return a vector
 of \code{numeric}s for the length of the onset-to-hospitalisation delay. The
 function must have a single argument.
 
-An \verb{<epidist>} can be provided. This will be converted into a random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.
@@ -81,7 +81,7 @@ number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and
 If \code{onset_to_hosp} is set to \code{NULL} then \code{hosp_risk} and \code{hosp_death_risk}
 will be automatically set to \code{NULL} if not manually specified.}
 
-\item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
+\item{onset_to_death}{A \code{function} or an \verb{<epiparameter>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
 \code{NULL} to not simulate dates for individuals that died.
 
@@ -89,8 +89,8 @@ The function can be defined or anonymous. The function must return a vector
 of \code{numeric}s for the length of the onset-to-death delay. The function must
 have a single argument.
 
-An \verb{<epidist>} can be provided. This will be converted into a random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.
@@ -99,7 +99,7 @@ If \code{onset_to_death} is set to \code{NULL} then \code{non_hosp_death_risk} a
 \code{hosp_death_risk} will be automatically set to \code{NULL} if not manually
 specified.}
 
-\item{onset_to_recovery}{A \code{function} or an \verb{<epidist>} object for the
+\item{onset_to_recovery}{A \code{function} or an \verb{<epiparameter>} object for the
 onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
 to not simulate dates for individuals that recovered.
 
@@ -107,8 +107,8 @@ The function can be defined or anonymous. The function must return a vector
 of \code{numeric}s for the length of the onset-to-recovery delay. The function
 must have a single argument.
 
-An \verb{<epidist>} can be provided. This will be converted into a random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a random
+number generator internally.
 
 The default is \code{NULL} so by default cases that recover get an \code{NA} in the
 \verb{$date_outcome} line list column.}
@@ -207,14 +207,14 @@ head(linelist)
 
 # to simulate a more realistic line list load epiparameters from
 # {epiparameter}
-contact_distribution <- epiparameter::epidist(
+contact_distribution <- epiparameter::epiparameter(
   disease = "COVID-19",
   epi_dist = "contact distribution",
   prob_distribution = "pois",
   prob_distribution_params = c(mean = 2)
 )
 
-infectious_period <- epiparameter::epidist(
+infectious_period <- epiparameter::epiparameter(
   disease = "COVID-19",
   epi_dist = "infectious period",
   prob_distribution = "gamma",
@@ -222,17 +222,17 @@ infectious_period <- epiparameter::epidist(
 )
 
 # get onset to hospital admission from {epiparameter} database
-onset_to_hosp <- epiparameter::epidist_db(
+onset_to_hosp <- epiparameter::epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to hospitalisation",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 
 # get onset to death from {epiparameter} database
-onset_to_death <- epiparameter::epidist_db(
+onset_to_death <- epiparameter::epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to death",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 # example with single hospitalisation risk for entire population
 linelist <- sim_linelist(

--- a/man/sim_outbreak.Rd
+++ b/man/sim_outbreak.Rd
@@ -25,8 +25,8 @@ sim_outbreak(
 )
 }
 \arguments{
-\item{contact_distribution}{A \code{function} or an \verb{<epidist>} object to generate
-the number of contacts per infection.
+\item{contact_distribution}{A \code{function} or an \verb{<epiparameter>} object to
+generate the number of contacts per infection.
 
 The function can be defined or anonymous. The function must have a single
 argument in the form of an \code{integer} vector with elements representing the
@@ -38,13 +38,13 @@ of contacts, i.e. the first element of the output vector is the probability
 of observing zero contacts, the second element is the probability of
 observing one contact, etc.
 
-An \verb{<epidist>} can be provided. This will be converted into a probability
-mass function internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a
+probability mass function internally.
 
 The default is an anonymous function with a Poisson probability mass function
 (\code{\link[=dpois]{dpois()}}) with a mean (\eqn{\lambda}) of 2 contacts per infection.}
 
-\item{infectious_period}{A \code{function} or an \verb{<epidist>} object for the
+\item{infectious_period}{A \code{function} or an \verb{<epiparameter>} object for the
 infectious period. This defines the duration from becoming infectious to
 no longer infectious. In the simulation, individuals are assumed to
 become infectious immediately after being infected (the latency period is
@@ -57,8 +57,8 @@ of randomly generated real numbers representing sampled infectious periods.
 The function must have a single argument, the number of random infectious
 periods to generate.
 
-An \verb{<epidist>} can be provided. This will be converted into random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \code{sdlog = 0.5}.}
@@ -66,7 +66,7 @@ number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2} and \
 \item{prob_infection}{A single \code{numeric} for the probability of a secondary
 contact being infected by an infected primary contact.}
 
-\item{onset_to_hosp}{A \code{function} or an \verb{<epidist>} object for the
+\item{onset_to_hosp}{A \code{function} or an \verb{<epiparameter>} object for the
 onset-to-hospitalisation delay distribution. \code{onset_to_hosp} can also be
 set to \code{NULL} to not simulate hospitalisation (admission) dates.
 
@@ -74,8 +74,8 @@ The function can be defined or anonymous. The function must return a vector
 of \code{numeric}s for the length of the onset-to-hospitalisation delay. The
 function must have a single argument.
 
-An \verb{<epidist>} can be provided. This will be converted into a random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and \code{sdlog = 0.5}.
@@ -83,7 +83,7 @@ number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 1.5} and
 If \code{onset_to_hosp} is set to \code{NULL} then \code{hosp_risk} and \code{hosp_death_risk}
 will be automatically set to \code{NULL} if not manually specified.}
 
-\item{onset_to_death}{A \code{function} or an \verb{<epidist>} object for the
+\item{onset_to_death}{A \code{function} or an \verb{<epiparameter>} object for the
 onset-to-death delay distribution. \code{onset_to_death} can also be set to
 \code{NULL} to not simulate dates for individuals that died.
 
@@ -91,8 +91,8 @@ The function can be defined or anonymous. The function must return a vector
 of \code{numeric}s for the length of the onset-to-death delay. The function must
 have a single argument.
 
-An \verb{<epidist>} can be provided. This will be converted into a random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a random
+number generator internally.
 
 The default is an anonymous function with a lognormal distribution random
 number generator (\code{\link[=rlnorm]{rlnorm()}}) with \code{meanlog = 2.5} and \code{sdlog = 0.5}.
@@ -101,7 +101,7 @@ If \code{onset_to_death} is set to \code{NULL} then \code{non_hosp_death_risk} a
 \code{hosp_death_risk} will be automatically set to \code{NULL} if not manually
 specified.}
 
-\item{onset_to_recovery}{A \code{function} or an \verb{<epidist>} object for the
+\item{onset_to_recovery}{A \code{function} or an \verb{<epiparameter>} object for the
 onset-to-recovery delay distribution. \code{onset_to_recovery} can also be \code{NULL}
 to not simulate dates for individuals that recovered.
 
@@ -109,8 +109,8 @@ The function can be defined or anonymous. The function must return a vector
 of \code{numeric}s for the length of the onset-to-recovery delay. The function
 must have a single argument.
 
-An \verb{<epidist>} can be provided. This will be converted into a random number
-generator internally.
+An \verb{<epiparameter>} can be provided. This will be converted into a random
+number generator internally.
 
 The default is \code{NULL} so by default cases that recover get an \code{NA} in the
 \verb{$date_outcome} line list column.}
@@ -219,14 +219,14 @@ head(outbreak$contacts)
 
 # to simulate a more realistic outbreak load epiparameters from
 # {epiparameter}
-contact_distribution <- epiparameter::epidist(
+contact_distribution <- epiparameter::epiparameter(
   disease = "COVID-19",
   epi_dist = "contact distribution",
   prob_distribution = "pois",
   prob_distribution_params = c(mean = 2)
 )
 
-infectious_period <- epiparameter::epidist(
+infectious_period <- epiparameter::epiparameter(
   disease = "COVID-19",
   epi_dist = "infectious period",
   prob_distribution = "gamma",
@@ -234,17 +234,17 @@ infectious_period <- epiparameter::epidist(
 )
 
 # get onset to hospital admission from {epiparameter} database
-onset_to_hosp <- epiparameter::epidist_db(
+onset_to_hosp <- epiparameter::epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to hospitalisation",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 
 # get onset to death from {epiparameter} database
-onset_to_death <- epiparameter::epidist_db(
+onset_to_death <- epiparameter::epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to death",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 
 outbreak <- sim_outbreak(

--- a/tests/testthat/test-add_cols.R
+++ b/tests/testthat/test-add_cols.R
@@ -1,17 +1,17 @@
 suppressMessages({
   # get onset to hospital admission from {epiparameter} database &
   # convert to function
-  onset_to_hosp <- as.function(epiparameter::epidist_db(
+  onset_to_hosp <- as.function(epiparameter::epiparameter_db(
     disease = "COVID-19",
     epi_dist = "onset to hospitalisation",
-    single_epidist = TRUE
+    single_epiparameter = TRUE
   ))
 
   # get onset to death from {epiparameter} database
-  onset_to_death <- as.function(epiparameter::epidist_db(
+  onset_to_death <- as.function(epiparameter::epiparameter_db(
     disease = "COVID-19",
     epi_dist = "onset to death",
-    single_epidist = TRUE
+    single_epiparameter = TRUE
   ))
 
   onset_to_recovery <- function(x) rep(NA, times = x)

--- a/tests/testthat/test-checkers.R
+++ b/tests/testthat/test-checkers.R
@@ -138,14 +138,14 @@ test_that(".check_age_df fails as expected", {
 })
 
 suppressMessages({
-  contact_distribution <- as.function(epiparameter::epidist(
+  contact_distribution <- as.function(epiparameter::epiparameter(
     disease = "COVID-19",
     epi_dist = "contact distribution",
     prob_distribution = "pois",
     prob_distribution_params = c(mean = 2)
   ))
 
-  infectious_period <- as.function(epiparameter::epidist(
+  infectious_period <- as.function(epiparameter::epiparameter(
     disease = "COVID-19",
     epi_dist = "infectious period",
     prob_distribution = "gamma",
@@ -153,20 +153,20 @@ suppressMessages({
   ))
 
   # get onset to hospital admission from {epiparameter} database
-  onset_to_hosp <- as.function(epiparameter::epidist_db(
+  onset_to_hosp <- as.function(epiparameter::epiparameter_db(
     disease = "COVID-19",
     epi_dist = "onset to hospitalisation",
-    single_epidist = TRUE
+    single_epiparameter = TRUE
   ))
 
   # get onset to death from {epiparameter} database
-  onset_to_death <- as.function(epiparameter::epidist_db(
+  onset_to_death <- as.function(epiparameter::epiparameter_db(
     disease = "COVID-19",
     epi_dist = "onset to death",
-    single_epidist = TRUE
+    single_epiparameter = TRUE
   ))
 
-  onset_to_recovery <- as.function(epiparameter::epidist(
+  onset_to_recovery <- as.function(epiparameter::epiparameter(
     disease = "COVID-19",
     epi_dist = "onset to recovery",
     prob_distribution = "lnorm",

--- a/tests/testthat/test-sim_contacts.R
+++ b/tests/testthat/test-sim_contacts.R
@@ -4,14 +4,14 @@ test_that("sim_contacts works as expected with defaults", {
 })
 
 suppressMessages({
-  contact_distribution <- epiparameter::epidist(
+  contact_distribution <- epiparameter::epiparameter(
     disease = "COVID-19",
     epi_dist = "contact distribution",
     prob_distribution = "pois",
     prob_distribution_params = c(mean = 2)
   )
 
-  infectious_period <- epiparameter::epidist(
+  infectious_period <- epiparameter::epiparameter(
     disease = "COVID-19",
     epi_dist = "infectious period",
     prob_distribution = "gamma",

--- a/tests/testthat/test-sim_linelist.R
+++ b/tests/testthat/test-sim_linelist.R
@@ -4,14 +4,14 @@ test_that("sim_linelist works as expected with defaults", {
 })
 
 suppressMessages({
-  contact_distribution <- epiparameter::epidist(
+  contact_distribution <- epiparameter::epiparameter(
     disease = "COVID-19",
     epi_dist = "contact distribution",
     prob_distribution = "pois",
     prob_distribution_params = c(mean = 2)
   )
 
-  infectious_period <- epiparameter::epidist(
+  infectious_period <- epiparameter::epiparameter(
     disease = "COVID-19",
     epi_dist = "infectious period",
     prob_distribution = "gamma",
@@ -19,17 +19,17 @@ suppressMessages({
   )
 
   # get onset to hospital admission from {epiparameter} database
-  onset_to_hosp <- epiparameter::epidist_db(
+  onset_to_hosp <- epiparameter::epiparameter_db(
     disease = "COVID-19",
     epi_dist = "onset to hospitalisation",
-    single_epidist = TRUE
+    single_epiparameter = TRUE
   )
 
   # get onset to death from {epiparameter} database
-  onset_to_death <- epiparameter::epidist_db(
+  onset_to_death <- epiparameter::epiparameter_db(
     disease = "COVID-19",
     epi_dist = "onset to death",
-    single_epidist = TRUE
+    single_epiparameter = TRUE
   )
 })
 

--- a/tests/testthat/test-sim_network_bp.R
+++ b/tests/testthat/test-sim_network_bp.R
@@ -1,6 +1,6 @@
 suppressMessages({
   contact_distribution <- as.function(
-    epiparameter::epidist(
+    epiparameter::epiparameter(
       disease = "COVID-19",
       epi_dist = "contact distribution",
       prob_distribution = "pois",
@@ -9,7 +9,7 @@ suppressMessages({
   )
 
   infectious_period <- as.function(
-    epiparameter::epidist(
+    epiparameter::epiparameter(
       disease = "COVID-19",
       epi_dist = "infectious period",
       prob_distribution = "gamma",
@@ -34,7 +34,7 @@ test_that(".sim_network_bp works as expected", {
 test_that(".sim_network_bp works as expected with no contacts", {
   suppressMessages(
     contact_distribution <- as.function(
-      epiparameter::epidist(
+      epiparameter::epiparameter(
         disease = "COVID-19",
         epi_dist = "contact distribution",
         prob_distribution = "pois",
@@ -84,7 +84,7 @@ test_that(".sim_network_bp warns as expected", {
 test_that(".sim_network_bp errors with negative infectious period", {
   suppressMessages({
     infectious_period <- as.function(
-    epiparameter::epidist(
+    epiparameter::epiparameter(
       disease = "COVID-19",
       epi_dist = "infectious period",
       prob_distribution = "norm",

--- a/tests/testthat/test-sim_outbreak.R
+++ b/tests/testthat/test-sim_outbreak.R
@@ -4,14 +4,14 @@ test_that("sim_outbreak works as expected with defaults", {
 })
 
 suppressMessages({
-  contact_distribution <- epiparameter::epidist(
+  contact_distribution <- epiparameter::epiparameter(
     disease = "COVID-19",
     epi_dist = "contact distribution",
     prob_distribution = "pois",
     prob_distribution_params = c(mean = 2)
   )
 
-  infectious_period <- epiparameter::epidist(
+  infectious_period <- epiparameter::epiparameter(
     disease = "COVID-19",
     epi_dist = "infectious period",
     prob_distribution = "gamma",
@@ -19,17 +19,17 @@ suppressMessages({
   )
 
   # get onset to hospital admission from {epiparameter} database
-  onset_to_hosp <- epiparameter::epidist_db(
+  onset_to_hosp <- epiparameter::epiparameter_db(
     disease = "COVID-19",
     epi_dist = "onset to hospitalisation",
-    single_epidist = TRUE
+    single_epiparameter = TRUE
   )
 
   # get onset to death from {epiparameter} database
-  onset_to_death <- epiparameter::epidist_db(
+  onset_to_death <- epiparameter::epiparameter_db(
     disease = "COVID-19",
     epi_dist = "onset to death",
-    single_epidist = TRUE
+    single_epiparameter = TRUE
   )
 })
 

--- a/tests/testthat/testdata/README.md
+++ b/tests/testthat/testdata/README.md
@@ -18,14 +18,14 @@ The script to reproduce the data is:
 
 ``` r
 # load data required to simulate line list
-contact_distribution <- epiparameter::epidist(
+contact_distribution <- epiparameter::epiparameter(
   disease = "COVID-19",
   epi_dist = "contact distribution",
   prob_distribution = "pois",
   prob_distribution_params = c(mean = 2)
 )
 
-infectious_period <- epiparameter::epidist(
+infectious_period <- epiparameter::epiparameter(
   disease = "COVID-19",
   epi_dist = "infectious period",
   prob_distribution = "gamma",
@@ -33,17 +33,17 @@ infectious_period <- epiparameter::epidist(
 )
 
 # get onset to hospital admission from {epiparameter} database
-onset_to_hosp <- epiparameter::epidist_db(
+onset_to_hosp <- epiparameter::epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to hospitalisation",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 
 # get onset to death from {epiparameter} database
-onset_to_death <- epiparameter::epidist_db(
+onset_to_death <- epiparameter::epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to death",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 set.seed(1)
 

--- a/vignettes/age-strat-risks.Rmd
+++ b/vignettes/age-strat-risks.Rmd
@@ -40,14 +40,14 @@ library(epiparameter)
 Here is an example that uses the default hospitalisation and death risks (inside and outside of hospital). First we load the requested delay distributions using the {epiparameter} package.
 
 ```{r, read-delay-dists}
-contact_distribution <- epidist(
+contact_distribution <- epiparameter(
   disease = "COVID-19",
   epi_dist = "contact distribution",
   prob_distribution = "pois",
   prob_distribution_params = c(mean = 2)
 )
 
-infectious_period <- epidist(
+infectious_period <- epiparameter(
   disease = "COVID-19",
   epi_dist = "infectious period",
   prob_distribution = "gamma",
@@ -55,17 +55,17 @@ infectious_period <- epidist(
 )
 
 # get onset to hospital admission from {epiparameter} database
-onset_to_hosp <- epidist_db(
+onset_to_hosp <- epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to hospitalisation",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 
 # get onset to death from {epiparameter} database
-onset_to_death <- epidist_db(
+onset_to_death <- epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to death",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 ```
 

--- a/vignettes/age-struct-pop.Rmd
+++ b/vignettes/age-struct-pop.Rmd
@@ -33,14 +33,14 @@ library(ggplot2)
 First we load the requested delay distributions using the {epiparameter} package. The onset-to-hospitalisation and onset-to-death delay distributions are extracted from the {epiparameter} database, and the contact distribution and the infectious period are manually defined as they are not yet available from the {epiparameter} database.
 
 ```{r, read-delay-dists}
-contact_distribution <- epidist(
+contact_distribution <- epiparameter(
   disease = "COVID-19",
   epi_dist = "contact distribution",
   prob_distribution = "pois",
   prob_distribution_params = c(mean = 2)
 )
 
-infectious_period <- epidist(
+infectious_period <- epiparameter(
   disease = "COVID-19",
   epi_dist = "infectious period",
   prob_distribution = "gamma",
@@ -48,17 +48,17 @@ infectious_period <- epidist(
 )
 
 # get onset to hospital admission from {epiparameter} database
-onset_to_hosp <- epidist_db(
+onset_to_hosp <- epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to hospitalisation",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 
 # get onset to death from {epiparameter} database
-onset_to_death <- epidist_db(
+onset_to_death <- epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to death",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 ```
 

--- a/vignettes/simulist.Rmd
+++ b/vignettes/simulist.Rmd
@@ -29,7 +29,7 @@ First we load in some data that is required for the line list simulation. Data o
 
 ```{r read-epidist}
 # create contact distribution (not available from {epiparameter} database)
-contact_distribution <- epidist(
+contact_distribution <- epiparameter(
   disease = "COVID-19",
   epi_dist = "contact distribution",
   prob_distribution = "pois",
@@ -37,7 +37,7 @@ contact_distribution <- epidist(
 )
 
 # create infectious period (not available from {epiparameter} database)
-infectious_period <- epidist(
+infectious_period <- epiparameter(
   disease = "COVID-19",
   epi_dist = "infectious period",
   prob_distribution = "gamma",
@@ -45,17 +45,17 @@ infectious_period <- epidist(
 )
 
 # get onset to hospital admission from {epiparameter} database
-onset_to_hosp <- epidist_db(
+onset_to_hosp <- epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to hospitalisation",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 
 # get onset to death from {epiparameter} database
-onset_to_death <- epidist_db(
+onset_to_death <- epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to death",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 ```
 
@@ -216,9 +216,9 @@ The `sim_*()` functions, by default, use an excess degree distribution to accoun
 
 :::
 
-## Using functions for distributions instead of `<epidist>`
+## Using functions for distributions instead of `<epiparameter>`
 
-The `contact_distribution`, `infectious_period`, `onset_to_hosp`, `onset_to_death` and `onset_to_recovery` arguments can accept either an `<epidist>` object (as shown above), or can accept a function. It is possible to use a predefined function or an [anonymous function](https://en.wikipedia.org/wiki/Anonymous_function). Here we'll demonstrate how to use both.
+The `contact_distribution`, `infectious_period`, `onset_to_hosp`, `onset_to_death` and `onset_to_recovery` arguments can accept either an `<epiparameter>` object (as shown above), or can accept a function. It is possible to use a predefined function or an [anonymous function](https://en.wikipedia.org/wiki/Anonymous_function). Here we'll demonstrate how to use both.
 
 ### Predefined functions
 

--- a/vignettes/time-varying-cfr.Rmd
+++ b/vignettes/time-varying-cfr.Rmd
@@ -46,14 +46,14 @@ First we will demonstrate the default setting of a constant case fatality risk t
 We load the required delay distributions using the {epiparameter} package, by either manually creating them (contact distribution and infectious period), or load them from the {epiparameter} library of epidemiological parameters (onset-to-hospitalisation and onset-to-death).
 
 ```{r, read-delay-dists}
-contact_distribution <- epidist(
+contact_distribution <- epiparameter(
   disease = "COVID-19",
   epi_dist = "contact distribution",
   prob_distribution = "pois",
   prob_distribution_params = c(mean = 2)
 )
 
-infectious_period <- epidist(
+infectious_period <- epiparameter(
   disease = "COVID-19",
   epi_dist = "infectious period",
   prob_distribution = "gamma",
@@ -61,17 +61,17 @@ infectious_period <- epidist(
 )
 
 # get onset to hospital admission from {epiparameter} database
-onset_to_hosp <- epidist_db(
+onset_to_hosp <- epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to hospitalisation",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 
 # get onset to death from {epiparameter} database
-onset_to_death <- epidist_db(
+onset_to_death <- epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to death",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 ```
 

--- a/vignettes/vis-linelist.Rmd
+++ b/vignettes/vis-linelist.Rmd
@@ -28,14 +28,14 @@ library(epicontacts)
 First we load the required delay distributions using the {epiparameter} package.
 
 ```{r, read-delay-dists}
-contact_distribution <- epidist(
+contact_distribution <- epiparameter(
   disease = "COVID-19",
   epi_dist = "contact distribution",
   prob_distribution = "pois",
   prob_distribution_params = c(mean = 3)
 )
 
-infectious_period <- epidist(
+infectious_period <- epiparameter(
   disease = "COVID-19",
   epi_dist = "infectious period",
   prob_distribution = "gamma",
@@ -43,17 +43,17 @@ infectious_period <- epidist(
 )
 
 # get onset to hospital admission from {epiparameter} database
-onset_to_hosp <- epidist_db(
+onset_to_hosp <- epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to hospitalisation",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 
 # get onset to death from {epiparameter} database
-onset_to_death <- epidist_db(
+onset_to_death <- epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to death",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 ```
 
@@ -206,7 +206,7 @@ Additionally, {epicontacts} provides access to network plotting from JavaScript 
 The {epicontacts} function `make_epicontacts()` requires both the line list and contacts table, so we will run the `sim_outbreak()` function to produce both. We will use the same epidemiological delay distributions that we used to simulate a line list above, but reduce the mean number of contacts in the contact distribution to 2.
 
 ```{r, contact-distribution}
-contact_distribution <- epidist(
+contact_distribution <- epiparameter(
   disease = "COVID-19",
   epi_dist = "contact distribution",
   prob_distribution = "pois",

--- a/vignettes/wrangling-linelist.Rmd
+++ b/vignettes/wrangling-linelist.Rmd
@@ -45,7 +45,7 @@ First we load in some data that is required for the outbreak simulation. Data on
 
 ```{r read-epidist}
 # create contact distribution (not available from {epiparameter} database)
-contact_distribution <- epidist(
+contact_distribution <- epiparameter(
   disease = "COVID-19",
   epi_dist = "contact distribution",
   prob_distribution = "pois",
@@ -53,7 +53,7 @@ contact_distribution <- epidist(
 )
 
 # create infectious period (not available from {epiparameter} database)
-infectious_period <- epidist(
+infectious_period <- epiparameter(
   disease = "COVID-19",
   epi_dist = "infectious period",
   prob_distribution = "gamma",
@@ -61,17 +61,17 @@ infectious_period <- epidist(
 )
 
 # get onset to hospital admission from {epiparameter} database
-onset_to_hosp <- epidist_db(
+onset_to_hosp <- epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to hospitalisation",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 
 # get onset to death from {epiparameter} database
-onset_to_death <- epidist_db(
+onset_to_death <- epiparameter_db(
   disease = "COVID-19",
   epi_dist = "onset to death",
-  single_epidist = TRUE
+  single_epiparameter = TRUE
 )
 ```
 


### PR DESCRIPTION
This PR fixes the use of {epiparameter} functions and classes within the {simulist} package. In epiverse-trace/epiparameter#360 there were breaking changes to the {epiparameter} package. Function calls and checking for S3 classes have now been updated in this PR.