### PR TITLE
Use `\describe{}` in messy_linelist `...` documentation

### DIFF
--- a/R/checkers.R
+++ b/R/checkers.R
@@ -366,7 +366,7 @@
 #' the class of the object, in other words, it does not check the object is
 #' of class `<linelist>`.
 #'
-#' @inheritParams truncate_linelist
+#' @inheritParams messy_linelist
 #'
 #' @return Invisibly return the `linelist` `<data.frame>`. The function is
 #' called for its side-effects, which will error if the input is invalid.

--- a/R/messy_linelist.R
+++ b/R/messy_linelist.R
@@ -6,32 +6,22 @@
 #' mistakes and inconsistencies, as well as coerce date types.
 #'
 #' @param linelist Line list `<data.frame>` output from [sim_linelist()].
-#' @inheritParams create_config
-#'
-#' @details
-#' By default `messy_linelist()`:
-#'
-#' * Makes 10% of values missing, i.e. converts to `NA`.
-#' * Introduces spelling mistakes in 10% of `character` columns.
-#' * Introduce inconsistency in the reporting of `$sex`.
-#' * Converts `numeric` columns (`double` & `integer`) to `character`.
-#' * Converts `Date` columns to `character`.
-#' * Converts `integer` columns to (English) words.
-#' * Duplicates 1% of rows
-#'
-#' To change the defaults of `messy_linelist()` arguments can be supplied
-#' to `...`.
+#' @param ... <[`dynamic-dots`][rlang::dyn-dots]> Named elements to replace
+#' default settings. Only if names match exactly are elements replaced,
+#' otherwise the function errors.
 #'
 #' Accepted arguments and their defaults are:
 #'
 #' \describe{
 #'   \item{`prop_missing`}{A `numeric` between 0 and 1 for the proportion of
-#'   missing values. Default is `0.1` (10%).}
+#'   missing values. Default is `0.1` (10%).
+#'   }
 #'   \item{`missing_value`}{A single atomic \R object used to represent missing
 #'   values. Default is `NA`.}
 #'   \item{`prop_spelling_mistakes`}{A `numeric` between 0 and 1 used to
 #'   specify the proportion of spelling mistakes in `character` columns.
-#'   Default is `0.1` (10%).}
+#'   Default is `0.1` (10%).
+#'   }
 #'   \item{`inconsistent_sex`}{A `logical` boolean to specify whether the
 #'   `$sex` column uses `"m"` and `"f"`, or inconsistently uses `"m"`, `"f"`,
 #'   `"M"`, `"F"`, `"male"`, `"female"`, `"Male"` or `"Female"`. Default
@@ -56,6 +46,17 @@
 #'   `prop_duplicate_row` > 0 then it is guaranteed that at least one row will
 #'   be duplicated.}
 #' }
+#'
+#' @details
+#' By default `messy_linelist()`:
+#'
+#' * Makes 10% of values missing, i.e. converts to `NA`.
+#' * Introduces spelling mistakes in 10% of `character` columns.
+#' * Introduce inconsistency in the reporting of `$sex`.
+#' * Converts `numeric` columns (`double` & `integer`) to `character`.
+#' * Converts `Date` columns to `character`.
+#' * Converts `integer` columns to (English) words.
+#' * Duplicates 1% of rows
 #'
 #' When setting `sex_as_numeric` to `TRUE`, male is set to `0` and female
 #' to `1`. Only one of `inconsistent_sex` or `sex_as_numeric` can be `TRUE`,

--- a/R/truncate_linelist.R
+++ b/R/truncate_linelist.R
@@ -17,7 +17,7 @@
 #' to the variability in the reporting delays. See examples for variable or
 #' fixed `delay` functions.
 #'
-#' @param linelist A `<data.frame>` output from [sim_linelist()].
+#' @inheritParams messy_linelist
 #' @param delay A `function` (either anonymous or predefined) that
 #' has a single argument and generates random numbers given a probability
 #' distribution. The function must return a vector of real numbers for

