### PR TITLE
Add note to `design-principles.Rmd` on changing output between versions

### DIFF
--- a/vignettes/design-principles.Rmd
+++ b/vignettes/design-principles.Rmd
@@ -26,6 +26,8 @@ The {simulist} package aims to simulate data on infectious disease outbreaks, pr
 
 The simulation functions either return a `<data.frame>` or a `list` of `<data.frame>`s. This consistency across functions of a well-known data structure makes it easy to understand for users.
 
+Before the first stable release (v1.0.0) of {simulist} we cannot guarantee that two versions of the package will produce identical output when using the same function with the same seed (i.e. _output breaking change_ as opposed to _API breaking change_). Given the many random number generation calls in the simulation code, it is too constraining to ensure reproducibility of function output between versions. We aim to ensure consistent and reproducible output from `sim_*()` functions between minor version releases after v1.0.0.
+
 ## Package architecture
 
  <img src="../man/figures/simulist_archi.png" width="700" />


### PR DESCRIPTION
This PR addresses #204 by adding a note to the `design-principles.Rmd` vignette on the breaking changes to the output of the `sim_*()` functions prior to the v1.0.0 release.