### PR TITLE
Update package infrastructure for v0.5.0 release

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -54,6 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          # Test with the 3 R versions and the 3 platforms from CRAN checks
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -72,13 +72,13 @@ jobs:
         shell: Rscript {0}
 
       - name: Check website links
-        uses: untitaker/hyperlink@0.1.32
+        uses: untitaker/hyperlink@0.1.44
         with:
           args: docs/
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'merge_group' && github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.6.8
+        uses: JamesIves/github-pages-deploy-action@v4.7.3
         with:
           # We clean on releases because we want to remove old vignettes,
           # figures, etc. that have been deleted from the `main` branch.

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -62,11 +62,11 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
-          file: ./cobertura.xml
-          plugin: noop
+          files: ./cobertura.xml
+          plugins: noop
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.lintr
+++ b/.lintr
@@ -1,8 +1,8 @@
 linters: all_linters(
     packages = c("lintr", "etdev"),
+    pipe_consistency_linter(pipe = "%>%"),
     object_name_linter = NULL,
     implicit_integer_linter = NULL,
-    extraction_operator_linter = NULL,
     todo_comment_linter = NULL,
     library_call_linter = NULL,
     undesirable_function_linter(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,9 @@ Authors@R: c(
     person("Adam", "Kucharski", , "adam.kucharski@lshtm.ac.uk", role = "rev",
            comment = c(ORCID = "0000-0001-8814-9421")),
     person("Chris", "Hartgerink", , "chris@data.org", role = "rev",
-           comment = c(ORCID = "0000-0003-1050-6809"))
+           comment = c(ORCID = "0000-0003-1050-6809")),
+    person("London School of Hygiene and Tropical Medicine, LSHTM", role = "cph",
+           comment = c(ROR = "00a0jsq62")),
   )
 Description: Tools to simulate realistic raw case data for an epidemic in
     the form of line lists and contacts using a branching process.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Authors@R: c(
     person("Chris", "Hartgerink", , "chris@data.org", role = "rev",
            comment = c(ORCID = "0000-0003-1050-6809")),
     person("London School of Hygiene and Tropical Medicine, LSHTM", role = "cph",
-           comment = c(ROR = "00a0jsq62")),
+           comment = c(ROR = "00a0jsq62"))
   )
 Description: Tools to simulate realistic raw case data for an epidemic in
     the form of line lists and contacts using a branching process.

--- a/R/dev-utils.R
+++ b/R/dev-utils.R
@@ -5,6 +5,10 @@ release_bullets <- function() { # nocov start
     "Run `goodpractice::gp()`",
     "Review [WORDLIST](https://docs.cran.dev/spelling#wordlist)",
     "Check if `# nolint` comments are still needed with recent lintr releases",
+    paste(
+      "Check if", file.path("man", "figures", "simulist_archi.png"),
+      "needs updating"
+    ),
     "All contributors to this release are acknowledged in some way"
   )
 } # nocov end

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -42,6 +42,7 @@ infectee
 infector
 integerish
 io
+jsq
 Kadar
 knitr
 Kobo
@@ -50,6 +51,7 @@ linelist
 lintr
 LLsim
 lognormally
+LSHTM
 Lusseau
 Mancini
 md

--- a/man/simulist-package.Rd
+++ b/man/simulist-package.Rd
@@ -31,6 +31,7 @@ Other contributors:
   \item Pratik R. Gupte \email{pratik.gupte@lshtm.ac.uk} (\href{https://orcid.org/0000-0001-5294-7819}{ORCID}) [contributor, reviewer]
   \item Adam Kucharski \email{adam.kucharski@lshtm.ac.uk} (\href{https://orcid.org/0000-0001-8814-9421}{ORCID}) [reviewer]
   \item Chris Hartgerink \email{chris@data.org} (\href{https://orcid.org/0000-0003-1050-6809}{ORCID}) [reviewer]
+  \item London School of Hygiene and Tropical Medicine, LSHTM (00a0jsq62) [copyright holder]
 }
 
 }

--- a/tests/testthat/helper-state.R
+++ b/tests/testthat/helper-state.R
@@ -5,6 +5,15 @@
 # function, or more conveniently with the `withr` package.
 # We add a test on R >= 4.0.0 because some functions such as
 # `globalCallingHandlers()` did not exist before.
+get_pars_toreset <- function() {
+  pars <- par(no.readonly = TRUE)
+  # The following params are set and modified automatically by plot(), as
+  # documented in ?plot.window() and we:
+  # 1. have no control over them
+  # 2. do not care about resetting them
+  pars <- pars[!names(pars) %in% c("usr", "xaxp", "yaxp")]
+}
+
 if (getRversion() >= "4.0.0") {
   testthat::set_state_inspector(function() {
     list(
@@ -16,7 +25,7 @@ if (getRversion() >= "4.0.0") {
       libpaths    = .libPaths(),
       locale      = Sys.getlocale(),
       options     = options(),
-      par         = par(),
+      par         = get_pars_toreset(),
       packages    = .packages(all.available = TRUE),
       sink        = sink.number(),
       timezone    = Sys.timezone(),


### PR DESCRIPTION
This PR makes several miscellaneous infrastructure updates to keep the package up-to-date. These include:

* Updating the actions versions called in `pkgdown.yaml` and `test-coverage.yaml`
* Remove deprecated `extraction_operator_linter` from `.lintr` file and added `pipe_consistency_linter(pipe = "%>%")`
* Added LSHTM has package `cph` to `DESCRIPTION`
* Added reminder to `release_bullets()` for updating package architecture diagram in `design-principles.Rmd` vignette
* Added `get_pars_toreset()` to `helper-state.R` to remove checking global parameters that are changed by base R