### PR TITLE
Set pkgdown `development: mode` to `auto`

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,7 +5,7 @@ template:
     font_weight_base : 300
 
 development:
-  mode: unreleased
+  mode: auto
 
 reference:
   - title: Simulation functions


### PR DESCRIPTION
This PR updates the `development: mode` in `_pkgdown.yml` from `unreleased` to `auto`, as the per the [Epiverse-TRACE blueprints](https://epiverse-trace.github.io/blueprints/website.html) since v0.4.0 of {simulist} is now on CRAN.