### PR TITLE
Fix `lint-changed-files` CI for {lintr} v3.2.0

### DIFF
--- a/R/add_cols.R
+++ b/R/add_cols.R
@@ -56,10 +56,10 @@ NULL
   }
 
   # name list elements with vec names to ensure arg matching in do.call
-  args <- c(nrow(.data), list(...))
+  .args <- c(nrow(.data), list(...))
 
   contact_delay <- tryCatch(
-    do.call(rdist, args = args),
+    do.call(rdist, args = .args),
     error = function(cnd) {
       stop(
         "Incorrect parameterisation of distribution, check config",
@@ -260,13 +260,13 @@ NULL
 
   # name list elements with vec names to ensure arg matching in do.call
   # as.list(c(...)) ensures that ... can be a list, vector or multiple args
-  args <- c(
+  .args <- c(
     n = sum(.data$case_type == "confirmed", na.rm = TRUE),
     as.list(c(...))
   )
 
   ct_value <- tryCatch(
-    do.call(rdist, args = args),
+    do.call(rdist, args = .args),
     error = function(cnd) {
       stop(
         "Incorrect parameterisation of distribution, check config",

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -79,7 +79,7 @@
     "Age groups should be non-overlapping" =
       anyDuplicated(age_groups) == 0,
     "Age groups should be contiguous" =
-      all(min(age_groups):max(age_groups) %in% age_groups),
+      min(age_groups):max(age_groups) %in% age_groups,
     "Age groups should include only positive integers" =
       checkmate::test_integerish(unlist(age_bounds), lower = 0)
   )

--- a/R/create_config.R
+++ b/R/create_config.R
@@ -70,7 +70,7 @@ create_config <- function(...) {
   # check arguments in dots match arg list
   stopifnot(
     "Incorrect argument names supplied to create_config" =
-      all(dots_names %in% names(.args))
+      dots_names %in% names(.args)
   )
 
   # replace default args if in dots

--- a/R/create_config.R
+++ b/R/create_config.R
@@ -52,7 +52,7 @@
 #'   ct_distribution_params = c(meanlog = 2, sdlog = 1)
 #' )
 create_config <- function(...) {
-  args <- list(
+  .args <- list(
     last_contact_distribution = "pois",
     last_contact_distribution_params = c(lambda = 3),
     first_contact_distribution = "pois",
@@ -70,12 +70,12 @@ create_config <- function(...) {
   # check arguments in dots match arg list
   stopifnot(
     "Incorrect argument names supplied to create_config" =
-      all(dots_names %in% names(args))
+      all(dots_names %in% names(.args))
   )
 
   # replace default args if in dots
-  args <- utils::modifyList(args, dots)
+  .args <- utils::modifyList(.args, dots)
 
   # return args list
-  args
+  .args
 }

--- a/R/messy_linelist.R
+++ b/R/messy_linelist.R
@@ -132,7 +132,7 @@ messy_linelist <- function(linelist, ...) {
   # check arguments in dots match arg list
   stopifnot(
     "Incorrect argument names supplied to `messy_linelist()`" =
-      all(dots_names %in% names(.args))
+      dots_names %in% names(.args)
   )
 
   # replace default args if in dots

--- a/R/messy_linelist.R
+++ b/R/messy_linelist.R
@@ -140,7 +140,9 @@ messy_linelist <- function(linelist, ...) {
 
   # check args list after any user changes
   checkmate::assert_number(.args$prop_spelling_mistakes, lower = 0, upper = 1)
-  checkmate::assert_logical(.args$inconsistent_sex, any.missing = FALSE, len = 1)
+  checkmate::assert_logical(
+    .args$inconsistent_sex, any.missing = FALSE, len = 1
+  )
   checkmate::assert_logical(.args$sex_as_numeric, any.missing = FALSE, len = 1)
   checkmate::assert_logical(.args$numeric_as_char, any.missing = FALSE, len = 1)
   checkmate::assert_logical(.args$date_as_char, any.missing = FALSE, len = 1)
@@ -256,7 +258,10 @@ messy_linelist <- function(linelist, ...) {
 
   if (.args$prop_duplicate_row > 0) {
     n_row <- nrow(linelist)
-    row_idx <- sample(x = n_row,size = ceiling(.args$prop_duplicate_row * n_row))
+    row_idx <- sample(
+      x = n_row,
+      size = ceiling(.args$prop_duplicate_row * n_row)
+    )
     row_idx <- sort(c(seq_len(n_row), row_idx), decreasing = FALSE)
     linelist <- linelist[row_idx, ]
     row.names(linelist) <- NULL

--- a/R/sim_internal.R
+++ b/R/sim_internal.R
@@ -191,17 +191,16 @@
 
   if (sim_type == "contacts") {
     return(contacts_tbl)
-  } else {
-    .data <- .data[.data$infected == "infected", ]
-    .data <- .data[, linelist_cols]
-    row.names(.data) <- NULL
-
-    switch(sim_type,
-      linelist = return(.data),
-      outbreak = return(list(
-        linelist = .data,
-        contacts = contacts_tbl
-      ))
-    )
   }
+  .data <- .data[.data$infected == "infected", ]
+  .data <- .data[, linelist_cols]
+  row.names(.data) <- NULL
+
+  switch(sim_type,
+    linelist = return(.data),
+    outbreak = return(list(
+      linelist = .data,
+      contacts = contacts_tbl
+    ))
+  )
 }

--- a/R/sim_network_bp.R
+++ b/R/sim_network_bp.R
@@ -55,15 +55,20 @@
 
   if (config$network == "adjusted") {
     # sample contact distribution (excess degree distribution)
-    q <- contact_distribution(0:1e4 + 1) * (0:1e4 + 1)
-    q <- q / sum(q)
+    contact_dist_prob <- contact_distribution(0:1e4 + 1) * (0:1e4 + 1)
+    contact_dist_prob <- contact_dist_prob / sum(contact_dist_prob)
   } else {
-    q <- contact_distribution(0:1e4)
+    contact_dist_prob <- contact_distribution(0:1e4)
   }
 
   # run loop until no more individuals are sampled
   while (next_gen_size > 0) {
-    contacts <- sample(0:1e4, size = next_gen_size, replace = TRUE, prob = q)
+    contacts <- sample(
+      0:1e4,
+      size = next_gen_size,
+      replace = TRUE,
+      prob = contact_dist_prob
+    )
     # add contacts if sampled
     if (sum(contacts) > 0L) {
       chain_size <- chain_size + sum(contacts)

--- a/R/sim_network_bp.R
+++ b/R/sim_network_bp.R
@@ -36,14 +36,14 @@
   ancestor <- vector(mode = "integer", 1e5)
   generation <- vector(mode = "integer", 1e5)
   infected <- vector(mode = "integer", 1e5)
-  time <- vector(mode = "double", 1e5)
+  .time <- vector(mode = "double", 1e5)
 
   # store initial individual
   ancestor[1] <- NA_integer_
   generation[1] <- 1L
   # 1 is infected, 0 is non-infected contact
   infected[1] <- 1L
-  time[1] <- 0
+  .time[1] <- 0
 
   # initialise counters
   next_gen_size <- 1L
@@ -81,7 +81,7 @@
             ancestor <- c(ancestor, vector(mode = "integer", 1e5))
             generation <- c(generation, vector(mode = "integer", 1e5))
             infected <- c(infected, vector(mode = "integer", 1e5))
-            time <- c(time, vector(mode = "double", 1e5))
+            .time <- c(.time, vector(mode = "double", 1e5))
           }
 
           generation[vec_idx] <- chain_generation
@@ -106,7 +106,7 @@
             min = 0,
             max = contact_infectious_period
           )
-          time[vec_idx] <- contact_times + time[ancestor_idx[i]]
+          .time[vec_idx] <- contact_times + .time[ancestor_idx[i]]
         }
       }
       ancestor_idx <- setdiff(which(infected == 1), prev_ancestors)
@@ -135,7 +135,7 @@
   # if the outcome names are changed, please find and update all
   # logical expressions, e.g., x == "infected" or x == "contact"
   infected <- ifelse(test = infected, yes = "infected", no = "contact")
-  time <- time[seq_along(generation)]
+  .time <- .time[seq_along(generation)]
 
   # return chain as <data.frame>
   data.frame(
@@ -143,6 +143,6 @@
     ancestor = ancestor,
     generation = generation,
     infected = infected,
-    time = time
+    time = .time
   )
 }

--- a/R/truncate_linelist.R
+++ b/R/truncate_linelist.R
@@ -105,24 +105,24 @@ truncate_linelist <- function(linelist,
     )
   }
   col_name <- paste0("date_", truncation_event)
-  trunc <- delay(nrow(linelist))
+  trunc_time <- delay(nrow(linelist))
   # sample which onset dates are longer than reporting delay (i.e. reported)
   reported_lgl_idx <-
-    (max_date - linelist[[col_name]]) > trunc
+    (max_date - linelist[[col_name]]) > trunc_time
   # convert NAs to TRUE to prevent issues with subsetting with NAs
   reported_lgl_idx[is.na(reported_lgl_idx)] <- TRUE
   linelist <- linelist[reported_lgl_idx, ]
 
   # subset truncation times to remove times for individuals removed above
-  trunc <- trunc[reported_lgl_idx]
+  trunc_time <- trunc_time[reported_lgl_idx]
 
   # convert events (reporting, admissions & outcomes) more recent than
   # truncation time to NA
-  missing_outcome_lgl_idx <- (max_date - linelist$date_outcome) < trunc
+  missing_outcome_lgl_idx <- (max_date - linelist$date_outcome) < trunc_time
   linelist$date_outcome[missing_outcome_lgl_idx] <- NA_real_
-  missing_admission_lgl_idx <- (max_date - linelist$date_admission) < trunc
+  missing_admission_lgl_idx <- (max_date - linelist$date_admission) < trunc_time
   linelist$date_admission[missing_admission_lgl_idx] <- NA_real_
-  missing_reporting_lgl_idx <- (max_date - linelist$date_reporting) < trunc
+  missing_reporting_lgl_idx <- (max_date - linelist$date_reporting) < trunc_time
   linelist$date_reporting[missing_reporting_lgl_idx] <- NA_real_
 
   row.names(linelist) <- NULL

--- a/R/truncate_linelist.R
+++ b/R/truncate_linelist.R
@@ -104,11 +104,11 @@ truncate_linelist <- function(linelist,
       "Assuming an origin of '1970-01-01' in line with R >= v4.3.0."
     )
   }
-  col <- paste0("date_", truncation_event)
+  col_name <- paste0("date_", truncation_event)
   trunc <- delay(nrow(linelist))
   # sample which onset dates are longer than reporting delay (i.e. reported)
   reported_lgl_idx <-
-    (max_date - linelist[[col]]) > trunc
+    (max_date - linelist[[col_name]]) > trunc
   # convert NAs to TRUE to prevent issues with subsetting with NAs
   reported_lgl_idx[is.na(reported_lgl_idx)] <- TRUE
   linelist <- linelist[reported_lgl_idx, ]

--- a/R/utils.R
+++ b/R/utils.R
@@ -289,7 +289,7 @@ as_function <- function(x) {
   if (nchar(char) < 2) return(char)
   chars <- strsplit(char, "", fixed = TRUE)[[1]]
   n_chars <- length(chars)
-  letter_idx <- sample(seq_len(n_chars), size = 1)
+  letter_idx <- sample.int(n = n_chars, size = 1)
   chars[letter_idx] <- ifelse(
     test = letter_idx == 1,
     yes = sample(LETTERS, 1),

--- a/vignettes/reporting-delays-truncation.Rmd
+++ b/vignettes/reporting-delays-truncation.Rmd
@@ -409,7 +409,10 @@ plot(inci_late) +
 Next we repeat this procedure of creating data sets for early, mid, and late in the outbreak. For this example we will use the default right-truncation delay distribution (lognormal with `meanlog = 0.58` and `sdlog = 0.47`) and default truncation event (reporting date).
 
 ```{r trunc-stages-reporting-delay, fig.width = 8, fig.height = 5, fig.show="hold", out.width="30%"}
-linelist_early <- truncate_linelist(linelist = linelist, max_date = "2023-02-01")
+linelist_early <- truncate_linelist(
+  linelist = linelist,
+  max_date = "2023-02-01"
+)
 inci_early <- incidence(
   x = linelist_early,
   date_index = "date_onset",

--- a/vignettes/reporting-delays-truncation.Rmd
+++ b/vignettes/reporting-delays-truncation.Rmd
@@ -116,8 +116,8 @@ tidy_linelist <- linelist %>%
   pivot_longer(
     cols = c("date_onset", "date_reporting", "date_admission", "date_outcome")
   ) %>%
-  mutate(ordering_value = ifelse(name == "date_onset", value, NA)) %>%
-  mutate(case_name = reorder(case_name, ordering_value, min, na.rm = TRUE))
+  mutate(ordering_value = ifelse(name == "date_onset", value, NA)) %>% # nolint consecutive_mutate_linter
+  mutate(case_name = reorder(case_name, ordering_value, min, na.rm = TRUE)) # nolint consecutive_mutate_linter
 
 ggplot(data = tidy_linelist) +
   geom_line(
@@ -225,8 +225,8 @@ tidy_linelist <- linelist %>%
   pivot_longer(
     cols = c("date_onset", "date_reporting", "date_admission", "date_outcome")
   ) %>%
-  mutate(ordering_value = ifelse(name == "date_onset", value, NA)) %>%
-  mutate(case_name = reorder(case_name, ordering_value, min, na.rm = TRUE))
+  mutate(ordering_value = ifelse(name == "date_onset", value, NA)) %>% # nolint consecutive_mutate_linter
+  mutate(case_name = reorder(case_name, ordering_value, min, na.rm = TRUE)) # nolint consecutive_mutate_linter
 
 trunc_point <- data.frame(
   case_name = linelist$case_name,

--- a/vignettes/vis-linelist.Rmd
+++ b/vignettes/vis-linelist.Rmd
@@ -156,8 +156,7 @@ linelist <- linelist %>%
   tidyr::pivot_wider(
     names_from = outcome,
     values_from = date_outcome
-  )
-linelist <- linelist %>%
+  ) %>%
   dplyr::rename(
     date_death = died,
     date_recovery = recovered
@@ -280,7 +279,7 @@ outbreak$contacts <- outbreak$contacts[outbreak$contacts$was_case == "Y", ]
 
 ```{r, subset-linelist-tidyverse}
 library(dplyr)
-outbreak$contacts <- outbreak$contacts %>%
+outbreak$contacts <- outbreak$contacts %>% # nolint one_call_pipe_linter
   dplyr::filter(was_case == "Y")
 ```
 

--- a/vignettes/wrangling-linelist.Rmd
+++ b/vignettes/wrangling-linelist.Rmd
@@ -105,7 +105,7 @@ Not every column in the simulated line list may be required for the use case at 
 
 ```{r, rm-ct-col-tidyverse}
 # remove column by name
-linelist %>%
+linelist %>% # nolint one_call_pipe_linter
   select(!ct_value)
 ```
 


### PR DESCRIPTION
This PR fixes lintr warnings - causing the `lint-changed-files` workflow to fail - since the release of {lintr} v3.2.0. Most issues detected have been resolved, some have `# nolint` flags, where deemed better to keep the existing code, these can potentially be resolved and the `# nolint` flag removed in the future.

Changes include:

- Adding a dot prefix to variables assigned in functions that overwrite functions exported by base R, e.g. `.args`
- Remove `all()` from `stopifnot()` calls as this is done automatically
- Unnest `else` after `return()`
- All lines are less than 80 characters
- Use `sample.int()` instead of `sample()` 

Add `# nolint` flags for:

- `one_call_pipe_linter`
- `consecutive_mutate_linter`