### PR TITLE
Improve `truncate_linelist()`

### DIFF
--- a/R/checkers.R
+++ b/R/checkers.R
@@ -367,7 +367,7 @@
         )
       ),
     "`linelist$date_reporting` column cannot contain any NAs." =
-      anyNA(linelist$date_reporting)
+      !anyNA(linelist$date_reporting)
   )
   invisible(linelist)
 }

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -357,7 +357,7 @@
 #' @keywords internal
 .check_linelist <- function(linelist) {
   stopifnot(
-    "linelist must be a data.frame output from `sim_linelist()`" =
+    "linelist must be a data.frame output from `sim_linelist()`." =
       is.data.frame(linelist) && ncol(linelist) == 13 &&
       setequal(
         colnames(linelist), c(
@@ -365,7 +365,9 @@
           "date_reporting", "date_admission", "outcome", "date_outcome",
           "date_first_contact", "date_last_contact", "ct_value"
         )
-      )
+      ),
+    "`linelist$date_reporting` column cannot contain any NAs." =
+      anyNA(linelist$date_reporting)
   )
   invisible(linelist)
 }

--- a/R/truncate_linelist.R
+++ b/R/truncate_linelist.R
@@ -119,10 +119,16 @@ truncate_linelist <- function(linelist,
   reported_lgl_idx <- trunc_date > linelist$date_reporting
   linelist <- linelist[reported_lgl_idx, ]
 
-  # convert events (reporting, admissions & outcomes) more recent than
-  # truncation time to NA
-  linelist$date_outcome[linelist$date_outcome > trunc_date] <- NA_real_
-  linelist$date_admission[linelist$date_admission > trunc_date] <- NA_real_
+  # get date columns to be modified if after truncation time
+  date_col_lgl_idx <- vapply(
+    linelist, inherits, FUN.VALUE = logical(1), what = "Date"
+  )
+  date_cols <- colnames(linelist)[date_col_lgl_idx]
+  for (date_col in date_cols) {
+    # convert events (reporting, admissions & outcomes) more recent than
+    # truncation time to NA
+    linelist[[date_col]][linelist[[date_col]] > trunc_date] <- NA_real_
+  }
 
   row.names(linelist) <- NULL
   linelist

--- a/R/truncate_linelist.R
+++ b/R/truncate_linelist.R
@@ -6,7 +6,9 @@
 #' admission or outcome dates that are after the truncation point to `NA`.
 #'
 #' This is to replicate real-time outbreak data where recent cases or outcomes
-#' are not yet observed or reported (right truncation).
+#' are not yet observed or reported (right truncation). It implies an assumption 
+#' that symptom onsets are reported with a delay but hospitalisations are 
+#' reported instantly.
 #'
 #' @details
 #' The point at which the line list is right-truncated is the same for

--- a/R/truncate_linelist.R
+++ b/R/truncate_linelist.R
@@ -13,29 +13,29 @@
 #' @details
 #' The day on which the line list is truncated is the same for
 #' all individuals in the line list, and is specified by the
-#' `truncation_time` and `unit` arguments.
+#' `truncation_day` and `unit` arguments.
 #'
 #' @inheritParams messy_linelist
-#' @param truncation_time A single `numeric` specifying the number of
+#' @param truncation_day A single `numeric` specifying the number of
 #' days (default), weeks, months or years before the end of the outbreak
 #' (default) or since the start of the outbreak (see `direction` argument)
 #' to truncate the line list at. By default it is 14 days before the end
 #' of the outbreak.
 #'
-#' Alternatively, `truncation_time` can accept a `<Date>` and this is
-#' used as the `truncation_time` and the `unit` and `direction` is ignored.
+#' Alternatively, `truncation_day` can accept a `<Date>` and this is
+#' used as the `truncation_day` and the `unit` and `direction` is ignored.
 #'
 #' @param unit A `character` string, either `"days"` (default),
 #' `"weeks"`, `"months"`, or `"years"`, specifying the units of the
-#' `truncation_time` argument.
+#' `truncation_day` argument.
 #'
 #' Years are assumed to be 365.25 days and months are assumed to be 365.25 / 12
 #' days (same as \pkg{lubridate}).
 #'
 #' @param direction A `character` string, either `"backwards"` (default) or
-#' `"forwards"`. `direction = backwards` defines the `truncation_time` as
+#' `"forwards"`. `direction = backwards` defines the `truncation_day` as
 #' the time before the end of the outbreak. `direction = forwards` defines
-#' the `truncation_time` as the time since the start of the outbreak.
+#' the `truncation_day` as the time since the start of the outbreak.
 #'
 #' @return A line list `<data.frame>`.
 #' @export
@@ -48,14 +48,14 @@
 #' # set truncation point 3 weeks before the end of outbreak
 #' linelist_trunc <- truncate_linelist(
 #'   linelist,
-#'   truncation_time = 3,
+#'   truncation_day = 3,
 #'   unit = "weeks"
 #' )
 #'
 #' # set truncation point to 2 months since the start of outbreak
 #' linelist_trunc <- truncate_linelist(
 #'   linelist,
-#'   truncation_time = 2,
+#'   truncation_day = 2,
 #'   unit = "months",
 #'   direction = "forwards"
 #' )
@@ -63,29 +63,29 @@
 #' # set truncation point to 2023-03-01
 #' linelist_trunc <- truncate_linelist(
 #'   linelist,
-#'   truncation_time = as.Date("2023-03-01")
+#'   truncation_day = as.Date("2023-03-01")
 #' )
 truncate_linelist <- function(linelist,
-                              truncation_time = 14,
+                              truncation_day = 14,
                               unit = c("days", "weeks", "months", "years"),
                               direction = c("backwards", "forwards")) {
   arg_ignore <- missing(unit) && missing(direction)
   .check_linelist(linelist)
   stopifnot(
-    "`truncation_time` must be a single positive numeric or a <Date> object." =
-      checkmate::test_number(truncation_time, lower = 0, finite = TRUE) ||
-      checkmate::test_date(truncation_time, any.missing = FALSE, len = 1)
+    "`truncation_day` must be a single positive numeric or a <Date> object." =
+      checkmate::test_number(truncation_day, lower = 0, finite = TRUE) ||
+      checkmate::test_date(truncation_day, any.missing = FALSE, len = 1)
     )
   unit <- match.arg(unit)
   direction <- match.arg(direction)
 
-  if (is.numeric(truncation_time)) {
-    # convert truncation_time to days
-    truncation_time <- switch(unit,
-      days = truncation_time,
-      weeks = truncation_time * 7,
-      months = truncation_time * (365.25 / 12),
-      years = truncation_time * 365.25
+  if (is.numeric(truncation_day)) {
+    # convert truncation_day to days
+    truncation_day <- switch(unit,
+      days = truncation_day,
+      weeks = truncation_day * 7,
+      months = truncation_day * (365.25 / 12),
+      years = truncation_day * 365.25
     )
 
     date_cols <- grep(pattern = "date_", x = colnames(linelist), fixed = TRUE)
@@ -95,20 +95,20 @@ truncate_linelist <- function(linelist,
         max(unlist(linelist[, date_cols]), na.rm = TRUE),
         origin = "1970-01-01"
       )
-      trunc_date <- max_date - truncation_time
+      trunc_date <- max_date - truncation_day
     } else {
       # get outbreak start date as minimum date in line list
       min_date <- as.Date(
         min(unlist(linelist[, date_cols]), na.rm = TRUE),
         origin = "1970-01-01"
       )
-      trunc_date <- min_date + truncation_time
+      trunc_date <- min_date + truncation_day
     }
   } else {
-    trunc_date <- truncation_time
+    trunc_date <- truncation_day
     if (!arg_ignore) {
       warning(
-        "When `truncation_time` is given as a <Date>, ",
+        "When `truncation_day` is given as a <Date>, ",
         "`unit` and `direction` are ignored.",
         call. = FALSE
       )

--- a/R/truncate_linelist.R
+++ b/R/truncate_linelist.R
@@ -6,8 +6,8 @@
 #' admission or outcome dates that are after the truncation point to `NA`.
 #'
 #' This is to replicate real-time outbreak data where recent cases or outcomes
-#' are not yet observed or reported (right truncation). It implies an assumption 
-#' that symptom onsets are reported with a delay but hospitalisations are 
+#' are not yet observed or reported (right truncation). It implies an assumption
+#' that symptom onsets are reported with a delay but hospitalisations are
 #' reported instantly.
 #'
 #' @details
@@ -72,7 +72,7 @@ truncate_linelist <- function(linelist,
   arg_ignore <- missing(unit) && missing(direction)
   .check_linelist(linelist)
   stopifnot(
-    "`truncation_day` must be a single positive numeric or a <Date> object." =
+    "`truncation_day` must be a single nonnegative numeric or <Date> object." =
       checkmate::test_number(truncation_day, lower = 0, finite = TRUE) ||
       checkmate::test_date(truncation_day, any.missing = FALSE, len = 1)
     )

--- a/R/truncate_linelist.R
+++ b/R/truncate_linelist.R
@@ -11,7 +11,7 @@
 #' reported instantly.
 #'
 #' @details
-#' The point at which the line list is right-truncated is the same for
+#' The day on which the line list is truncated is the same for
 #' all individuals in the line list, and is specified by the
 #' `truncation_time` and `unit` arguments.
 #'

--- a/man/truncate_linelist.Rd
+++ b/man/truncate_linelist.Rd
@@ -44,10 +44,12 @@ have not been reported by the truncation time and setting hospitalisation
 admission or outcome dates that are after the truncation point to \code{NA}.
 
 This is to replicate real-time outbreak data where recent cases or outcomes
-are not yet observed or reported (right truncation).
+are not yet observed or reported (right truncation). It implies an assumption
+that symptom onsets are reported with a delay but hospitalisations are
+reported instantly.
 }
 \details{
-The point at which the line list is right-truncated is the same for
+The day on which the line list is truncated is the same for
 all individuals in the line list, and is specified by the
 \code{truncation_day} and \code{unit} arguments.
 }

--- a/man/truncate_linelist.Rd
+++ b/man/truncate_linelist.Rd
@@ -6,93 +6,74 @@
 \usage{
 truncate_linelist(
   linelist,
-  delay = function(x) stats::rlnorm(n = x, meanlog = 0.58, sdlog = 0.47),
-  max_date = NULL,
-  truncation_event = c("reporting", "onset", "admission", "outcome")
+  truncation_time = 14,
+  unit = c("days", "weeks", "months", "years"),
+  direction = c("backwards", "forwards")
 )
 }
 \arguments{
 \item{linelist}{Line list \verb{<data.frame>} output from \code{\link[=sim_linelist]{sim_linelist()}}.}
 
-\item{delay}{A \code{function} (either anonymous or predefined) that
-has a single argument and generates random numbers given a probability
-distribution. The function must return a vector of real numbers for
-representing the reporting delay between the right-truncation point and the
-cut off date (\code{max_date}).
+\item{truncation_time}{A single \code{numeric} specifying the number of
+days (default), weeks, months or years before the end of the outbreak
+(default) or since the start of the outbreak (see \code{direction} argument)
+to truncate the line list at. By default it is 14 days before the end
+of the outbreak.
 
-Default is a random number generator that is lognormally
-distributed (\code{\link[=rlnorm]{rlnorm()}}) delay with parameters \code{meanlog = 0.58} and
-\code{sdlog = 0.47}, which corresponds to a mean of 2 and a standard deviation
-of 1.}
+Alternatively, \code{truncation_time} can accept a \verb{<Date>} and this is
+used as the \code{truncation_time} and the \code{unit} and \code{direction} is ignored.}
 
-\item{max_date}{A maximum date to cut off the outbreak and apply reporting
-delays. Default is \code{NULL}, so the maximum date will be automatically
-calculated as the date at the end of the outbreak (i.e. date of the last
-outcome).}
+\item{unit}{A \code{character} string, either \code{"days"} (default),
+\code{"weeks"}, \code{"months"}, or \code{"years"}, specifying the units of the
+\code{truncation_time} argument.
 
-\item{truncation_event}{A \code{character} string with which event in the line
-list the right truncation should apply to. The default is \code{"reporting"} for
-the reporting delay, which is likely the most common form of right truncation
-in real-time outbreak data. When \code{truncation_event = "reporting"} if a date
-of reporting (\verb{$date_reporting}) is more recent than the sampled truncation
-time then the individual (row) is removed from the line list. If the date of
-reporting is less recent than the sampled truncation time but either the
-date of hospitalisation (\verb{$date_admission}) or date of outcome
-(\verb{$date_outcome}) is more recent than the sampled truncation time then these
-dates are converted from \code{Date}s to \code{NA}s.
+Years are assumed to be 365.25 days and months are assumed to be 365.25 / 12
+days (same as \pkg{lubridate}).}
 
-The other options for \code{truncation_event} are \code{"onset"}, \code{"admission"}
-or \code{"outcome"}.  If these are chosen then if the truncation point is more
-recent than the date of symptom onset, date of hospital admission, or
-date of outcome (death or recovery), respectively, then these individuals
-(rows) will be removed from the line list (i.e. the \verb{<data.frame>} is
-subset). If the event is less recent than the sampled truncation time then
-any events after the truncation point will be set to \code{NA}.}
+\item{direction}{A \code{character} string, either \code{"backwards"} (default) or
+\code{"forwards"}. \code{direction = backwards} defines the \code{truncation_time} as
+the time before the end of the outbreak. \code{direction = forwards} defines
+the \code{truncation_time} as the time since the start of the outbreak.}
 }
 \value{
 A line list \verb{<data.frame>}.
 }
 \description{
-Adjust or subset the line list \verb{<data.frame>} by either changing dates that
-are within the right-truncation window to \code{NA} or removing cases that have
-occurred within a delay period. This occurs to recent cases or outcomes
-that are not yet recorded in the line list and will be revised upwards. See
-\code{truncation_event} argument documentation for different types of truncation.
+Adjust or subset the line list \verb{<data.frame>} by removing cases that
+have not been reported by the truncation time and setting hospitalisation
+admission or outcome dates that are after the truncation point to \code{NA}.
+
+This is to replicate real-time outbreak data where recent cases or outcomes
+are not yet observed or reported (right truncation).
 }
 \details{
-The truncation window is sampled for each individual and is specified by a
-(random) number generating function supplied to the \code{delay}
-argument. Therefore, if this function has variability
-(e.g. a probability distribution) it will not be a fixed time window for
-all individuals. It is possible that someone with a more recent date of
-onset is kept but someone with a less recent date of onset is removed due
-to the variability in the reporting delays. See examples for variable or
-fixed \code{delay} functions.
+The point at which the line list is right-truncated is the same for
+all individuals in the line list, and is specified by the
+\code{truncation_time} and \code{unit} arguments.
 }
 \examples{
 set.seed(1)
 linelist <- sim_linelist()
 linelist_trunc <- truncate_linelist(linelist)
 
-# set maximum date to apply truncation to 2023-01-01
-linelist_trunc <- truncate_linelist(linelist, max_date = "2023-01-01")
-
-# apply longer truncation to hospital admission
+# set truncation point 3 weeks before the end of outbreak
 linelist_trunc <- truncate_linelist(
   linelist,
-  delay = function(x) rlnorm(n = x, meanlog = 2, sdlog = 0.5),
-  truncation_event = "admission"
+  truncation_time = 3,
+  unit = "weeks"
 )
 
-# variable right truncation with mean 2 and sd 1 (default behaviour)
+# set truncation point to 2 months since the start of outbreak
 linelist_trunc <- truncate_linelist(
   linelist,
-  delay = function(x) rlnorm(n = x, meanlog = 0.58, sdlog = 0.47)
+  truncation_time = 2,
+  unit = "months",
+  direction = "forwards"
 )
 
-# fixed right truncation of 5 days
+# set truncation point to 2023-03-01
 linelist_trunc <- truncate_linelist(
   linelist,
-  delay = function(x) rep(5, n = x)
+  truncation_time = as.Date("2023-03-01")
 )
 }

--- a/man/truncate_linelist.Rd
+++ b/man/truncate_linelist.Rd
@@ -6,7 +6,7 @@
 \usage{
 truncate_linelist(
   linelist,
-  truncation_time = 14,
+  truncation_day = 14,
   unit = c("days", "weeks", "months", "years"),
   direction = c("backwards", "forwards")
 )
@@ -14,26 +14,26 @@ truncate_linelist(
 \arguments{
 \item{linelist}{Line list \verb{<data.frame>} output from \code{\link[=sim_linelist]{sim_linelist()}}.}
 
-\item{truncation_time}{A single \code{numeric} specifying the number of
+\item{truncation_day}{A single \code{numeric} specifying the number of
 days (default), weeks, months or years before the end of the outbreak
 (default) or since the start of the outbreak (see \code{direction} argument)
 to truncate the line list at. By default it is 14 days before the end
 of the outbreak.
 
-Alternatively, \code{truncation_time} can accept a \verb{<Date>} and this is
-used as the \code{truncation_time} and the \code{unit} and \code{direction} is ignored.}
+Alternatively, \code{truncation_day} can accept a \verb{<Date>} and this is
+used as the \code{truncation_day} and the \code{unit} and \code{direction} is ignored.}
 
 \item{unit}{A \code{character} string, either \code{"days"} (default),
 \code{"weeks"}, \code{"months"}, or \code{"years"}, specifying the units of the
-\code{truncation_time} argument.
+\code{truncation_day} argument.
 
 Years are assumed to be 365.25 days and months are assumed to be 365.25 / 12
 days (same as \pkg{lubridate}).}
 
 \item{direction}{A \code{character} string, either \code{"backwards"} (default) or
-\code{"forwards"}. \code{direction = backwards} defines the \code{truncation_time} as
+\code{"forwards"}. \code{direction = backwards} defines the \code{truncation_day} as
 the time before the end of the outbreak. \code{direction = forwards} defines
-the \code{truncation_time} as the time since the start of the outbreak.}
+the \code{truncation_day} as the time since the start of the outbreak.}
 }
 \value{
 A line list \verb{<data.frame>}.
@@ -49,7 +49,7 @@ are not yet observed or reported (right truncation).
 \details{
 The point at which the line list is right-truncated is the same for
 all individuals in the line list, and is specified by the
-\code{truncation_time} and \code{unit} arguments.
+\code{truncation_day} and \code{unit} arguments.
 }
 \examples{
 set.seed(1)
@@ -59,14 +59,14 @@ linelist_trunc <- truncate_linelist(linelist)
 # set truncation point 3 weeks before the end of outbreak
 linelist_trunc <- truncate_linelist(
   linelist,
-  truncation_time = 3,
+  truncation_day = 3,
   unit = "weeks"
 )
 
 # set truncation point to 2 months since the start of outbreak
 linelist_trunc <- truncate_linelist(
   linelist,
-  truncation_time = 2,
+  truncation_day = 2,
   unit = "months",
   direction = "forwards"
 )
@@ -74,6 +74,6 @@ linelist_trunc <- truncate_linelist(
 # set truncation point to 2023-03-01
 linelist_trunc <- truncate_linelist(
   linelist,
-  truncation_time = as.Date("2023-03-01")
+  truncation_day = as.Date("2023-03-01")
 )
 }

--- a/tests/testthat/test-truncate_linelist.R
+++ b/tests/testthat/test-truncate_linelist.R
@@ -89,8 +89,12 @@ test_that("truncate_linelist works as expected with non-integer truncation", {
   expect_false(ll[92, "case_name"] %in% ll_trunc_excl$case_name)
 
   # events on 2023-03-16 still in the linelist based on non-integer truncation
-  trunc_date_incl %in% as.character(as.Date(unlist(ll_trunc_incl[, date_cols])))
-  trunc_date_excl %in% as.character(as.Date(unlist(ll_trunc_excl[, date_cols])))
+  trunc_date_incl %in% as.character(
+    as.Date(unlist(ll_trunc_incl[, date_cols]), origin = "1970-01-01")
+  )
+  trunc_date_excl %in% as.character(
+    as.Date(unlist(ll_trunc_excl[, date_cols]),  origin = "1970-01-01")
+  )
 })
 
 test_that("truncate_linelist works as expected with forward direction", {

--- a/tests/testthat/test-truncate_linelist.R
+++ b/tests/testthat/test-truncate_linelist.R
@@ -3,30 +3,40 @@ ll <- sim_linelist()
 
 test_that("truncate_linelist works as expected with defaults", {
   ll_trunc <- truncate_linelist(ll)
-  # in this example dataset only the outcome col is adjusted from truncate_linelist
+  # in this example dataset one case is removed
   expect_false(identical(ll$date_outcome, ll_trunc$date_outcome))
+  expect_gt(nrow(ll), nrow(ll_trunc))
 })
 
-test_that("truncate_linelist works as expected with modified delay", {
+test_that("truncate_linelist works as expected with modified truncation_time", {
   ll_trunc <- truncate_linelist(
-    ll,
-    delay = function(x) rlnorm(n = x, meanlog = 3, sdlog = 2)
+    linelist = ll,
+    truncation_time = 60
   )
-  # in this example dataset the df is subset
   expect_gt(nrow(ll), nrow(ll_trunc))
 })
 
-test_that("truncate_linelist works as expected with max_date", {
-  expect_message(ll_trunc <- truncate_linelist(ll, max_date = "2023-02-01"))
-  # in this example dataset the df is subset
+test_that("truncate_linelist works as expected with different units", {
+  ll_trunc <- truncate_linelist(
+    linelist = ll,
+    truncation_time = 3,
+    unit = "weeks"
+  )
   expect_gt(nrow(ll), nrow(ll_trunc))
-  expect_true(all(ll_trunc$date_onset < as.Date("2023-02-01")))
 })
 
-test_that("truncate_linelist works as expected with outcome delay_type", {
-  ll_trunc <- truncate_linelist(ll, truncation_event = "outcome")
-  # in this example dataset the df is subset
+test_that("truncate_linelist works as expected with forward direction", {
+  ll_trunc <- truncate_linelist(linelist = ll, direction = "forward")
   expect_gt(nrow(ll), nrow(ll_trunc))
+})
+
+test_that("truncate_linelist workds as expected with <Date> truncation_time", {
+  ll_trunc <- truncate_linelist(
+    linelist = ll,
+    truncation_time = as.Date("2023-03-01")
+  )
+  expect_gt(nrow(ll), nrow(ll_trunc))
+  expect_true(all(ll_trunc$date_reporting < as.Date("2023-03-01")))
 })
 
 test_that("truncate_linelist sets dates as NA when between events", {
@@ -34,13 +44,10 @@ test_that("truncate_linelist sets dates as NA when between events", {
   # hospitalisation and onset to death to truncate between reporting and event
   ll <- sim_linelist(
     hosp_risk = 0.9,
-    onset_to_hosp = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.1),
+    onset_to_hosp = function(x) stats::rlnorm(n = x, meanlog = 3, sdlog = 0.1),
     onset_to_death = function(x) stats::rlnorm(n = x, meanlog = 3, sdlog = 0.1)
   )
-  ll_trunc <- truncate_linelist(
-    ll,
-    delay = function(x) rlnorm(n = x, meanlog = 2, sdlog = 0.5)
-  )
+  ll_trunc <- truncate_linelist(ll, truncation_time = 30)
   # it is possible that the proportion of NAs in the truncated data is lower
   # than the complete data if by chance the hospitalised cases are removed
   # but some NAs should be introduced in truncated data in rows that are kept
@@ -50,10 +57,22 @@ test_that("truncate_linelist sets dates as NA when between events", {
   )
 })
 
-test_that("truncate_linelist prints message as expected for with numeric max_date", {
-  expect_message(
-    truncate_linelist(ll, max_date = 10),
-    regexp = "(Truncation max date is:)*(Assuming)*(origin)*('1970-01-01')"
+test_that("truncate_linelist warns if truncation_time is Date and unit given", {
+  expect_warning(
+    truncate_linelist(
+      linelist = ll,
+      truncation_time = as.Date("2023-03-01"),
+      unit = "weeks"
+    ),
+    regexp = "(truncation_time)*(is)*(Date)*(unit)*(direction)*(are ignored)"
+  )
+  expect_warning(
+    truncate_linelist(
+      linelist = ll,
+      truncation_time = as.Date("2023-03-01"),
+      direction = "forwards"
+    ),
+    regexp = "(truncation_time)*(is)*(Date)*(unit)*(direction)*(are ignored)"
   )
 })
 
@@ -64,16 +83,23 @@ test_that("truncate_linelist fails as expected for invalid linelist", {
   )
 })
 
-test_that("truncate_linelist fails as expected for invalid delay", {
+test_that("truncate_linelist fails as expected for invalid truncation_time", {
   expect_error(
-    truncate_linelist(ll, delay = function(x, y) x + y),
-    regexp = "(delay supplied must have 1 argument)"
+    truncate_linelist(ll, truncation_time = -1),
+    regexp = "(truncation_time)*(single positive numeric or)*(Date)"
   )
 })
 
-test_that("truncate_linelist fails as expected for invalid delay_type", {
+test_that("truncate_linelist fails as expected for invalid unit", {
   expect_error(
-    truncate_linelist(ll, truncation_event = "random"),
-    regexp = "(should be one of)*(reporting)*(onset)*(admission)*(outcome)"
+    truncate_linelist(ll, unit = "daily"),
+    regexp = "(should be one of)*(days)*(weeks)*(months)*(years)"
+  )
+})
+
+test_that("truncate_linelist fails as expected for invalid direction", {
+  expect_error(
+    truncate_linelist(ll, direction = "retrospective"),
+    regexp = "(should be one of)*(backwards)*(forwards)"
   )
 })

--- a/tests/testthat/test-truncate_linelist.R
+++ b/tests/testthat/test-truncate_linelist.R
@@ -8,10 +8,10 @@ test_that("truncate_linelist works as expected with defaults", {
   expect_gt(nrow(ll), nrow(ll_trunc))
 })
 
-test_that("truncate_linelist works as expected with modified truncation_time", {
+test_that("truncate_linelist works as expected with modified truncation_day", {
   ll_trunc <- truncate_linelist(
     linelist = ll,
-    truncation_time = 60
+    truncation_day = 60
   )
   expect_gt(nrow(ll), nrow(ll_trunc))
 })
@@ -19,7 +19,7 @@ test_that("truncate_linelist works as expected with modified truncation_time", {
 test_that("truncate_linelist works as expected with different units", {
   ll_trunc <- truncate_linelist(
     linelist = ll,
-    truncation_time = 3,
+    truncation_day = 3,
     unit = "weeks"
   )
   expect_gt(nrow(ll), nrow(ll_trunc))
@@ -30,10 +30,10 @@ test_that("truncate_linelist works as expected with forward direction", {
   expect_gt(nrow(ll), nrow(ll_trunc))
 })
 
-test_that("truncate_linelist workds as expected with <Date> truncation_time", {
+test_that("truncate_linelist workds as expected with <Date> truncation_day", {
   ll_trunc <- truncate_linelist(
     linelist = ll,
-    truncation_time = as.Date("2023-03-01")
+    truncation_day = as.Date("2023-03-01")
   )
   expect_gt(nrow(ll), nrow(ll_trunc))
   expect_true(all(ll_trunc$date_reporting < as.Date("2023-03-01")))
@@ -47,7 +47,7 @@ test_that("truncate_linelist sets dates as NA when between events", {
     onset_to_hosp = function(x) stats::rlnorm(n = x, meanlog = 3, sdlog = 0.1),
     onset_to_death = function(x) stats::rlnorm(n = x, meanlog = 3, sdlog = 0.1)
   )
-  ll_trunc <- truncate_linelist(ll, truncation_time = 30)
+  ll_trunc <- truncate_linelist(ll, truncation_day = 30)
   # it is possible that the proportion of NAs in the truncated data is lower
   # than the complete data if by chance the hospitalised cases are removed
   # but some NAs should be introduced in truncated data in rows that are kept
@@ -57,22 +57,22 @@ test_that("truncate_linelist sets dates as NA when between events", {
   )
 })
 
-test_that("truncate_linelist warns if truncation_time is Date and unit given", {
+test_that("truncate_linelist warns if truncation_day is Date and unit given", {
   expect_warning(
     truncate_linelist(
       linelist = ll,
-      truncation_time = as.Date("2023-03-01"),
+      truncation_day = as.Date("2023-03-01"),
       unit = "weeks"
     ),
-    regexp = "(truncation_time)*(is)*(Date)*(unit)*(direction)*(are ignored)"
+    regexp = "(truncation_day)*(is)*(Date)*(unit)*(direction)*(are ignored)"
   )
   expect_warning(
     truncate_linelist(
       linelist = ll,
-      truncation_time = as.Date("2023-03-01"),
+      truncation_day = as.Date("2023-03-01"),
       direction = "forwards"
     ),
-    regexp = "(truncation_time)*(is)*(Date)*(unit)*(direction)*(are ignored)"
+    regexp = "(truncation_day)*(is)*(Date)*(unit)*(direction)*(are ignored)"
   )
 })
 
@@ -83,10 +83,10 @@ test_that("truncate_linelist fails as expected for invalid linelist", {
   )
 })
 
-test_that("truncate_linelist fails as expected for invalid truncation_time", {
+test_that("truncate_linelist fails as expected for invalid truncation_day", {
   expect_error(
-    truncate_linelist(ll, truncation_time = -1),
-    regexp = "(truncation_time)*(single positive numeric or)*(Date)"
+    truncate_linelist(ll, truncation_day = -1),
+    regexp = "(truncation_day)*(single positive numeric or)*(Date)"
   )
 })
 

--- a/tests/testthat/test-truncate_linelist.R
+++ b/tests/testthat/test-truncate_linelist.R
@@ -86,7 +86,7 @@ test_that("truncate_linelist fails as expected for invalid linelist", {
 test_that("truncate_linelist fails as expected for invalid truncation_day", {
   expect_error(
     truncate_linelist(ll, truncation_day = -1),
-    regexp = "(truncation_day)*(single positive numeric or)*(Date)"
+    regexp = "(truncation_day)*(single nonnegative numeric or)*(Date)"
   )
 })
 

--- a/tests/testthat/test-truncate_linelist.R
+++ b/tests/testthat/test-truncate_linelist.R
@@ -66,12 +66,12 @@ test_that("truncate_linelist works as expected with forward direction", {
   # truncated line list has no dates after truncation day
   trunc_date <- min_date + 14
   expect_true(
-    all(unlist(ll_trunc[, date_cols]) < (trunc_date), na.rm = TRUE)
+    all(unlist(ll_trunc[, date_cols]) < trunc_date, na.rm = TRUE)
   )
   # original line list has dates between truncation day and max date
   expect_true(
-    all(unlist(ll[, date_cols]) <= trunc_date, na.rm = TRUE) &&
-      any(unlist(ll[, date_cols]) > (trunc_date), na.rm = TRUE)
+    all(unlist(ll[, date_cols]) <= max_date, na.rm = TRUE) &&
+      any(unlist(ll[, date_cols]) > trunc_date, na.rm = TRUE)
   )
 })
 
@@ -81,7 +81,9 @@ test_that("truncate_linelist workds as expected with <Date> truncation_day", {
     truncation_day = as.Date("2023-03-01")
   )
   expect_gt(nrow(ll), nrow(ll_trunc))
-  expect_true(all(ll_trunc$date_reporting < as.Date("2023-03-01")))
+  expect_true(
+    all(unlist(ll_trunc[, date_cols]) < as.Date("2023-03-01"), na.rm = TRUE)
+  )
 })
 
 test_that("truncate_linelist sets dates as NA when between events", {

--- a/tests/testthat/test-truncate_linelist.R
+++ b/tests/testthat/test-truncate_linelist.R
@@ -60,6 +60,39 @@ test_that("truncate_linelist works as expected with different units", {
   )
 })
 
+test_that("truncate_linelist works as expected with non-integer truncation", {
+  # targetting row 90 & row 92 which are reported on 2023-03-16
+  # but differ by half a day
+  # row 90 max date minus reporting date of 30.85773
+  # row 92 max date minus reporting date of 30.20320
+
+  # both are "2023-03-16"
+  trunc_date_incl <- as.character(max_date - 30.15)
+  trunc_date_excl <- as.character(max_date - 30.5)
+  expect_identical(trunc_date_incl, trunc_date_excl)
+
+  # include both cases
+  ll_trunc_incl <- truncate_linelist(
+    linelist = ll,
+    truncation_day = 30.15
+  )
+  # exclude on case earlier on 2023-03-16 but not other half a day later
+  ll_trunc_excl <- truncate_linelist(
+    linelist = ll,
+    truncation_day = 30.5
+  )
+
+  # cases on the same day are kept or removed based on non-integer time/date
+  expect_true(ll[90, "case_name"] %in% ll_trunc_incl$case_name)
+  expect_true(ll[90, "case_name"] %in% ll_trunc_excl$case_name)
+  expect_true(ll[92, "case_name"] %in% ll_trunc_incl$case_name)
+  expect_false(ll[92, "case_name"] %in% ll_trunc_excl$case_name)
+
+  # events on 2023-03-16 still in the linelist based on non-integer truncation
+  trunc_date_incl %in% as.character(as.Date(unlist(ll_trunc_incl[, date_cols])))
+  trunc_date_excl %in% as.character(as.Date(unlist(ll_trunc_excl[, date_cols])))
+})
+
 test_that("truncate_linelist works as expected with forward direction", {
   ll_trunc <- truncate_linelist(linelist = ll, direction = "forward")
   expect_gt(nrow(ll), nrow(ll_trunc))

--- a/vignettes/reporting-delays-truncation.Rmd
+++ b/vignettes/reporting-delays-truncation.Rmd
@@ -150,7 +150,7 @@ ggplot(data = tidy_linelist) +
   theme(legend.position = "bottom", axis.text.y = element_text(size = 4))
 ```
 
-If we plot the difference between the date of symptom onset and reporting then the distribution is roughly lognormally distributed.
+If we plot the difference between the date of symptom onset and reporting then, as expected, the distribution is roughly lognormally distributed.
 
 ```{r plot-variable-reporting-delay, fig.width = 8, fig.height = 5}
 ggplot(data = linelist) +
@@ -194,31 +194,30 @@ Right-truncated outbreak data, in particular line list data, can give the impres
 
 By default {simulist} simulates an outbreak from start to finish. Therefore, the line list or contact data contain all cases and outcomes. In order to get data that is more representative of ongoing outbreak dynamics where recent cases are not yet recorded and may be revised upwards in the future the `truncate_linelist()` function can be applied.
 
-Re-simulating a simple line list using `sim_linelist()`.
+Re-simulating a simple line list using `sim_linelist()` with a lognormal reporting delay with `meanlog = 2` and `sdlog = 0.5`.
 
 ```{r, sim-linelist}
 # set seed to produce small line list
-set.seed(1)
+set.seed(3)
 linelist <- sim_linelist(
   contact_distribution = contact_distribution,
   infectious_period = infectious_period,
   prob_infection = 0.5,
   onset_to_hosp = onset_to_hosp,
-  onset_to_death = onset_to_death
+  onset_to_death = onset_to_death,
+  reporting_delay = function(x) rlnorm(n = x, meanlog = 2, sdlog = 0.5)
 )
 
 # first 6 rows of linelist
 head(linelist)
 ```
 
-### Variable truncation point (default)
-
-The right-truncation point for each individual (row) in the line list might not be equal, if for example there are regional differences in time taken to input data into a health information system. The `truncate_linelist()` function has a `delay` argument, which accepts a function that generates random numbers from which the _truncation point_ can be sampled.
+The _truncation time_ is the time/date at which we want to take a snapshot of the line list and see what it would have looked like on that day (i.e. real-time during the outbreak). By default `truncate_linelist()` will truncate from 14 days before the end of the outbreak (defined as the maximum date in the line list). 
 
 ::: {.alert .alert-primary}
 Here we define the time between the latest, or user-specified date, and the time point at which data is truncated as the _truncation point_.
 
-In the plot below we show the truncation points as a cross for each case. If the cross falls before the truncation event, in this case date of reporting, then the case is removed from the linelist, if it falls after the date of reporting but before the hospital admission and/or outcome date they are set to `NA`.
+In the plot below we show the _truncation time_ as a vertical line. If the date of reporting falls after the truncation time, then the case is removed from the line list, if it falls before the date of reporting but after the hospital admission and/or outcome date they are set to `NA`.
 
 ```{r plot-linelist-events-trunc, fig.width = 8, fig.height = 5}
 tidy_linelist <- linelist %>%
@@ -228,18 +227,8 @@ tidy_linelist <- linelist %>%
   mutate(ordering_value = ifelse(name == "date_onset", value, NA)) %>% # nolint consecutive_mutate_linter
   mutate(case_name = reorder(case_name, ordering_value, min, na.rm = TRUE)) # nolint consecutive_mutate_linter
 
-trunc_point <- data.frame(
-  case_name = linelist$case_name,
-  trunc_point = as.Date(
-    max(
-      unlist(
-        linelist[grep(pattern = "date_", x = colnames(linelist), fixed = TRUE)]
-      ),
-      na.rm = TRUE
-    ) - rlnorm(n = nrow(linelist), meanlog = 2.75, sdlog = 0.5),
-    origin = "1970-01-01"
-  )
-)
+truncation_time <- 14
+trunc_date <- max(tidy_linelist$value, na.rm = TRUE) - truncation_time
 
 ggplot(data = tidy_linelist) +
   geom_line(
@@ -255,14 +244,7 @@ ggplot(data = tidy_linelist) +
     ),
     size = 2
   ) +
-  geom_point(
-    data = trunc_point,
-    mapping = aes(
-      x = trunc_point,
-      y = case_name
-    ),
-    shape = 4
-  ) +
+  geom_vline(xintercept = trunc_date, linetype = 2) +
   scale_x_date(name = "Event date", date_breaks = "2 week") +
   scale_y_discrete(name = "Case name") +
   scale_color_brewer(
@@ -281,46 +263,28 @@ ggplot(data = tidy_linelist) +
   theme(legend.position = "bottom", axis.text.y = element_text(size = 4))
 ```
 
-In this example one case is removed (Vladmir Sanchez) and two outcome times are set to `NA` (Benito Redding and Abdul Kadar el-Diab).
+In this example several cases are removed as the reporting date occurs after the truncation time.
 :::
 
+```{r truncate-ll}
+linelist_trunc <- truncate_linelist(linelist = linelist)
+```
 
-```{r truncate-ll-with-delay}
+`truncate_linelist()` assumes the event which is pertinent to the truncation of the data is the date of reporting (`$date_reporting`), as this is likely the date the case was first input into the line list, even if this date is before the date of hospital admission (`$date_admission`) or date of outcome (`$date_outcome`).
+
+Right-truncating line list date using {simulist} removes individuals (rows) when the sampled truncation time is less recent than the reporting date. For cases where the rows are kept because the truncation time is more recent than the truncation event, but there are subsequent events, such as date of hospitalisation, that are more recent than the truncation time, these events dates are set to `NA`. The reasoning being that these events are assumed to have not been reported yet.
+
+The `truncate_linelist()` function can also be used to reflect if the reporting of cases during an outbreak stopped on a given date. 
+
+It is also possible to specify the _truncation time_ as the number of days, weeks, months or years since the start of the outbreak. Here we right-truncate the line list 3 months since the start of the outbreak.
+
+```{r truncate-ll-forward}
 linelist_trunc <- truncate_linelist(
   linelist = linelist,
-  delay = function(x) rlnorm(n = x, meanlog = 1, sdlog = 0.5)
+  truncation_time = 3,
+  unit = "months",
+  direction = "forward"
 )
-```
-
-By default `truncate_linelist()` will assume the event which is pertinent to the truncation of the data is the date of reporting (`$date_reporting`), as this is likely the date the data was input, even if this date is before the date of hospital admission (`$date_admission`) or date of outcome (`$date_outcome`). It also assumes that the date you want to sample the truncation times from is the end of the outbreak, which is defined as the latest date in any of the date columns of the line list. 
-
-Right-truncating line list date using {simulist} removes individuals (rows) when the sampled truncation time is less recent than the truncation event time (e.g. reporting date). For cases where the rows are kept because the truncation time is more recent than the truncation event, but there are subsequent events, such as date of hospitalisation, that are more recent than the truncation time, these events dates are set to `NA`. The reasoning being that these events are assumed to have not been reported yet.
-
-### Different truncation events
-
-If the date influencing the right-truncation of line list date is not the date of reporting, but instead the date of symptom onset, date of hospitalisation, or date of outcome then this can be specified in `truncate_linelist()` by setting the `truncation_event` argument. This argument accepts `"reporting"` (default), `"onset"`, `"admission"`, `"outcome"`.
-
-```{r truncate-ll-with-truncation-event}
-linelist_trunc <- truncate_linelist(
-  linelist = linelist,
-  delay = function(x) rlnorm(n = x, meanlog = 1, sdlog = 0.5),
-  truncation_event = "outcome"
-)
-```
-
-### Fixed truncation point
-
-The `delay` argument in `truncate_linelist()` is flexible to allow the use of a variety of random number generators, such as different parametric probability distributions or different distribution parameters. This enables variability in the truncation. However, it may be warranted that the truncation point is the same for all cases. This could be the case if the reporting of cases during an outbreak stopped on a given date. 
-
-To adjust the line list for right truncation using a fixed truncation point we can use the same setup as specifying a fixed `reporting_delay` as outlined above. This will remove all events more recent than this time slice. 
-
-```{r, rlnorm-zero-sd}
-delay <- function(x) rep(6, times = x)
-delay(10)
-```
-
-```{r, truncate-linelist-zero-sd}
-linelist_trunc <- truncate_linelist(linelist = linelist, delay = delay)
 ```
 
 ## Truncate to emulate different stages of outbreak
@@ -359,13 +323,12 @@ plot(weekly_inci)
 
 By looking at the outbreak, we can pick three points to truncate: 1) early in the outbreak when the epicurve is growing (1st February 2023, epiweek 5), 2) in the middle of the outbreak (15th March 2023, epiweek 11), and 3) late in the outbreak when the number of cases is declining and the end of the outbreak is near (1st May 2023, epiweek 18).
 
-We use the `max_date` argument in `truncate_linelist()` to specify the date we want to apply the right truncation to, i.e. the sample truncation times are applied to `max_date` and not the day the outbreak is considered over (day of last event, the default setting). For this example we will set the right-truncation delay distribution to zero so it does not remove any cases before the `max_date`, and use the default truncation event (reporting date).
+We can specify a `<Date>` object to the `truncation_time` argument in `truncate_linelist()` to specify the date we want to apply the right truncation to.
 
 ```{r trunc-stages, fig.width = 8, fig.height = 5, fig.show="hold", out.width="30%"}
 linelist_early <- truncate_linelist(
   linelist = linelist,
-  delay = function(x) rep(0, times = x),
-  max_date = "2023-02-01"
+  truncation_time = as.Date("2023-02-01")
 )
 inci_early <- incidence(
   x = linelist_early,
@@ -376,10 +339,10 @@ inci_early <- incidence(
 plot(inci_early) +
   ggtitle("Early") +
   theme(plot.title = element_text(size = 25, hjust = 0.5))
+
 linelist_mid <- truncate_linelist(
   linelist = linelist,
-  delay = function(x) rep(0, times = x),
-  max_date = "2023-03-15"
+  truncation_time = as.Date("2023-03-15")
 )
 inci_mid <- incidence(
   x = linelist_mid,
@@ -390,10 +353,10 @@ inci_mid <- incidence(
 plot(inci_mid) +
   ggtitle("Mid") +
   theme(plot.title = element_text(size = 25, hjust = 0.5))
+
 linelist_late <- truncate_linelist(
   linelist = linelist,
-  delay = function(x) rep(0, times = x),
-  max_date = "2023-05-01"
+  truncation_time = as.Date("2023-05-01")
 )
 inci_late <- incidence(
   x = linelist_late,
@@ -406,12 +369,26 @@ plot(inci_late) +
   theme(plot.title = element_text(size = 25, hjust = 0.5))
 ```
 
-Next we repeat this procedure of creating data sets for early, mid, and late in the outbreak. For this example we will use the default right-truncation delay distribution (lognormal with `meanlog = 0.58` and `sdlog = 0.47`) and default truncation event (reporting date).
+Next we repeat this procedure of creating data sets for early, mid, and late in the outbreak. For this example we will use a reporting delay to illustrate the issue of under-reporting of recent cases when there is a time delay between symptom onset and reporting.
+
+```{r sim-linelist-plot-incidence-reporting-delay, fig.cap="Daily incidence of cases from symptom onset including days with zero cases.", fig.width = 8, fig.height = 5}
+# set seed to produce single wave outbreak
+set.seed(3)
+linelist <- sim_linelist(
+  contact_distribution = contact_distribution,
+  infectious_period = infectious_period,
+  prob_infection = 0.5,
+  onset_to_hosp = onset_to_hosp,
+  onset_to_death = onset_to_death,
+  reporting_delay = function(x) rlnorm(n = x, meanlog = 2, sdlog = 0.5),
+  outbreak_size = c(500, 5000)
+)
+```
 
 ```{r trunc-stages-reporting-delay, fig.width = 8, fig.height = 5, fig.show="hold", out.width="30%"}
 linelist_early <- truncate_linelist(
   linelist = linelist,
-  max_date = "2023-02-01"
+  truncation_time = as.Date("2023-02-01")
 )
 inci_early <- incidence(
   x = linelist_early,
@@ -422,10 +399,10 @@ inci_early <- incidence(
 plot(inci_early) +
   ggtitle("Early") +
   theme(plot.title = element_text(size = 25, hjust = 0.5))
+
 linelist_mid <- truncate_linelist(
   linelist = linelist,
-  delay = function(x) rlnorm(n = x, meanlog = 1, sdlog = 0.5),
-  max_date = "2023-03-15"
+  truncation_time = as.Date("2023-03-15")
 )
 inci_mid <- incidence(
   x = linelist_mid,
@@ -436,10 +413,10 @@ inci_mid <- incidence(
 plot(inci_mid) +
   ggtitle("Mid") +
   theme(plot.title = element_text(size = 25, hjust = 0.5))
+
 linelist_late <- truncate_linelist(
   linelist = linelist,
-  delay = function(x) rlnorm(n = x, meanlog = 1, sdlog = 0.5),
-  max_date = "2023-05-01"
+  truncation_time = as.Date("2023-05-01")
 )
 inci_late <- incidence(
   x = linelist_late,

--- a/vignettes/reporting-delays-truncation.Rmd
+++ b/vignettes/reporting-delays-truncation.Rmd
@@ -227,8 +227,8 @@ tidy_linelist <- linelist %>%
   mutate(ordering_value = ifelse(name == "date_onset", value, NA)) %>% # nolint consecutive_mutate_linter
   mutate(case_name = reorder(case_name, ordering_value, min, na.rm = TRUE)) # nolint consecutive_mutate_linter
 
-truncation_time <- 14
-trunc_date <- max(tidy_linelist$value, na.rm = TRUE) - truncation_time
+truncation_day <- 14
+trunc_date <- max(tidy_linelist$value, na.rm = TRUE) - truncation_day
 
 ggplot(data = tidy_linelist) +
   geom_line(
@@ -281,7 +281,7 @@ It is also possible to specify the _truncation time_ as the number of days, week
 ```{r truncate-ll-forward}
 linelist_trunc <- truncate_linelist(
   linelist = linelist,
-  truncation_time = 3,
+  truncation_day = 3,
   unit = "months",
   direction = "forward"
 )
@@ -323,12 +323,12 @@ plot(weekly_inci)
 
 By looking at the outbreak, we can pick three points to truncate: 1) early in the outbreak when the epicurve is growing (1st February 2023, epiweek 5), 2) in the middle of the outbreak (15th March 2023, epiweek 11), and 3) late in the outbreak when the number of cases is declining and the end of the outbreak is near (1st May 2023, epiweek 18).
 
-We can specify a `<Date>` object to the `truncation_time` argument in `truncate_linelist()` to specify the date we want to apply the right truncation to.
+We can specify a `<Date>` object to the `truncation_day` argument in `truncate_linelist()` to specify the date we want to apply the right truncation to.
 
 ```{r trunc-stages, fig.width = 8, fig.height = 5, fig.show="hold", out.width="30%"}
 linelist_early <- truncate_linelist(
   linelist = linelist,
-  truncation_time = as.Date("2023-02-01")
+  truncation_day = as.Date("2023-02-01")
 )
 inci_early <- incidence(
   x = linelist_early,
@@ -342,7 +342,7 @@ plot(inci_early) +
 
 linelist_mid <- truncate_linelist(
   linelist = linelist,
-  truncation_time = as.Date("2023-03-15")
+  truncation_day = as.Date("2023-03-15")
 )
 inci_mid <- incidence(
   x = linelist_mid,
@@ -356,7 +356,7 @@ plot(inci_mid) +
 
 linelist_late <- truncate_linelist(
   linelist = linelist,
-  truncation_time = as.Date("2023-05-01")
+  truncation_day = as.Date("2023-05-01")
 )
 inci_late <- incidence(
   x = linelist_late,
@@ -388,7 +388,7 @@ linelist <- sim_linelist(
 ```{r trunc-stages-reporting-delay, fig.width = 8, fig.height = 5, fig.show="hold", out.width="30%"}
 linelist_early <- truncate_linelist(
   linelist = linelist,
-  truncation_time = as.Date("2023-02-01")
+  truncation_day = as.Date("2023-02-01")
 )
 inci_early <- incidence(
   x = linelist_early,
@@ -402,7 +402,7 @@ plot(inci_early) +
 
 linelist_mid <- truncate_linelist(
   linelist = linelist,
-  truncation_time = as.Date("2023-03-15")
+  truncation_day = as.Date("2023-03-15")
 )
 inci_mid <- incidence(
   x = linelist_mid,
@@ -416,7 +416,7 @@ plot(inci_mid) +
 
 linelist_late <- truncate_linelist(
   linelist = linelist,
-  truncation_time = as.Date("2023-05-01")
+  truncation_day = as.Date("2023-05-01")
 )
 inci_late <- incidence(
   x = linelist_late,


### PR DESCRIPTION
This PR addresses some comments raised in PR #179 about the functionality in `truncate_linelist()` (previously named `truncation()`) and the documentation accompanying this functionality (the `truncate_linelist()` function documentation and the  `reporting-delays-truncation.Rmd` vignette). 

After discussing this with @sbfnk, I've implemented several changes to hopefully improve and clarify the truncation functionality offered in {simulist}. 

The `truncate_linelist()` function signature has changed. It now accepts a `truncation_time` which is the number of days, weeks, months or years before the end of the outbreak, or since the start of the outbreak. This backwards or forwards approach is controlled by the `direction` argument. The time unit is controlled by the `unit` argument. The `truncation_time` can also accept a `<Data>` object.

Some of the confusion from the previous implementation stemmed from the ability to generate a random reporting delay for each case both at the simulation stage (`sim_linelist()`), but also at the truncation stage (`truncate_linelist()`). This has been updated to only allow reporting delays to be generated during the simulation. 

The `reporting-delays-truncation.Rmd` vignette is updated to use the new function signature. Unit tests for `truncate_linelist()` are also updated. 



