### PR TITLE
Increase minimum R version to v4.1.0 and add GHA R CMD check

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -59,6 +59,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: '3.6'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -59,7 +59,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,   r: '3.6'}
+          - {os: ubuntu-latest,   r: '4.1'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ URL: https://github.com/epiverse-trace/simulist,
     https://epiverse-trace.github.io/simulist/
 BugReports: https://github.com/epiverse-trace/simulist/issues
 Depends: 
-    R (>= 3.6.0)
+    R (>= 4.1.0)
 Imports:
     checkmate,
     epiparameter (>= 0.4.0),


### PR DESCRIPTION
This PR adds another R CMD check to the jobs matrix in the R-CMD-check workflow file. The new check runs on R v4.1.0 as this is the minimum R version required for the package (as specified in the `DESCRIPTION` file). This will more robustly check that the package runs on older R versions. 