### PR TITLE
Remove {epiparameter} usage from tests

### DIFF
--- a/tests/testthat/test-add_cols.R
+++ b/tests/testthat/test-add_cols.R
@@ -1,25 +1,10 @@
-suppressMessages({
-  # get onset to hospital admission from {epiparameter} database &
-  # convert to function
-  onset_to_hosp <- as.function(
-    epiparameter::epiparameter_db(
-      disease = "COVID-19",
-      epi_name = "onset to hospitalisation",
-      single_epiparameter = TRUE
-    )
-  )
-
-  # get onset to death from {epiparameter} database
-  onset_to_death <- as.function(
-    epiparameter::epiparameter_db(
-      disease = "COVID-19",
-      epi_name = "onset to death",
-      single_epiparameter = TRUE
-    )
-  )
-
-  onset_to_recovery <- function(x) rep(NA, times = x)
-})
+onset_to_hosp <- function(x) {
+  stats::rlnorm(n = x, meanlog = 0.947, sdlog = 1.628)
+}
+onset_to_death <- function(x) {
+  stats::rlnorm(n = x, meanlog = 2.863, sdlog = 0.534)
+}
+onset_to_recovery <- function(x) rep(NA, times = x)
 
 test_that(".add_date_contact works as expected with contact_type = 'last'", {
   ll <- readRDS(file = file.path("testdata", "pre_date_last_contact.rds"))

--- a/tests/testthat/test-checkers.R
+++ b/tests/testthat/test-checkers.R
@@ -137,57 +137,15 @@ test_that(".check_age_df fails as expected", {
   )
 })
 
-suppressMessages({
-  library(epiparameter)
-  contact_distribution <- as.function(
-    epiparameter(
-      disease = "COVID-19",
-      epi_name = "contact distribution",
-      prob_distribution = create_prob_distribution(
-        prob_distribution = "pois",
-        prob_distribution_params = c(mean = 2)
-      )
-    )
-  )
-
-  infectious_period <- as.function(
-    epiparameter(
-      disease = "COVID-19",
-      epi_name = "infectious period",
-      prob_distribution = create_prob_distribution(
-        prob_distribution = "gamma",
-        prob_distribution_params = c(shape = 1, scale = 1)
-      )
-    )
-  )
-
-  # get onset to hospital admission from {epiparameter} database
-  onset_to_hosp <- as.function(
-    epiparameter_db(
-      disease = "COVID-19",
-      epi_name = "onset to hospitalisation",
-      single_epiparameter = TRUE
-    )
-  )
-
-  # get onset to death from {epiparameter} database
-  onset_to_death <- as.function(
-    epiparameter_db(
-      disease = "COVID-19",
-      epi_name = "onset to death",
-      single_epiparameter = TRUE
-    )
-  )
-
-  onset_to_recovery <- as.function(epiparameter(
-    disease = "COVID-19",
-    epi_name = "onset to recovery",
-    prob_distribution = create_prob_distribution(
-      prob_distribution = "lnorm",
-      prob_distribution_params = c(meanlog = 3, sdlog = 1)
-    )
-  ))
-})
+contact_distribution <- function(x) stats::dpois(x = x, lambda = 2)
+infectious_period <- function(x) stats::rgamma(n = x, shape = 1, scale = 1)
+onset_to_hosp <- function(x) {
+  stats::rlnorm(n = x, meanlog = 0.947, sdlog = 1.628)
+}
+onset_to_death <- function(x) {
+  stats::rlnorm(n = x, meanlog = 2.863, sdlog = 0.534)
+}
+onset_to_recovery <- function(x) stats::rlnorm(n = x, meanlog = 3, sdlog = 1)
 
 test_that(".check_sim_input works as expected", {
   chk <- .check_sim_input(

--- a/tests/testthat/test-sim_contacts.R
+++ b/tests/testthat/test-sim_contacts.R
@@ -3,25 +3,8 @@ test_that("sim_contacts works as expected with defaults", {
   expect_snapshot(sim_contacts())
 })
 
-suppressMessages({
-  contact_distribution <- epiparameter::epiparameter(
-    disease = "COVID-19",
-    epi_name = "contact distribution",
-    prob_distribution = create_prob_distribution(
-      prob_distribution = "pois",
-      prob_distribution_params = c(mean = 2)
-    )
-  )
-
-  infectious_period <- epiparameter::epiparameter(
-    disease = "COVID-19",
-    epi_name = "infectious period",
-    prob_distribution = create_prob_distribution(
-      prob_distribution = "gamma",
-      prob_distribution_params = c(shape = 1, scale = 1)
-    )
-  )
-})
+contact_distribution <- function(x) stats::dpois(x = x, lambda = 2)
+infectious_period <- function(x) stats::rgamma(n = x, shape = 1, scale = 1)
 
 test_that("sim_contacts works as expected", {
   set.seed(1)

--- a/tests/testthat/test-sim_linelist.R
+++ b/tests/testthat/test-sim_linelist.R
@@ -3,40 +3,14 @@ test_that("sim_linelist works as expected with defaults", {
   expect_snapshot(sim_linelist())
 })
 
-suppressMessages({
-  library(epiparameter)
-  contact_distribution <- epiparameter(
-    disease = "COVID-19",
-    epi_name = "contact distribution",
-    prob_distribution = create_prob_distribution(
-      prob_distribution = "pois",
-      prob_distribution_params = c(mean = 2)
-    )
-  )
-
-  infectious_period <- epiparameter(
-    disease = "COVID-19",
-    epi_name = "infectious period",
-    prob_distribution = create_prob_distribution(
-      prob_distribution = "gamma",
-      prob_distribution_params = c(shape = 1, scale = 1)
-    )
-  )
-
-  # get onset to hospital admission from {epiparameter} database
-  onset_to_hosp <- epiparameter_db(
-    disease = "COVID-19",
-    epi_name = "onset to hospitalisation",
-    single_epiparameter = TRUE
-  )
-
-  # get onset to death from {epiparameter} database
-  onset_to_death <- epiparameter_db(
-    disease = "COVID-19",
-    epi_name = "onset to death",
-    single_epiparameter = TRUE
-  )
-})
+contact_distribution <- function(x) stats::dpois(x = x, lambda = 2)
+infectious_period <- function(x) stats::rgamma(n = x, shape = 1, scale = 1)
+onset_to_hosp <- function(x) {
+  stats::rlnorm(n = x, meanlog = 0.947, sdlog = 1.628)
+}
+onset_to_death <- function(x) {
+  stats::rlnorm(n = x, meanlog = 2.863, sdlog = 0.534)
+}
 
 test_that("sim_linelist works as expected", {
   set.seed(1)

--- a/tests/testthat/test-sim_network_bp.R
+++ b/tests/testthat/test-sim_network_bp.R
@@ -1,28 +1,5 @@
-suppressMessages({
-  library(epiparameter)
-  contact_distribution <- as.function(
-    epiparameter(
-      disease = "COVID-19",
-      epi_name = "contact distribution",
-      prob_distribution = create_prob_distribution(
-        prob_distribution = "pois",
-        prob_distribution_params = c(mean = 2)
-      )
-    )
-  )
-
-  infectious_period <- as.function(
-    epiparameter(
-      disease = "COVID-19",
-      epi_name = "infectious period",
-      prob_distribution = create_prob_distribution(
-        prob_distribution = "gamma",
-        prob_distribution_params = c(shape = 1, scale = 1)
-      )
-    ),
-    func_type = "generate"
-  )
-})
+contact_distribution <- function(x) stats::dpois(x = x, lambda = 2)
+infectious_period <- function(x) stats::rgamma(n = x, shape = 1, scale = 1)
 
 test_that(".sim_network_bp works as expected", {
   set.seed(1)
@@ -38,18 +15,7 @@ test_that(".sim_network_bp works as expected", {
 })
 
 test_that(".sim_network_bp works as expected with no contacts", {
-  suppressMessages(
-    contact_distribution <- as.function(
-      epiparameter(
-        disease = "COVID-19",
-        epi_name = "contact distribution",
-        prob_distribution = create_prob_distribution(
-          prob_distribution = "pois",
-          prob_distribution_params = c(mean = 1)
-        )
-      )
-    )
-  )
+  contact_distribution <- function(x) stats::dpois(x = x, lambda = 1)
   set.seed(1)
   expect_snapshot(
     .sim_network_bp(
@@ -90,19 +56,7 @@ test_that(".sim_network_bp warns as expected", {
 })
 
 test_that(".sim_network_bp errors with negative infectious period", {
-  suppressMessages({
-    infectious_period <- as.function(
-      epiparameter(
-        disease = "COVID-19",
-        epi_name = "infectious period",
-        prob_distribution = create_prob_distribution(
-          prob_distribution = "norm",
-          prob_distribution_params = c(mean = 10, sd = 5)
-        )
-      ),
-      func_type = "generate"
-    )
-  })
+  infectious_period <- function(x) stats::rnorm(n = x, mean = 10, sd = 5)
   set.seed(3)
   expect_error(
     .sim_network_bp(

--- a/tests/testthat/test-sim_outbreak.R
+++ b/tests/testthat/test-sim_outbreak.R
@@ -3,39 +3,15 @@ test_that("sim_outbreak works as expected with defaults", {
   expect_snapshot(sim_outbreak())
 })
 
-suppressMessages({
-  contact_distribution <- epiparameter::epiparameter(
-    disease = "COVID-19",
-    epi_name = "contact distribution",
-    prob_distribution = create_prob_distribution(
-      prob_distribution = "pois",
-      prob_distribution_params = c(mean = 2)
-    )
-  )
 
-  infectious_period <- epiparameter::epiparameter(
-    disease = "COVID-19",
-    epi_name = "infectious period",
-    prob_distribution = create_prob_distribution(
-      prob_distribution = "gamma",
-      prob_distribution_params = c(shape = 1, scale = 1)
-    )
-  )
-
-  # get onset to hospital admission from {epiparameter} database
-  onset_to_hosp <- epiparameter::epiparameter_db(
-    disease = "COVID-19",
-    epi_name = "onset to hospitalisation",
-    single_epiparameter = TRUE
-  )
-
-  # get onset to death from {epiparameter} database
-  onset_to_death <- epiparameter::epiparameter_db(
-    disease = "COVID-19",
-    epi_name = "onset to death",
-    single_epiparameter = TRUE
-  )
-})
+contact_distribution <- function(x) stats::dpois(x = x, lambda = 2)
+infectious_period <- function(x) stats::rgamma(n = x, shape = 1, scale = 1)
+onset_to_hosp <- function(x) {
+  stats::rlnorm(n = x, meanlog = 0.947, sdlog = 1.628)
+}
+onset_to_death <- function(x) {
+  stats::rlnorm(n = x, meanlog = 2.863, sdlog = 0.534)
+}
 
 test_that("sim_outbreak works as expected", {
   set.seed(1)

--- a/tests/testthat/testdata/README.md
+++ b/tests/testthat/testdata/README.md
@@ -18,37 +18,15 @@ The script to reproduce the data is:
 
 ``` r
 # load data required to simulate line list
-contact_distribution <- epiparameter::epiparameter(
-  disease = "COVID-19",
-  epi_name = "contact distribution",
-  prob_distribution = create_prob_distribution(
-    prob_distribution = "pois",
-    prob_distribution_params = c(mean = 2)
-  )
-)
+contact_distribution <- function(x) stats::dpois(x = x, lambda = 2)
+infectious_period <- function(x) stats::rgamma(n = x, shape = 1, scale = 1)
+onset_to_hosp <- function(x) {
+  stats::rlnorm(n = x, meanlog = 0.947, sdlog = 1.628)
+}
+onset_to_death <- function(x) {
+  stats::rlnorm(n = x, meanlog = 2.863, sdlog = 0.534)
+}
 
-infectious_period <- epiparameter::epiparameter(
-  disease = "COVID-19",
-  epi_name = "infectious period",
-  prob_distribution = create_prob_distribution(
-    prob_distribution = "gamma",
-    prob_distribution_params = c(shape = 1, scale = 1)
-  )
-)
-
-# get onset to hospital admission from {epiparameter} database
-onset_to_hosp <- epiparameter::epiparameter_db(
-  disease = "COVID-19",
-  epi_name = "onset to hospitalisation",
-  single_epiparameter = TRUE
-)
-
-# get onset to death from {epiparameter} database
-onset_to_death <- epiparameter::epiparameter_db(
-  disease = "COVID-19",
-  epi_name = "onset to death",
-  single_epiparameter = TRUE
-)
 set.seed(1)
 
 linelist <- sim_linelist(


### PR DESCRIPTION
This PR removes the use of {epiparameter} functions (`epiparameter()` and `epiparameter_db()`) from the testing. This has several benefits. 

1. The epidemiological parameter functions are now explicitly stated and it is easy to adjust their parameterisation, easing maintenance burden.
2. The functions are more succinct to define than `<epiparameter>` objects. 
3. The defined functions are deterministic compared to loading epidemiological parameters using `epiparameter_db()` which may return different database entries in future versions of {epiparameter}, making the tests less robust.
4. The functions are accepted by both external and internal functions in {simulist}, making the testing more consistent. When using an `<epiparameter>` object, they are converted to function objects internally, so if testing an internal function the `as.function()` method for `<epiparameter>` need to be called, making the code more complex.
5. Constructing or loading `<epiparameter>` objects produces messages which were suppressed (`suppressMessages()`), by defining functions, this is no longer needed. 

One potential downside of not using `<epiparameter>` objects to test the exported functions, and the reason they are accepted in {simulist}, is that it requires knowing the type of distribution function for each input. The `contact_distribution` argument requires a density function, whereas the others require a random number generator function. As the testing will only be worked on by developers with knowledge of the package, the benefits are judged to outweigh the cost in this scenario. 