### PR TITLE
Hyphenate "age-structured"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Authors@R: c(
 Description: Tools to simulate realistic raw case data for an epidemic in
     the form of line lists and contacts using a branching process.
     Simulated outbreaks are parameterised with epidemiological parameters
-    and can have age structured populations, age-stratified
+    and can have age-structured populations, age-stratified
     hospitalisation and death risk and time-varying case fatality risk.
 License: MIT + file LICENSE
 URL: https://github.com/epiverse-trace/simulist,

--- a/NEWS.md
+++ b/NEWS.md
@@ -142,7 +142,7 @@ Initial release of _simulist_, an R package containing tools to simulate epidemi
 * Four general vignettes
   - Get Started vignette (`simulist.Rmd`)
   - Age-stratified hospitalisation and death risks vignette (`age-strat-risks.Rmd`)
-  - Age structured population vignette (`age-struct-pop.Rmd`)
+  - Age-structured population vignette (`age-struct-pop.Rmd`)
   - Visualising simulated data (`vis-linelist.Rmd`)
 
 * One developer focused vignette

--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -12,7 +12,7 @@
 #' (or probability) of hospitalisation for that age group. Should be between
 #' 0 and 1.
 #'
-#' For an age structured population, a `<data.frame>` with two columns:
+#' For an age-structured population, a `<data.frame>` with two columns:
 #' * `age_range`: a column with characters specifying the lower and upper bound
 #'  of that age group, separated by a hyphen (-). Both bounds are inclusive
 #' (integers). For example, an age group of one to ten would be given as

--- a/man/sim_linelist.Rd
+++ b/man/sim_linelist.Rd
@@ -219,7 +219,7 @@ arguments. This \verb{<data.frame>} should have two columns:
 0 and 1.
 }
 
-For an age structured population, a \verb{<data.frame>} with two columns:
+For an age-structured population, a \verb{<data.frame>} with two columns:
 \itemize{
 \item \code{age_range}: a column with characters specifying the lower and upper bound
 of that age group, separated by a hyphen (-). Both bounds are inclusive

--- a/man/sim_outbreak.Rd
+++ b/man/sim_outbreak.Rd
@@ -230,7 +230,7 @@ arguments. This \verb{<data.frame>} should have two columns:
 0 and 1.
 }
 
-For an age structured population, a \verb{<data.frame>} with two columns:
+For an age-structured population, a \verb{<data.frame>} with two columns:
 \itemize{
 \item \code{age_range}: a column with characters specifying the lower and upper bound
 of that age group, separated by a hyphen (-). Both bounds are inclusive

--- a/man/simulist-package.Rd
+++ b/man/simulist-package.Rd
@@ -6,7 +6,7 @@
 \alias{simulist-package}
 \title{simulist: Simulate Disease Outbreak Line List and Contacts Data}
 \description{
-Tools to simulate realistic raw case data for an epidemic in the form of line lists and contacts using a branching process. Simulated outbreaks are parameterised with epidemiological parameters and can have age structured populations, age-stratified hospitalisation and death risk and time-varying case fatality risk.
+Tools to simulate realistic raw case data for an epidemic in the form of line lists and contacts using a branching process. Simulated outbreaks are parameterised with epidemiological parameters and can have age-structured populations, age-stratified hospitalisation and death risk and time-varying case fatality risk.
 }
 \seealso{
 Useful links:

--- a/vignettes/age-struct-pop.Rmd
+++ b/vignettes/age-struct-pop.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "Age structured population"
+title: "Age-structured population"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Age structured population}
+  %\VignetteIndexEntry{Age-structured population}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -193,7 +193,7 @@ head(linelist)
 ```
 A common and useful method for plotting age data is in the form of age pyramids. Here we partition the data by sex and plot the age distribution.
 
-```{r plot-age-struct-young, fig.cap="Age pyramid for a simulated line list with an age structured population.", fig.width = 8, fig.height = 5}
+```{r plot-age-struct-young, fig.cap="Age pyramid for a simulated line list with an age-structured population.", fig.width = 8, fig.height = 5}
 linelist_m <- subset(linelist, subset = sex == "m")
 age_cats_m <- as.data.frame(table(floor(linelist_m$age / 5) * 5))
 colnames(age_cats_m) <- c("AgeCat", "Population")
@@ -218,4 +218,4 @@ ggplot(age_cats) +
 
 We have used the {ggplot2} package to construct our age pyramid, however the [{apyramid} R package from R4Epi](https://r4epi.github.io/apyramid/) can assist in making these plots; as can the [Applied Epidemiology Handbook chapter on age pyramids](https://www.epirhandbook.com/en/new_pages/age_pyramid.html). The blog post on ["Population Pyramid Plots in ggplot2"](https://www.njtierney.com/post/2022/08/09/ggplot-pyramid/) also contains useful tips on constructing pyramid plots.
 
-As shown in the two age structured examples, the number of age groups is flexible. Therefore a coarse population structure with two or three age groups can be specified, or where precise census demographic data is available, several age groups can be specified.
+As shown in the two age-structured examples, the number of age groups is flexible. Therefore a coarse population structure with two or three age groups can be specified, or where precise census demographic data is available, several age groups can be specified.

--- a/vignettes/vis-linelist.Rmd
+++ b/vignettes/vis-linelist.Rmd
@@ -183,7 +183,7 @@ plot(daily)
 
 ## Demographic data
 
-Please see the [Age structured population vignette](age-struct-pop.html) for examples of how to plot the distribution of ages within a line list data set, including age pyramids. 
+Please see the [Age-structured population vignette](age-struct-pop.html) for examples of how to plot the distribution of ages within a line list data set, including age pyramids. 
 
 The plotting code in vignettes is hidden by default, click the Code button with arrow to reveal the plotting code.
 


### PR DESCRIPTION
This PR ensures instances of "age-structured" are hyphenated as pointed out in #181.