### PR TITLE
Ensure `truncate_linelist()` is "compa-tibble" 

### DIFF
--- a/R/truncate_linelist.R
+++ b/R/truncate_linelist.R
@@ -71,6 +71,7 @@ truncate_linelist <- function(linelist,
                               direction = c("backwards", "forwards")) {
   arg_ignore <- missing(unit) && missing(direction)
   .check_linelist(linelist)
+  linelist <- .as_df(linelist)
   stopifnot(
     "`truncation_day` must be a single nonnegative numeric or <Date> object." =
       checkmate::test_number(truncation_day, lower = 0, finite = TRUE) ||
@@ -131,5 +132,6 @@ truncate_linelist <- function(linelist,
   }
 
   row.names(linelist) <- NULL
+  linelist <- .restore_df_subclass(linelist)
   linelist
 }


### PR DESCRIPTION
This PR adds `.as_df()` and `.restore_df_subclass()` in `truncate_linelist()`, in the same way they are called in `messy_linelist()`, to ensure that the line list post-processing functions are compatible with `<tibble>`s as well as `<data.frame>` input., and in theory other `<data.frame>` subclasses.

There was no issue prior to this PR with calling `truncate_linelist()` on a `<tibble>`, but this PR should help future development to not be caught out by differences in default behaviour between `<data.frame>` functions/methods and `<data.frame>` subclasses.