--- a/man/dot-check_linelist.Rd
+++ b/man/dot-check_linelist.Rd
@@ -7,7 +7,7 @@
 .check_linelist(linelist)
 }
 \arguments{
-\item{linelist}{A \verb{<data.frame>} output from \code{\link[=sim_linelist]{sim_linelist()}}.}
+\item{linelist}{Line list \verb{<data.frame>} output from \code{\link[=sim_linelist]{sim_linelist()}}.}
 }
 \value{
 Invisibly return the \code{linelist} \verb{<data.frame>}. The function is

--- a/man/messy_linelist.Rd
+++ b/man/messy_linelist.Rd
@@ -11,41 +11,20 @@ messy_linelist(linelist, ...)
 
 \item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> Named elements to replace
 default settings. Only if names match exactly are elements replaced,
-otherwise the function errors.}
-}
-\value{
-A messy line list \verb{<data.frame>}.
-}
-\description{
-Take line list output from \code{\link[=sim_linelist]{sim_linelist()}} and replace elements of
-the \verb{<data.frame>} with missing values (e.g. \code{NA}), introduce spelling
-mistakes and inconsistencies, as well as coerce date types.
-}
-\details{
-By default \code{messy_linelist()}:
-\itemize{
-\item Makes 10\% of values missing, i.e. converts to \code{NA}.
-\item Introduces spelling mistakes in 10\% of \code{character} columns.
-\item Introduce inconsistency in the reporting of \verb{$sex}.
-\item Converts \code{numeric} columns (\code{double} & \code{integer}) to \code{character}.
-\item Converts \code{Date} columns to \code{character}.
-\item Converts \code{integer} columns to (English) words.
-\item Duplicates 1\% of rows
-}
-
-To change the defaults of \code{messy_linelist()} arguments can be supplied
-to \code{...}.
+otherwise the function errors.
 
 Accepted arguments and their defaults are:
 
 \describe{
 \item{\code{prop_missing}}{A \code{numeric} between 0 and 1 for the proportion of
-missing values. Default is \code{0.1} (10\%).}
+missing values. Default is \code{0.1} (10\%).
+}
 \item{\code{missing_value}}{A single atomic \R object used to represent missing
 values. Default is \code{NA}.}
 \item{\code{prop_spelling_mistakes}}{A \code{numeric} between 0 and 1 used to
 specify the proportion of spelling mistakes in \code{character} columns.
-Default is \code{0.1} (10\%).}
+Default is \code{0.1} (10\%).
+}
 \item{\code{inconsistent_sex}}{A \code{logical} boolean to specify whether the
 \verb{$sex} column uses \code{"m"} and \code{"f"}, or inconsistently uses \code{"m"}, \code{"f"},
 \code{"M"}, \code{"F"}, \code{"male"}, \code{"female"}, \code{"Male"} or \code{"Female"}. Default
@@ -69,6 +48,26 @@ Default is \code{FALSE}.}
 proportion of rows to duplicate. Default is \code{0.01} (1\%). If
 \code{prop_duplicate_row} > 0 then it is guaranteed that at least one row will
 be duplicated.}
+}}
+}
+\value{
+A messy line list \verb{<data.frame>}.
+}
+\description{
+Take line list output from \code{\link[=sim_linelist]{sim_linelist()}} and replace elements of
+the \verb{<data.frame>} with missing values (e.g. \code{NA}), introduce spelling
+mistakes and inconsistencies, as well as coerce date types.
+}
+\details{
+By default \code{messy_linelist()}:
+\itemize{
+\item Makes 10\% of values missing, i.e. converts to \code{NA}.
+\item Introduces spelling mistakes in 10\% of \code{character} columns.
+\item Introduce inconsistency in the reporting of \verb{$sex}.
+\item Converts \code{numeric} columns (\code{double} & \code{integer}) to \code{character}.
+\item Converts \code{Date} columns to \code{character}.
+\item Converts \code{integer} columns to (English) words.
+\item Duplicates 1\% of rows
 }
 
 When setting \code{sex_as_numeric} to \code{TRUE}, male is set to \code{0} and female

--- a/man/truncate_linelist.Rd
+++ b/man/truncate_linelist.Rd
@@ -12,7 +12,7 @@ truncate_linelist(
 )
 }
 \arguments{
-\item{linelist}{A \verb{<data.frame>} output from \code{\link[=sim_linelist]{sim_linelist()}}.}
+\item{linelist}{Line list \verb{<data.frame>} output from \code{\link[=sim_linelist]{sim_linelist()}}.}
 
 \item{delay}{A \code{function} (either anonymous or predefined) that
 has a single argument and generates random numbers given a probability


### PR DESCRIPTION
This PR addresses #194 by moving the `\describe{}` documentation, added in PR #187, from `@details` to `@param` for `...` of `messy_linelist()`. The `...` documentation from `create_config()` is manually copied instead of being inherited as was previously being done (as inheriting and appending is not possible).

The `linelist` argument is now consistently inherited from `messy_linelist()` throughout the package.