### PR TITLE
Add alt text to vignette figures

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Suggests:
     dplyr,
     epicontacts (>= 1.1.3),
     ggplot2,
-    incidence2 (>= 2.1.0),
+    incidence2 (>= 2.3.0),
     knitr,
     rmarkdown,
     spelling,

--- a/vignettes/age-struct-pop.Rmd
+++ b/vignettes/age-struct-pop.Rmd
@@ -10,7 +10,9 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  fig.width = 8,
+  fig.height = 5
 )
 ```
 
@@ -95,7 +97,7 @@ head(linelist)
 
 We can plot the age distribution for individuals in the line list, binned into 5 year categories.
 
-```{r plot-age-range, fig.width = 8, fig.height = 5}
+```{r plot-age-range}
 #| fig.alt: >
 #|   A histogram for the age distribution of individuals in a simulated line
 #|   list sampled from a uniform distribution between 5 and 75. Ages are binned
@@ -152,7 +154,7 @@ head(linelist)
 
 Again we can plot the age distribution to see the age structure for individuals in the line list. Given the relative uniformity of the age structure specified it is not greatly different from the uniform age structure plotted above, other than having a higher upper age limit. The data is binned into 5 year categories and facetted by sex.
 
-```{r plot-age-struct, fig.width = 8, fig.height = 5}
+```{r plot-age-struct}
 #| fig.alt: >
 #|   Two histograms, facetted by sex, for the age distribution of individuals
 #|   in a simulated line list sampled from an age-structured population defined
@@ -203,7 +205,7 @@ head(linelist)
 ```
 A common and useful method for plotting age data is in the form of age pyramids. Here we partition the data by sex and plot the age distribution.
 
-```{r plot-age-struct-young, fig.width = 8, fig.height = 5}
+```{r plot-age-struct-young}
 linelist_m <- subset(linelist, subset = sex == "m")
 age_cats_m <- as.data.frame(table(floor(linelist_m$age / 5) * 5))
 colnames(age_cats_m) <- c("AgeCat", "Population")

--- a/vignettes/age-struct-pop.Rmd
+++ b/vignettes/age-struct-pop.Rmd
@@ -95,7 +95,13 @@ head(linelist)
 
 We can plot the age distribution for individuals in the line list, binned into 5 year categories.
 
-```{r plot-age-range, fig.cap="Age distribution of individuals in a simulated line list sampled from a uniform distribution between 5 and 75.", fig.width = 8, fig.height = 5}
+```{r plot-age-range, fig.width = 8, fig.height = 5}
+#| fig.alt: >
+#|   A histogram for the age distribution of individuals in a simulated line
+#|   list sampled from a uniform distribution between 5 and 75. Ages are binned
+#|   into 5 year age groups. There is a small amount of variation in counts
+#|   of individuals in each group. The y-axis is labelled "Number of 
+#|   Individuals", and the x-axis is labelled "Age".
 ggplot(linelist[, c("sex", "age")]) +
   geom_histogram(
     mapping = aes(x = age),
@@ -146,7 +152,14 @@ head(linelist)
 
 Again we can plot the age distribution to see the age structure for individuals in the line list. Given the relative uniformity of the age structure specified it is not greatly different from the uniform age structure plotted above, other than having a higher upper age limit. The data is binned into 5 year categories and facetted by sex.
 
-```{r plot-age-struct, fig.cap="Age distribution of line list cases facetted by sex", fig.width = 8, fig.height = 5}
+```{r plot-age-struct, fig.width = 8, fig.height = 5}
+#| fig.alt: >
+#|   Two histograms, facetted by sex, for the age distribution of individuals
+#|   in a simulated line list sampled from an age-structured population defined
+#|   in the data.frame above. Ages are binned into 5 year age groups. There is
+#|   variation in counts of individuals in each group, and the histograms 
+#|   between male (m) and female (f) are similar. The y-axis is labelled 
+#|   "Number of Individuals", and the x-axis is labelled "Age".
 ggplot(linelist[, c("sex", "age")]) +
   geom_histogram(
     mapping = aes(x = age),
@@ -190,7 +203,7 @@ head(linelist)
 ```
 A common and useful method for plotting age data is in the form of age pyramids. Here we partition the data by sex and plot the age distribution.
 
-```{r plot-age-struct-young, fig.cap="Age pyramid for a simulated line list with an age-structured population.", fig.width = 8, fig.height = 5}
+```{r plot-age-struct-young, fig.width = 8, fig.height = 5}
 linelist_m <- subset(linelist, subset = sex == "m")
 age_cats_m <- as.data.frame(table(floor(linelist_m$age / 5) * 5))
 colnames(age_cats_m) <- c("AgeCat", "Population")
@@ -205,6 +218,15 @@ age_cats <- rbind(age_cats_m, age_cats_f)
 breaks <- pretty(range(age_cats$Population), n = 10)
 labels <- abs(breaks)
 
+#| fig.alt: >
+#|   An age pyramid for a simulated line list with an age-structured population.
+#|   The y-axis is labeled "Lower bound of Age Category", the x-axis is labelled
+#|   "Population". The left of the age pyramid plots the number of female 
+#|   individuals (red) in each age category and the right of the age pyramid
+#|   plots the number of male individuals (blue) in each age category. The age
+#|   pyramid shows many young people in the population, aged below 10, and
+#|   relatively fewer older individuals. The pattern between male and female is
+#|   similar.
 ggplot(age_cats) +
   geom_col(mapping = aes(x = Population, y = factor(AgeCat), fill = sex)) +
   scale_y_discrete(name = "Lower bound of Age Category") +

--- a/vignettes/age-struct-pop.Rmd
+++ b/vignettes/age-struct-pop.Rmd
@@ -102,7 +102,7 @@ We can plot the age distribution for individuals in the line list, binned into 5
 #|   A histogram for the age distribution of individuals in a simulated line
 #|   list sampled from a uniform distribution between 5 and 75. Ages are binned
 #|   into 5 year age groups. There is a small amount of variation in counts
-#|   of individuals in each group. The y-axis is labelled "Number of 
+#|   of individuals in each group. The y-axis is labelled "Number of
 #|   Individuals", and the x-axis is labelled "Age".
 ggplot(linelist[, c("sex", "age")]) +
   geom_histogram(
@@ -159,8 +159,8 @@ Again we can plot the age distribution to see the age structure for individuals 
 #|   Two histograms, facetted by sex, for the age distribution of individuals
 #|   in a simulated line list sampled from an age-structured population defined
 #|   in the data.frame above. Ages are binned into 5 year age groups. There is
-#|   variation in counts of individuals in each group, and the histograms 
-#|   between male (m) and female (f) are similar. The y-axis is labelled 
+#|   variation in counts of individuals in each group, and the histograms
+#|   between male (m) and female (f) are similar. The y-axis is labelled
 #|   "Number of Individuals", and the x-axis is labelled "Age".
 ggplot(linelist[, c("sex", "age")]) +
   geom_histogram(
@@ -205,7 +205,7 @@ head(linelist)
 ```
 A common and useful method for plotting age data is in the form of age pyramids. Here we partition the data by sex and plot the age distribution.
 
-```{r plot-age-struct-young}
+```{r prep-age-struct-young}
 linelist_m <- subset(linelist, subset = sex == "m")
 age_cats_m <- as.data.frame(table(floor(linelist_m$age / 5) * 5))
 colnames(age_cats_m) <- c("AgeCat", "Population")
@@ -219,11 +219,13 @@ age_cats <- rbind(age_cats_m, age_cats_f)
 
 breaks <- pretty(range(age_cats$Population), n = 10)
 labels <- abs(breaks)
+```
 
+```{r, plot-age-struct-young}
 #| fig.alt: >
 #|   An age pyramid for a simulated line list with an age-structured population.
 #|   The y-axis is labeled "Lower bound of Age Category", the x-axis is labelled
-#|   "Population". The left of the age pyramid plots the number of female 
+#|   "Population". The left of the age pyramid plots the number of female
 #|   individuals (red) in each age category and the right of the age pyramid
 #|   plots the number of male individuals (blue) in each age category. The age
 #|   pyramid shows many young people in the population, aged below 10, and

--- a/vignettes/design-principles.Rmd
+++ b/vignettes/design-principles.Rmd
@@ -72,7 +72,7 @@ The aim is to restrict the number of dependencies to a minimal required set for 
 
 The soft dependencies (and their minimum version requirements) are:
 
-* [{incidence2}](https://CRAN.R-project.org/package=incidence2) (>= 2.1.0)
+* [{incidence2}](https://CRAN.R-project.org/package=incidence2) (>= 2.3.0)
 * [{epicontacts}](https://CRAN.R-project.org/package=epicontacts) (>= 1.1.3)
 * [{knitr}](https://CRAN.R-project.org/package=knitr)
 * [{ggplot2}](https://CRAN.R-project.org/package=ggplot2)

--- a/vignettes/reporting-delays-truncation.Rmd
+++ b/vignettes/reporting-delays-truncation.Rmd
@@ -326,7 +326,7 @@ We can simulate another outbreak, this time with more cases, and plot the comple
 For a full overview of how to visualise outbreak data simulated with {simulist} see the [Visualising simulated data](vis-linelist.html) vignette.
 :::
 
-```{r sim-linelist-plot-incidence, fig.cap="Weekly incidence of cases from symptom onset.", fig.width = 8, fig.height = 5}
+```{r sim-linelist-plot-incidence, fig.width = 8, fig.height = 5}
 # set seed to produce single wave outbreak
 set.seed(3)
 linelist <- sim_linelist(
@@ -345,10 +345,12 @@ weekly_inci <- incidence(
   interval = "epiweek",
   complete_dates = TRUE
 )
+
 #| fig.alt: >
-#|   An incidence curve (epicurve) of cases aggregated by week. The y-axis is
-#|   the count, the x-axis is the date index. The weekly incidence increases
-#|   from week 1 to week 6, then it gradually declines.
+#|   An incidence curve (epicurve) of cases from symptom onset aggregated by 
+#|   week. The y-axis is the count, the x-axis is the date index. The 
+#|   weekly incidence increases from week 1 to week 6, then it gradually 
+#|   declines.
 plot(weekly_inci)
 ```
 
@@ -393,7 +395,7 @@ inci_late <- incidence(
 
 Next we repeat this procedure of creating data sets for early, mid, and late in the outbreak. For this example we will use a reporting delay to illustrate the issue of under-reporting of recent cases when there is a time delay between symptom onset and reporting.
 
-```{r sim-linelist-plot-incidence-reporting-delay, fig.cap="Daily incidence of cases from symptom onset including days with zero cases.", fig.width = 8, fig.height = 5}
+```{r sim-linelist-plot-incidence-reporting-delay, fig.width = 8, fig.height = 5}
 # set seed to produce single wave outbreak
 set.seed(3)
 linelist <- sim_linelist(

--- a/vignettes/reporting-delays-truncation.Rmd
+++ b/vignettes/reporting-delays-truncation.Rmd
@@ -112,6 +112,16 @@ head(linelist)
 Here from the first 6 rows of the line list you can see differences between the `$date_onset` column and the `$date_reporting` column. 
 
 ```{r plot-linelist-events, fig.width = 8, fig.height = 5}
+#| fig.alt: >
+#|   A dot plot with the event dates in the line list plotted a points on the 
+#|   figure, connected by horizontal lines. One row in the dot plot corresponds
+#|   to one case (i.e. one row in the line list). The y-axis label is 
+#|   "Case name", and the x-axis label is "Event date". The event types are
+#|   "Date admission" (red square), "Date Onset" (blue circle), "Date Outcome"
+#|   (green triangle), and "Date Reporting" (purple diamond). The plot shows
+#|   the distribution of delay times between each event for each individual in
+#|   the line list, with the y-axis order by earliest date of symptom onset at
+#|   the bottom.
 tidy_linelist <- linelist %>%
   pivot_longer(
     cols = c("date_onset", "date_reporting", "date_admission", "date_outcome")
@@ -153,6 +163,12 @@ ggplot(data = tidy_linelist) +
 If we plot the difference between the date of symptom onset and reporting then, as expected, the distribution is roughly lognormally distributed.
 
 ```{r plot-variable-reporting-delay, fig.width = 8, fig.height = 5}
+#| fig.alt: >
+#|   The distribution of reporting delays from a line list plotted as a 
+#|   histogram. The y-axis is the count, and the x-axis is the reporting delay
+#|   in days. Most of the histogram weight is around 5 and there a tail to the
+#|   distribution (left-skewed) with a small number of values above 40. The 
+#|   histogram looks approximately lognormally distributed.
 ggplot(data = linelist) +
   geom_histogram(
     mapping = aes(x = as.numeric(date_reporting - date_onset)),
@@ -230,6 +246,17 @@ tidy_linelist <- linelist %>%
 truncation_day <- 14
 trunc_date <- max(tidy_linelist$value, na.rm = TRUE) - truncation_day
 
+#| fig.alt: >
+#|   A dot plot with the event dates in the line list plotted a points on the 
+#|   figure, connected by horizontal lines. One row in the dot plot corresponds
+#|   to one case (i.e. one row in the line list). The y-axis label is 
+#|   "Case name", and the x-axis label is "Event date". The event types are
+#|   "Date admission" (red square), "Date Onset" (blue circle), "Date Outcome"
+#|   (green triangle), and "Date Reporting" (purple diamond). The plot shows
+#|   the distribution of delay times between each event for each individual in
+#|   the line list, with the y-axis order by earliest date of symptom onset at
+#|   the bottom. There is a vertical dashed line showing when the truncation day
+#|   is.
 ggplot(data = tidy_linelist) +
   geom_line(
     mapping = aes(x = value, y = case_name),
@@ -299,7 +326,7 @@ We can simulate another outbreak, this time with more cases, and plot the comple
 For a full overview of how to visualise outbreak data simulated with {simulist} see the [Visualising simulated data](vis-linelist.html) vignette.
 :::
 
-```{r sim-linelist-plot-incidence, fig.cap="Daily incidence of cases from symptom onset including days with zero cases.", fig.width = 8, fig.height = 5}
+```{r sim-linelist-plot-incidence, fig.cap="Weekly incidence of cases from symptom onset.", fig.width = 8, fig.height = 5}
 # set seed to produce single wave outbreak
 set.seed(3)
 linelist <- sim_linelist(
@@ -318,6 +345,10 @@ weekly_inci <- incidence(
   interval = "epiweek",
   complete_dates = TRUE
 )
+#| fig.alt: >
+#|   An incidence curve (epicurve) of cases aggregated by week. The y-axis is
+#|   the count, the x-axis is the date index. The weekly incidence increases
+#|   from week 1 to week 6, then it gradually declines.
 plot(weekly_inci)
 ```
 
@@ -325,7 +356,7 @@ By looking at the outbreak, we can pick three points to truncate: 1) early in th
 
 We can specify a `<Date>` object to the `truncation_day` argument in `truncate_linelist()` to specify the date we want to apply the right truncation to.
 
-```{r trunc-stages, fig.width = 8, fig.height = 5, fig.show="hold", out.width="30%"}
+```{r trunc-stages}
 linelist_early <- truncate_linelist(
   linelist = linelist,
   truncation_day = as.Date("2023-02-01")
@@ -336,9 +367,6 @@ inci_early <- incidence(
   interval = "epiweek",
   complete_dates = TRUE
 )
-plot(inci_early) +
-  ggtitle("Early") +
-  theme(plot.title = element_text(size = 25, hjust = 0.5))
 
 linelist_mid <- truncate_linelist(
   linelist = linelist,
@@ -350,9 +378,6 @@ inci_mid <- incidence(
   interval = "epiweek",
   complete_dates = TRUE
 )
-plot(inci_mid) +
-  ggtitle("Mid") +
-  theme(plot.title = element_text(size = 25, hjust = 0.5))
 
 linelist_late <- truncate_linelist(
   linelist = linelist,
@@ -364,9 +389,6 @@ inci_late <- incidence(
   interval = "epiweek",
   complete_dates = TRUE
 )
-plot(inci_late) +
-  ggtitle("Late") +
-  theme(plot.title = element_text(size = 25, hjust = 0.5))
 ```
 
 Next we repeat this procedure of creating data sets for early, mid, and late in the outbreak. For this example we will use a reporting delay to illustrate the issue of under-reporting of recent cases when there is a time delay between symptom onset and reporting.
@@ -396,9 +418,6 @@ inci_early <- incidence(
   interval = "epiweek",
   complete_dates = TRUE
 )
-plot(inci_early) +
-  ggtitle("Early") +
-  theme(plot.title = element_text(size = 25, hjust = 0.5))
 
 linelist_mid <- truncate_linelist(
   linelist = linelist,
@@ -410,9 +429,6 @@ inci_mid <- incidence(
   interval = "epiweek",
   complete_dates = TRUE
 )
-plot(inci_mid) +
-  ggtitle("Mid") +
-  theme(plot.title = element_text(size = 25, hjust = 0.5))
 
 linelist_late <- truncate_linelist(
   linelist = linelist,
@@ -424,6 +440,22 @@ inci_late <- incidence(
   interval = "epiweek",
   complete_dates = TRUE
 )
+```
+
+```{r plot-trunc-stages-reporting-delay, fig.width = 8, fig.height = 5, fig.show="hold", out.width="30%"}
+#| fig.alt: >
+#|   Three incidence curves (epicurves) in a single row, the left plot is the 
+#|   outbreak snapshot early in the outbreak, the middle plot is the outbreak
+#|   and the right plot is the end of the outbreak. The cases are aggregated 
+#|   by week. The y-axis is the count, the x-axis is the date index. This plot
+#|   shows fewer cases in the days before the truncation day due to 
+#|   right-truncation of the reporting delay.
+plot(inci_early) +
+  ggtitle("Early") +
+  theme(plot.title = element_text(size = 25, hjust = 0.5))
+plot(inci_mid) +
+  ggtitle("Mid") +
+  theme(plot.title = element_text(size = 25, hjust = 0.5))
 plot(inci_late) +
   ggtitle("Late") +
   theme(plot.title = element_text(size = 25, hjust = 0.5))

--- a/vignettes/reporting-delays-truncation.Rmd
+++ b/vignettes/reporting-delays-truncation.Rmd
@@ -115,9 +115,9 @@ Here from the first 6 rows of the line list you can see differences between the 
 
 ```{r plot-linelist-events}
 #| fig.alt: >
-#|   A dot plot with the event dates in the line list plotted a points on the 
+#|   A dot plot with the event dates in the line list plotted a points on the
 #|   figure, connected by horizontal lines. One row in the dot plot corresponds
-#|   to one case (i.e. one row in the line list). The y-axis label is 
+#|   to one case (i.e. one row in the line list). The y-axis label is
 #|   "Case name", and the x-axis label is "Event date". The event types are
 #|   "Date admission" (red square), "Date Onset" (blue circle), "Date Outcome"
 #|   (green triangle), and "Date Reporting" (purple diamond). The plot shows
@@ -166,10 +166,10 @@ If we plot the difference between the date of symptom onset and reporting then, 
 
 ```{r plot-variable-reporting-delay}
 #| fig.alt: >
-#|   The distribution of reporting delays from a line list plotted as a 
+#|   The distribution of reporting delays from a line list plotted as a
 #|   histogram. The y-axis is the count, and the x-axis is the reporting delay
 #|   in days. Most of the histogram weight is around 5 and there a tail to the
-#|   distribution (left-skewed) with a small number of values above 40. The 
+#|   distribution (left-skewed) with a small number of values above 40. The
 #|   histogram looks approximately lognormally distributed.
 ggplot(data = linelist) +
   geom_histogram(
@@ -237,7 +237,7 @@ Here we define the time between the latest, or user-specified date, and the time
 
 In the plot below we show the _truncation time_ as a vertical line. If the date of reporting falls after the truncation time, then the case is removed from the line list, if it falls before the date of reporting but after the hospital admission and/or outcome date they are set to `NA`.
 
-```{r plot-linelist-events-trunc}
+```{r prep-linelist-events-trunc}
 tidy_linelist <- linelist %>%
   pivot_longer(
     cols = c("date_onset", "date_reporting", "date_admission", "date_outcome")
@@ -247,11 +247,13 @@ tidy_linelist <- linelist %>%
 
 truncation_day <- 14
 trunc_date <- max(tidy_linelist$value, na.rm = TRUE) - truncation_day
+```
 
+```{r plot-linelist-events-trunc}
 #| fig.alt: >
-#|   A dot plot with the event dates in the line list plotted a points on the 
+#|   A dot plot with the event dates in the line list plotted a points on the
 #|   figure, connected by horizontal lines. One row in the dot plot corresponds
-#|   to one case (i.e. one row in the line list). The y-axis label is 
+#|   to one case (i.e. one row in the line list). The y-axis label is
 #|   "Case name", and the x-axis label is "Event date". The event types are
 #|   "Date admission" (red square), "Date Onset" (blue circle), "Date Outcome"
 #|   (green triangle), and "Date Reporting" (purple diamond). The plot shows
@@ -328,7 +330,7 @@ We can simulate another outbreak, this time with more cases, and plot the comple
 For a full overview of how to visualise outbreak data simulated with {simulist} see the [Visualising simulated data](vis-linelist.html) vignette.
 :::
 
-```{r sim-linelist-plot-incidence}
+```{r sim-linelist-incidence}
 # set seed to produce single wave outbreak
 set.seed(3)
 linelist <- sim_linelist(
@@ -347,11 +349,13 @@ weekly_inci <- incidence(
   interval = "epiweek",
   complete_dates = TRUE
 )
+```
 
+```{r sim-linelist-plot-incidence}
 #| fig.alt: >
-#|   An incidence curve (epicurve) of cases from symptom onset aggregated by 
-#|   week. The y-axis is the count, the x-axis is the date index. The 
-#|   weekly incidence increases from week 1 to week 6, then it gradually 
+#|   An incidence curve (epicurve) of cases from symptom onset aggregated by
+#|   week. The y-axis is the count, the x-axis is the date index. The
+#|   weekly incidence increases from week 1 to week 6, then it gradually
 #|   declines.
 plot(weekly_inci)
 ```
@@ -448,11 +452,11 @@ inci_late <- incidence(
 
 ```{r plot-trunc-stages-reporting-delay, fig.show="hold", out.width="30%"}
 #| fig.alt: >
-#|   Three incidence curves (epicurves) in a single row, the left plot is the 
+#|   Three incidence curves (epicurves) in a single row, the left plot is the
 #|   outbreak snapshot early in the outbreak, the middle plot is the outbreak
-#|   and the right plot is the end of the outbreak. The cases are aggregated 
+#|   and the right plot is the end of the outbreak. The cases are aggregated
 #|   by week. The y-axis is the count, the x-axis is the date index. This plot
-#|   shows fewer cases in the days before the truncation day due to 
+#|   shows fewer cases in the days before the truncation day due to
 #|   right-truncation of the reporting delay.
 plot(inci_early) +
   ggtitle("Early") +

--- a/vignettes/reporting-delays-truncation.Rmd
+++ b/vignettes/reporting-delays-truncation.Rmd
@@ -10,7 +10,9 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  fig.width = 8,
+  fig.height = 5
 )
 ```
 
@@ -111,7 +113,7 @@ head(linelist)
 
 Here from the first 6 rows of the line list you can see differences between the `$date_onset` column and the `$date_reporting` column. 
 
-```{r plot-linelist-events, fig.width = 8, fig.height = 5}
+```{r plot-linelist-events}
 #| fig.alt: >
 #|   A dot plot with the event dates in the line list plotted a points on the 
 #|   figure, connected by horizontal lines. One row in the dot plot corresponds
@@ -162,7 +164,7 @@ ggplot(data = tidy_linelist) +
 
 If we plot the difference between the date of symptom onset and reporting then, as expected, the distribution is roughly lognormally distributed.
 
-```{r plot-variable-reporting-delay, fig.width = 8, fig.height = 5}
+```{r plot-variable-reporting-delay}
 #| fig.alt: >
 #|   The distribution of reporting delays from a line list plotted as a 
 #|   histogram. The y-axis is the count, and the x-axis is the reporting delay
@@ -235,7 +237,7 @@ Here we define the time between the latest, or user-specified date, and the time
 
 In the plot below we show the _truncation time_ as a vertical line. If the date of reporting falls after the truncation time, then the case is removed from the line list, if it falls before the date of reporting but after the hospital admission and/or outcome date they are set to `NA`.
 
-```{r plot-linelist-events-trunc, fig.width = 8, fig.height = 5}
+```{r plot-linelist-events-trunc}
 tidy_linelist <- linelist %>%
   pivot_longer(
     cols = c("date_onset", "date_reporting", "date_admission", "date_outcome")
@@ -326,7 +328,7 @@ We can simulate another outbreak, this time with more cases, and plot the comple
 For a full overview of how to visualise outbreak data simulated with {simulist} see the [Visualising simulated data](vis-linelist.html) vignette.
 :::
 
-```{r sim-linelist-plot-incidence, fig.width = 8, fig.height = 5}
+```{r sim-linelist-plot-incidence}
 # set seed to produce single wave outbreak
 set.seed(3)
 linelist <- sim_linelist(
@@ -395,7 +397,7 @@ inci_late <- incidence(
 
 Next we repeat this procedure of creating data sets for early, mid, and late in the outbreak. For this example we will use a reporting delay to illustrate the issue of under-reporting of recent cases when there is a time delay between symptom onset and reporting.
 
-```{r sim-linelist-plot-incidence-reporting-delay, fig.width = 8, fig.height = 5}
+```{r sim-linelist-plot-incidence-reporting-delay}
 # set seed to produce single wave outbreak
 set.seed(3)
 linelist <- sim_linelist(
@@ -409,7 +411,7 @@ linelist <- sim_linelist(
 )
 ```
 
-```{r trunc-stages-reporting-delay, fig.width = 8, fig.height = 5, fig.show="hold", out.width="30%"}
+```{r trunc-stages-reporting-delay, fig.show="hold", out.width="30%"}
 linelist_early <- truncate_linelist(
   linelist = linelist,
   truncation_day = as.Date("2023-02-01")
@@ -444,7 +446,7 @@ inci_late <- incidence(
 )
 ```
 
-```{r plot-trunc-stages-reporting-delay, fig.width = 8, fig.height = 5, fig.show="hold", out.width="30%"}
+```{r plot-trunc-stages-reporting-delay, fig.show="hold", out.width="30%"}
 #| fig.alt: >
 #|   Three incidence curves (epicurves) in a single row, the left plot is the 
 #|   outbreak snapshot early in the outbreak, the middle plot is the outbreak

--- a/vignettes/time-varying-cfr.Rmd
+++ b/vignettes/time-varying-cfr.Rmd
@@ -144,12 +144,12 @@ linelist <- linelist %>%
 
 ```{r, plot-onset-hospitalisation}
 #| fig.alt: >
-#|   Two histograms in a single column, showing the daily incidence of cases 
-#|   from symptom onset and incidence of deaths. Case fatality risk for 
-#|   hospitalised individuals is 0.5 and the risk of non-hospitalised 
+#|   Two histograms in a single column, showing the daily incidence of cases
+#|   from symptom onset and incidence of deaths. Case fatality risk for
+#|   hospitalised individuals is 0.5 and the risk of non-hospitalised
 #|   individuals is 0.05, and these risks are constant through time. The
 #|   y-axis is labelled "count" and the x-axis is labelled "date_index". The
-#|   plot shows fluctuating number of cases over time with substantially 
+#|   plot shows fluctuating number of cases over time with substantially
 #|   fewer deaths than cases.
 daily <- incidence(
   linelist,
@@ -195,7 +195,7 @@ linelist <- linelist %>%
   )
 ```
 
-```{r, plot-onset-death-higher-risk}
+```{r, prep-onset-death-higher-risk}
 daily <- incidence(
   linelist,
   date_index = c(
@@ -205,14 +205,16 @@ daily <- incidence(
   interval = "daily"
 )
 daily <- complete_dates(daily)
+```
 
+```{r plot-onset-death-higher-risk}
 #| fig.alt: >
-#|   Two histograms in a single column, showing the daily incidence of cases 
-#|   from symptom onset and incidence of deaths. Case fatality risk for 
-#|   hospitalised individuals is 0.9 and the risk of non-hospitalised 
+#|   Two histograms in a single column, showing the daily incidence of cases
+#|   from symptom onset and incidence of deaths. Case fatality risk for
+#|   hospitalised individuals is 0.9 and the risk of non-hospitalised
 #|   individuals is 0.75, and these risks are constant through time. The
 #|   y-axis is labelled "count" and the x-axis is labelled "date_index". The
-#|   plot shows growth and subsequent decline of the outbreak, with a similar 
+#|   plot shows growth and subsequent decline of the outbreak, with a similar
 #|   number of cases and deaths over time.
 plot(daily)
 ```
@@ -233,12 +235,14 @@ config <- create_config(
 
 Here we set the case fatality risk to exponentially decrease through time. This will provide a shallow (monotonic) decline of case fatality through the simulated epidemic. 
 
-```{r, plot-exponential-dist}
+```{r, prep-exponential-dist}
 exp_df <- data.frame(
   time = 1:150,
   value = config$time_varying_death_risk(risk = 0.9, time = 1:150)
 )
+```
 
+```{r plot-exponential-dist}
 #| fig.alt: >
 #|   A scatter plot showing an exponential decline over time representing the
 #|   time-varying hospitalised case fatality risk over time.
@@ -291,7 +295,7 @@ linelist <- linelist %>%
   )
 ```
 
-```{r, plot-onset-death-time-varying-cfr}
+```{r, prep-onset-death-time-varying-cfr}
 daily <- incidence(
   linelist,
   date_index = c(
@@ -301,11 +305,13 @@ daily <- incidence(
   interval = "daily"
 )
 daily <- complete_dates(daily)
+```
 
+```{r plot-onset-death-time-varying-cfr}
 #| fig.alt: >
-#|   Two histograms in a single column, showing the daily incidence of cases 
-#|   from symptom onset and incidence of deaths. The baseline case fatality 
-#|   risk for  hospitalised individuals is 0.9 and the risk of non-hospitalised 
+#|   Two histograms in a single column, showing the daily incidence of cases
+#|   from symptom onset and incidence of deaths. The baseline case fatality
+#|   risk for  hospitalised individuals is 0.9 and the risk of non-hospitalised
 #|   individuals is 0.75, and these decline exponentially through time. The
 #|   y-axis is labelled "count" and the x-axis is labelled "date_index". The
 #|   plot shows fluctuating cases over time, and only a few deaths early in the
@@ -327,12 +333,14 @@ config <- create_config(
 # nolint end
 ```
 
-```{r, plot-stepwise-dist}
+```{r, prep-stepwise-dist}
 stepwise_df <- data.frame(
   time = 1:150,
   value = config$time_varying_death_risk(risk = 0.9, time = 1:150)
 )
+```
 
+```{r plot-stepwise-dist}
 #| fig.alt: >
 #|   A scatter plot showing an step-wise function representing the
 #|   time-varying hospitalised case fatality risk over time. The function
@@ -376,7 +384,7 @@ linelist <- linelist %>%
   )
 ```
 
-```{r, plot-onset-death-time-varying-cfr-stepwise}
+```{r, prep-onset-death-time-varying-cfr-stepwise}
 daily <- incidence(
   linelist,
   date_index = c(
@@ -386,11 +394,13 @@ daily <- incidence(
   interval = "daily"
 )
 daily <- complete_dates(daily)
+```
 
+```{r plot-onset-death-time-varying-cfr-stepwise}
 #| fig.alt: >
-#|   Two histograms in a single column, showing the daily incidence of cases 
-#|   from symptom onset and incidence of deaths. The baseline case fatality 
-#|   risk for  hospitalised individuals is 0.9 and the risk of non-hospitalised 
+#|   Two histograms in a single column, showing the daily incidence of cases
+#|   from symptom onset and incidence of deaths. The baseline case fatality
+#|   risk for  hospitalised individuals is 0.9 and the risk of non-hospitalised
 #|   individuals is 0.75, and these change in a step-wise manner at day 60 of
 #|   the epidemic. The y-axis is labelled "count" and the x-axis is labelled
 #|   "date_index". The plot shows fluctuating cases over time, and deaths only
@@ -408,16 +418,18 @@ config <- create_config(
 )
 ```
 
-```{r, plot-stepwise-dist-window}
+```{r, prep-stepwise-dist-window}
 stepwise_df <- data.frame(
   time = 1:150,
   value = config$time_varying_death_risk(risk = 0.9, time = 1:150)
 )
+```
 
+```{r plot-stepwise-dist-window}
 #| fig.alt: >
 #|   A scatter plot showing an step-wise function representing the
 #|   time-varying hospitalised case fatality risk over time. The function
-#|   outputs 0.9 if time (days) is less than 50 or greater than 100, and 0.45 
+#|   outputs 0.9 if time (days) is less than 50 or greater than 100, and 0.45
 #|   if not.
 ggplot(stepwise_df) +
   geom_point(mapping = aes(x = time, y = value)) +
@@ -458,7 +470,7 @@ linelist <- linelist %>%
   )
 ```
 
-```{r, plot-onset-death-time-varying-cfr-stepwise-window}
+```{r, prep-onset-death-time-varying-cfr-stepwise-window}
 daily <- incidence(
   linelist,
   date_index = c(
@@ -468,14 +480,16 @@ daily <- incidence(
   interval = "daily"
 )
 daily <- complete_dates(daily)
+```
 
+```{r plot-onset-death-time-varying-cfr-stepwise-window}
 #| fig.alt: >
-#|   Two histograms in a single column, showing the daily incidence of cases 
-#|   from symptom onset and incidence of deaths. The maximum case fatality 
-#|   risk for  hospitalised individuals is 0.9 and the risk of non-hospitalised 
+#|   Two histograms in a single column, showing the daily incidence of cases
+#|   from symptom onset and incidence of deaths. The maximum case fatality
+#|   risk for  hospitalised individuals is 0.9 and the risk of non-hospitalised
 #|   individuals is 0.75, and these change in a step-wise manner at day 50 and
 #|   100 of the epidemic. The y-axis is labelled "count" and the x-axis is
-#|   labelled "date_index". The plot shows fluctuating cases over time, and 
+#|   labelled "date_index". The plot shows fluctuating cases over time, and
 #|   deaths closely resemble the number of cases over time.
 plot(daily)
 ```

--- a/vignettes/time-varying-cfr.Rmd
+++ b/vignettes/time-varying-cfr.Rmd
@@ -140,7 +140,15 @@ linelist <- linelist %>%
   )
 ```
 
-```{r, plot-onset-hospitalisation, fig.cap="Daily incidence of cases from symptom onset and incidence of deaths. Case fatality risk for hospitalised individuals is 0.5 and the risk for non-hospitalised individuals is 0.05, and these risks are constant through time.", fig.width = 8, fig.height = 5}
+```{r, plot-onset-hospitalisation, fig.width = 8, fig.height = 5}
+#| fig.alt: >
+#|   Two histograms in a single column, showing the daily incidence of cases 
+#|   from symptom onset and incidence of deaths. Case fatality risk for 
+#|   hospitalised individuals is 0.5 and the risk of non-hospitalised 
+#|   individuals is 0.05, and these risks are constant through time. The
+#|   y-axis is labelled "count" and the x-axis is labelled "date_index". The
+#|   plot shows fluctuating number of cases over time with substantially 
+#|   fewer deaths than cases.
 daily <- incidence(
   linelist,
   date_index = c(
@@ -185,7 +193,7 @@ linelist <- linelist %>%
   )
 ```
 
-```{r, plot-onset-death-higher-risk, fig.cap="Daily incidence of cases from symptom onset and incidence of deaths. Case fatality risk for hospitalised individuals is 0.9 and the risk for non-hospitalised individuals is 0.75, and these risks are constant through time.", fig.width = 8, fig.height = 5}
+```{r, plot-onset-death-higher-risk, fig.width = 8, fig.height = 5}
 daily <- incidence(
   linelist,
   date_index = c(
@@ -195,6 +203,15 @@ daily <- incidence(
   interval = "daily"
 )
 daily <- complete_dates(daily)
+
+#| fig.alt: >
+#|   Two histograms in a single column, showing the daily incidence of cases 
+#|   from symptom onset and incidence of deaths. Case fatality risk for 
+#|   hospitalised individuals is 0.9 and the risk of non-hospitalised 
+#|   individuals is 0.75, and these risks are constant through time. The
+#|   y-axis is labelled "count" and the x-axis is labelled "date_index". The
+#|   plot shows growth and subsequent decline of the outbreak, with a similar 
+#|   number of cases and deaths over time.
 plot(daily)
 ```
 
@@ -214,17 +231,23 @@ config <- create_config(
 
 Here we set the case fatality risk to exponentially decrease through time. This will provide a shallow (monotonic) decline of case fatality through the simulated epidemic. 
 
-```{r, plot-exponential-dist, fig.cap="The time-varying hospitalised case fatality risk function (`config$time_varying_death_risk`) throughout the epidemic. In this case the hospitalised risks (`hosp_death_risk`) are at their maximum value at day 0 and decline through time, with risk approaching zero at around day 100.", fig.width = 8, fig.height = 5}
+```{r, plot-exponential-dist, fig.width = 8, fig.height = 5}
 exp_df <- data.frame(
   time = 1:150,
   value = config$time_varying_death_risk(risk = 0.9, time = 1:150)
 )
+
+#| fig.alt: >
+#|   A scatter plot showing an exponential decline over time representing the
+#|   time-varying hospitalised case fatality risk over time.
 ggplot(exp_df) +
   geom_point(mapping = aes(x = time, y = value)) +
   scale_y_continuous(name = "Value") +
   scale_x_continuous(name = "Time (Days)") +
   theme_bw()
 ```
+
+The time-varying hospitalised case fatality risk function (`config$time_varying_death_risk`) throughout the epidemic. In this case the hospitalised risks (`hosp_death_risk`) are at their maximum value at day 0 and decline through time, with risk approaching zero at around day 100.
 
 ::: {.alert .alert-info}
 
@@ -266,7 +289,7 @@ linelist <- linelist %>%
   )
 ```
 
-```{r, plot-onset-death-time-varying-cfr, fig.cap="Daily incidence of cases from symptom onset and incidence of deaths. The baseline case fatality risk for hospitalised individuals is 0.9 and for non-hospitalised individuals is 0.75, and these decline exponentially through time.", fig.width = 8, fig.height = 5}
+```{r, plot-onset-death-time-varying-cfr, fig.width = 8, fig.height = 5}
 daily <- incidence(
   linelist,
   date_index = c(
@@ -276,6 +299,15 @@ daily <- incidence(
   interval = "daily"
 )
 daily <- complete_dates(daily)
+
+#| fig.alt: >
+#|   Two histograms in a single column, showing the daily incidence of cases 
+#|   from symptom onset and incidence of deaths. The baseline case fatality 
+#|   risk for  hospitalised individuals is 0.9 and the risk of non-hospitalised 
+#|   individuals is 0.75, and these decline exponentially through time. The
+#|   y-axis is labelled "count" and the x-axis is labelled "date_index". The
+#|   plot shows fluctuating cases over time, and only a few deaths early in the
+#|   epidemic and no deaths later in the outbreak.
 plot(daily)
 ```
 
@@ -293,17 +325,24 @@ config <- create_config(
 # nolint end
 ```
 
-```{r, plot-stepwise-dist, fig.cap="The time-varying case fatality risk function (`config$time_varying_death_risk`) for the hospitalised death risk (`hosp_death_risk`) and non-hospitalised death risk (`non_hosp_death_risk`) throughout the epidemic. In this case the risks are at their user-supplied values from day 0 to day 60, and then become 0 onwards.", fig.width = 8, fig.height = 5}
+```{r, plot-stepwise-dist, fig.width = 8, fig.height = 5}
 stepwise_df <- data.frame(
   time = 1:150,
   value = config$time_varying_death_risk(risk = 0.9, time = 1:150)
 )
+
+#| fig.alt: >
+#|   A scatter plot showing an step-wise function representing the
+#|   time-varying hospitalised case fatality risk over time. The function
+#|   outputs 0.9 if time (days) is less than 60, and 0 if not.
 ggplot(stepwise_df) +
   geom_point(mapping = aes(x = time, y = value)) +
   scale_y_continuous(name = "Value") +
   scale_x_continuous(name = "Time (Days)") +
   theme_bw()
 ```
+
+The time-varying case fatality risk function (`config$time_varying_death_risk`) for the hospitalised death risk (`hosp_death_risk`) and non-hospitalised death risk (`non_hosp_death_risk`) throughout the epidemic. In this case the risks are at their user-supplied values from day 0 to day 60, and then become 0 onwards.
 
 Simulating with the stepwise time-varying case fatality risk:
 
@@ -335,7 +374,7 @@ linelist <- linelist %>%
   )
 ```
 
-```{r, plot-onset-death-time-varying-cfr-stepwise, fig.cap="Daily incidence of cases from symptom onset and incidence of deaths. The maximum case fatality risk for hospitalised individuals is 0.9 and for non-hospitalised individuals is 0.75, and these rates remain constant from days 0 to 60, and then go to 0 from day 60 onwards.", fig.width = 8, fig.height = 5}
+```{r, plot-onset-death-time-varying-cfr-stepwise, fig.width = 8, fig.height = 5}
 daily <- incidence(
   linelist,
   date_index = c(
@@ -345,6 +384,15 @@ daily <- incidence(
   interval = "daily"
 )
 daily <- complete_dates(daily)
+
+#| fig.alt: >
+#|   Two histograms in a single column, showing the daily incidence of cases 
+#|   from symptom onset and incidence of deaths. The baseline case fatality 
+#|   risk for  hospitalised individuals is 0.9 and the risk of non-hospitalised 
+#|   individuals is 0.75, and these change in a step-wise manner at day 60 of
+#|   the epidemic. The y-axis is labelled "count" and the x-axis is labelled
+#|   "date_index". The plot shows fluctuating cases over time, and deaths only
+#|   occuring early in the  epidemic and no deaths later in the outbreak.
 plot(daily)
 ```
 
@@ -358,17 +406,25 @@ config <- create_config(
 )
 ```
 
-```{r, plot-stepwise-dist-window, fig.cap="The time-varying case fatality risk function (`config$time_varying_death_risk`) which scales the hospitalised death risk (`hosp_death_risk`) and non-hospitalised death risk (`non_hosp_death_risk`) throughout the epidemic. In this case the risks are at their maximum, user-supplied, values from day 0 to day 50, and then half the risks from day 50 to day 100, and then return to their maximum value from day 100 onwards.", fig.width = 8, fig.height = 5}
+```{r, plot-stepwise-dist-window, fig.width = 8, fig.height = 5}
 stepwise_df <- data.frame(
   time = 1:150,
   value = config$time_varying_death_risk(risk = 0.9, time = 1:150)
 )
+
+#| fig.alt: >
+#|   A scatter plot showing an step-wise function representing the
+#|   time-varying hospitalised case fatality risk over time. The function
+#|   outputs 0.9 if time (days) is less than 50 or greater than 100, and 0.45 
+#|   if not.
 ggplot(stepwise_df) +
   geom_point(mapping = aes(x = time, y = value)) +
   scale_y_continuous(name = "Value", limits = c(0, 1)) +
   scale_x_continuous(name = "Time (Days)") +
   theme_bw()
 ```
+
+The time-varying case fatality risk function (`config$time_varying_death_risk`) which scales the hospitalised death risk (`hosp_death_risk`) and non-hospitalised death risk (`non_hosp_death_risk`) throughout the epidemic. In this case the risks are at their maximum, user-supplied, values from day 0 to day 50, and then half the risks from day 50 to day 100, and then return to their maximum value from day 100 onwards.
 
 Simulating with the stepwise time-varying case fatality risk:
 
@@ -400,7 +456,7 @@ linelist <- linelist %>%
   )
 ```
 
-```{r, plot-onset-death-time-varying-cfr-stepwise-window, fig.cap="Daily incidence of cases from symptom onset and incidence of deaths. The maximum case fatality risk for hospitalised individuals is 0.9 and for non-hospitalised individuals is 0.75, and these rates remain constant from days 0 to 50, and then from days 50 to 100 the case fatality risk is halved (i.e `hosp_death_risk` = 0.45 and `non_hosp_death_risk` = 0.375), before going back to their original risks from day 100 onwards.", fig.width = 8, fig.height = 5}
+```{r, plot-onset-death-time-varying-cfr-stepwise-window, fig.width = 8, fig.height = 5}
 daily <- incidence(
   linelist,
   date_index = c(
@@ -410,8 +466,19 @@ daily <- incidence(
   interval = "daily"
 )
 daily <- complete_dates(daily)
+
+#| fig.alt: >
+#|   Two histograms in a single column, showing the daily incidence of cases 
+#|   from symptom onset and incidence of deaths. The maximum case fatality 
+#|   risk for  hospitalised individuals is 0.9 and the risk of non-hospitalised 
+#|   individuals is 0.75, and these change in a step-wise manner at day 50 and
+#|   100 of the epidemic. The y-axis is labelled "count" and the x-axis is
+#|   labelled "date_index". The plot shows fluctuating cases over time, and 
+#|   deaths closely resemble the number of cases over time.
 plot(daily)
 ```
+
+The maximum case fatality risk for hospitalised individuals is 0.9 and for non-hospitalised individuals is 0.75, and these rates remain constant from days 0 to 50, and then from days 50 to 100 the case fatality risk is halved (i.e `hosp_death_risk` = 0.45 and `non_hosp_death_risk` = 0.375), before going back to their original risks from day 100 onwards."
 
 This vignette does not explore applying a time-varying case fatality risk to age-stratified fatality risks, but this is possible with the `sim_linelist()` and `sim_outbreak()` functions. See the [Age-stratified hospitalisation and death risks vignette](age-strat-risks.html) and combine with instructions from this vignette on setting in a time-varying function using `create_config()`.
 

--- a/vignettes/time-varying-cfr.Rmd
+++ b/vignettes/time-varying-cfr.Rmd
@@ -157,9 +157,9 @@ daily <- incidence(
     onset = "date_onset",
     death = "date_death"
   ),
-  interval = "daily"
+  interval = "daily",
+  complete_dates = TRUE
 )
-daily <- complete_dates(daily)
 plot(daily)
 ```
 
@@ -202,9 +202,9 @@ daily <- incidence(
     onset = "date_onset",
     death = "date_death"
   ),
-  interval = "daily"
+  interval = "daily",
+  complete_dates = TRUE
 )
-daily <- complete_dates(daily)
 ```
 
 ```{r plot-onset-death-higher-risk}
@@ -302,9 +302,9 @@ daily <- incidence(
     onset = "date_onset",
     death = "date_death"
   ),
-  interval = "daily"
+  interval = "daily",
+  complete_dates = TRUE
 )
-daily <- complete_dates(daily)
 ```
 
 ```{r plot-onset-death-time-varying-cfr}
@@ -391,9 +391,9 @@ daily <- incidence(
     onset = "date_onset",
     death = "date_death"
   ),
-  interval = "daily"
+  interval = "daily",
+  complete_dates = TRUE
 )
-daily <- complete_dates(daily)
 ```
 
 ```{r plot-onset-death-time-varying-cfr-stepwise}
@@ -477,9 +477,9 @@ daily <- incidence(
     onset = "date_onset",
     death = "date_death"
   ),
-  interval = "daily"
+  interval = "daily",
+  complete_dates = TRUE
 )
-daily <- complete_dates(daily)
 ```
 
 ```{r plot-onset-death-time-varying-cfr-stepwise-window}

--- a/vignettes/time-varying-cfr.Rmd
+++ b/vignettes/time-varying-cfr.Rmd
@@ -10,7 +10,9 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  fig.width = 8,
+  fig.height = 5
 )
 ```
 
@@ -140,7 +142,7 @@ linelist <- linelist %>%
   )
 ```
 
-```{r, plot-onset-hospitalisation, fig.width = 8, fig.height = 5}
+```{r, plot-onset-hospitalisation}
 #| fig.alt: >
 #|   Two histograms in a single column, showing the daily incidence of cases 
 #|   from symptom onset and incidence of deaths. Case fatality risk for 
@@ -193,7 +195,7 @@ linelist <- linelist %>%
   )
 ```
 
-```{r, plot-onset-death-higher-risk, fig.width = 8, fig.height = 5}
+```{r, plot-onset-death-higher-risk}
 daily <- incidence(
   linelist,
   date_index = c(
@@ -231,7 +233,7 @@ config <- create_config(
 
 Here we set the case fatality risk to exponentially decrease through time. This will provide a shallow (monotonic) decline of case fatality through the simulated epidemic. 
 
-```{r, plot-exponential-dist, fig.width = 8, fig.height = 5}
+```{r, plot-exponential-dist}
 exp_df <- data.frame(
   time = 1:150,
   value = config$time_varying_death_risk(risk = 0.9, time = 1:150)
@@ -289,7 +291,7 @@ linelist <- linelist %>%
   )
 ```
 
-```{r, plot-onset-death-time-varying-cfr, fig.width = 8, fig.height = 5}
+```{r, plot-onset-death-time-varying-cfr}
 daily <- incidence(
   linelist,
   date_index = c(
@@ -325,7 +327,7 @@ config <- create_config(
 # nolint end
 ```
 
-```{r, plot-stepwise-dist, fig.width = 8, fig.height = 5}
+```{r, plot-stepwise-dist}
 stepwise_df <- data.frame(
   time = 1:150,
   value = config$time_varying_death_risk(risk = 0.9, time = 1:150)
@@ -374,7 +376,7 @@ linelist <- linelist %>%
   )
 ```
 
-```{r, plot-onset-death-time-varying-cfr-stepwise, fig.width = 8, fig.height = 5}
+```{r, plot-onset-death-time-varying-cfr-stepwise}
 daily <- incidence(
   linelist,
   date_index = c(
@@ -406,7 +408,7 @@ config <- create_config(
 )
 ```
 
-```{r, plot-stepwise-dist-window, fig.width = 8, fig.height = 5}
+```{r, plot-stepwise-dist-window}
 stepwise_df <- data.frame(
   time = 1:150,
   value = config$time_varying_death_risk(risk = 0.9, time = 1:150)
@@ -456,7 +458,7 @@ linelist <- linelist %>%
   )
 ```
 
-```{r, plot-onset-death-time-varying-cfr-stepwise-window, fig.width = 8, fig.height = 5}
+```{r, plot-onset-death-time-varying-cfr-stepwise-window}
 daily <- incidence(
   linelist,
   date_index = c(

--- a/vignettes/vis-linelist.Rmd
+++ b/vignettes/vis-linelist.Rmd
@@ -100,18 +100,16 @@ Currently {simulist} outputs dates that are not rounded to the nearest day, i.e.
 
 ***Note*** storing dates as precise doubles and not as integer days may change in the near future.
 
-The `interval = "daily"` is required as {incidence2} requires rounded dates to aggregate cases per unit time and specifying the `interval` will do this automatically for us.
+The `interval = "daily"` is required as {incidence2} requires rounded dates to aggregate cases per unit time and specifying the `interval` will do this automatically for us. It is possible that not every date had the onset of symptoms, resulting in some dates missing entries. This is taken care of by setting `complete_dates = TRUE`, alternatively this can be achieved by using `incidence2::complete_dates()` on the `<incidence2>` object.
 
 ```{r create-incidence}
 # create incidence object
-daily <- incidence(x = linelist, date_index = "date_onset", interval = "daily")
-```
-
-It is possible that not every date had the onset of symptoms, resulting in some dates missing entries. This is taken care of by the `complete_dates()` function in {incidence2}.
-
-```{r, complete-dates}
-# impute for days without cases
-daily <- complete_dates(daily)
+daily <- incidence(
+  x = linelist, 
+  date_index = "date_onset", 
+  interval = "daily", 
+  complete_dates = TRUE
+)
 ```
 
 ```{r plot-daily}
@@ -203,9 +201,9 @@ daily <- incidence(
     death = "date_death"
   ),
   interval = "daily",
-  groups = "sex"
+  groups = "sex",
+  complete_dates = TRUE
 )
-daily <- complete_dates(daily)
 ```
 
 ```{r plot-onset-hospitalisation}

--- a/vignettes/vis-linelist.Rmd
+++ b/vignettes/vis-linelist.Rmd
@@ -10,7 +10,9 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  fig.width = 8,
+  fig.height = 5
 )
 ```
 
@@ -107,7 +109,7 @@ daily <- incidence(x = linelist, date_index = "date_onset", interval = "daily")
 
 It is possible that not every date had the onset of symptoms, resulting in some dates missing entries. This is taken care of by the `complete_dates()` function in {incidence2}.
 
-```{r, complete-dates, fig.width = 8, fig.height = 5}
+```{r, complete-dates}
 # impute for days without cases
 daily <- complete_dates(daily)
 
@@ -121,7 +123,7 @@ plot(daily)
 
 Alternatively, incidence can be plotting weekly:
 
-```{r plot-weekly, fig.width = 8, fig.height = 5}
+```{r plot-weekly}
 weekly <- incidence(linelist, date_index = "date_onset", interval = "isoweek")
 
 #| fig.alt: >
@@ -134,7 +136,7 @@ plot(weekly)
 
 In order to check differences between a group in the line list data, for example sex, the `<incidence2>` data object can be recreated, specifying which columns to group by.
 
-```{r, group-by-sex, fig.width = 8, fig.height = 5}
+```{r, group-by-sex}
 weekly <- incidence(
   linelist,
   date_index = "date_onset",
@@ -186,7 +188,7 @@ linelist <- linelist %>%
 
 ## {-}
  
-```{r, plot-onset-hospitalisation, fig.width = 8, fig.height = 5}
+```{r, plot-onset-hospitalisation}
 daily <- incidence(
   linelist,
   date_index = c(

--- a/vignettes/vis-linelist.Rmd
+++ b/vignettes/vis-linelist.Rmd
@@ -107,28 +107,47 @@ daily <- incidence(x = linelist, date_index = "date_onset", interval = "daily")
 
 It is possible that not every date had the onset of symptoms, resulting in some dates missing entries. This is taken care of by the `complete_dates()` function in {incidence2}.
 
-```{r, complete-dates, fig.cap="Daily incidence of cases from symptom onset including days with zero cases.", fig.width = 8, fig.height = 5}
+```{r, complete-dates, fig.width = 8, fig.height = 5}
 # impute for days without cases
 daily <- complete_dates(daily)
+
+#| fig.alt: >
+#|   Histogram of incidence (epicurve) showing the daily incidence of cases
+#|   from symptom onset including days with zero cases. The plot shows the 
+#|   outbreak increasing in incidence and then declining, similar to a normal
+#|   distribution.
 plot(daily)
 ```
 
 Alternatively, incidence can be plotting weekly:
 
-```{r plot-weekly, fig.cap="Weekly incidence of cases from symptom onset", fig.width = 8, fig.height = 5}
+```{r plot-weekly, fig.width = 8, fig.height = 5}
 weekly <- incidence(linelist, date_index = "date_onset", interval = "isoweek")
+
+#| fig.alt: >
+#|   Histogram of incidence (epicurve) showing the weekly incidence of cases
+#|   from symptom onset including days with zero cases. The plot shows the 
+#|   outbreak increasing in incidence and then declining, with some weeks late
+#|   in the outbreak have noticably high case counts.
 plot(weekly)
 ```
 
 In order to check differences between a group in the line list data, for example sex, the `<incidence2>` data object can be recreated, specifying which columns to group by.
 
-```{r, group-by-sex, fig.cap="Weekly incidence of cases from symptom onset facetted by sex", fig.width = 8, fig.height = 5}
+```{r, group-by-sex, fig.width = 8, fig.height = 5}
 weekly <- incidence(
   linelist,
   date_index = "date_onset",
   interval = "isoweek",
   groups = "sex"
 )
+
+#| fig.alt: >
+#|   Two histograms, in a single row, of incidence (epicurve) showing the 
+#|   weekly incidence of cases from symtom onset including days with zero 
+#|   cases, facetted by sex (left female, right male). The plot shows the 
+#|   outbreak increasing in incidence and then declining, with epidemic curves
+#|   similar between sexes.
 plot(weekly)
 ```
  
@@ -167,7 +186,7 @@ linelist <- linelist %>%
 
 ## {-}
  
-```{r, plot-onset-hospitalisation, fig.cap="Daily incidence of cases from symptom onset and incidence of hospitalisations and deaths.", fig.width = 8, fig.height = 5}
+```{r, plot-onset-hospitalisation, fig.width = 8, fig.height = 5}
 daily <- incidence(
   linelist,
   date_index = c(
@@ -179,6 +198,14 @@ daily <- incidence(
   groups = "sex"
 )
 daily <- complete_dates(daily)
+
+#| fig.alt: >
+#|   Six histograms, in a grid of two columns and three rows, of incidence 
+#|   (epicurves) showing the daily incidence of cases from symtom onset 
+#|   (bottom row), hospital admission (middle row), and death (top row). 
+#|   The data is facetted by sex (left female, right male) and incidence event 
+#|   (rows). The plot shows the outbreak fluctuating, with many fewer
+#|   hospital admissions and deaths than cases.
 plot(daily)
 ```
 
@@ -261,7 +288,12 @@ If you are viewing this vignette on the web (or on a web browser) the graph belo
 
 :::
 
-```{r, plot-epicontacts, fig.cap="Contact network from infectious disease outbreak. This includes all contacts, i.e. individuals that were infected and not infected"}
+```{r, plot-epicontacts}
+#| fig.alt: >
+#|   Contact network from infectious disease outbreak. This includes all
+#|   contacts, i.e. individuals that were infected and not infected. Each
+#|   individual is shown as a circle with a name tag, and arrows connecting
+#|   the contacts to show directionality of contact.
 plot(epicontacts)
 ```
 
@@ -307,7 +339,12 @@ epicontacts <- make_epicontacts(
 epicontacts
 ```
 
-```{r, plot-cases-epicontacts, fig.cap="Transmission chain from infectious disease outbreak. This includes only individuals that were infected, including confirmed, probable and suspected cases."}
+```{r, plot-cases-epicontacts}
+#| fig.alt: >
+#|   Transmission chain from infectious disease outbreak. This includes only 
+#|   individuals that were infected, including confirmed, probable and 
+#|   suspected cases. Each individual is shown as a circle with a name tag, 
+#|   and arrows connecting the cases to show directionality of transmission.
 plot(epicontacts)
 ```
 

--- a/vignettes/vis-linelist.Rmd
+++ b/vignettes/vis-linelist.Rmd
@@ -105,9 +105,9 @@ The `interval = "daily"` is required as {incidence2} requires rounded dates to a
 ```{r create-incidence}
 # create incidence object
 daily <- incidence(
-  x = linelist, 
-  date_index = "date_onset", 
-  interval = "daily", 
+  x = linelist,
+  date_index = "date_onset",
+  interval = "daily",
   complete_dates = TRUE
 )
 ```

--- a/vignettes/vis-linelist.Rmd
+++ b/vignettes/vis-linelist.Rmd
@@ -112,10 +112,12 @@ It is possible that not every date had the onset of symptoms, resulting in some 
 ```{r, complete-dates}
 # impute for days without cases
 daily <- complete_dates(daily)
+```
 
+```{r plot-daily}
 #| fig.alt: >
 #|   Histogram of incidence (epicurve) showing the daily incidence of cases
-#|   from symptom onset including days with zero cases. The plot shows the 
+#|   from symptom onset including days with zero cases. The plot shows the
 #|   outbreak increasing in incidence and then declining, similar to a normal
 #|   distribution.
 plot(daily)
@@ -123,12 +125,14 @@ plot(daily)
 
 Alternatively, incidence can be plotting weekly:
 
-```{r plot-weekly}
+```{r prep-weekly}
 weekly <- incidence(linelist, date_index = "date_onset", interval = "isoweek")
+```
 
+```{r plot-weekly}
 #| fig.alt: >
 #|   Histogram of incidence (epicurve) showing the weekly incidence of cases
-#|   from symptom onset including days with zero cases. The plot shows the 
+#|   from symptom onset including days with zero cases. The plot shows the
 #|   outbreak increasing in incidence and then declining, with some weeks late
 #|   in the outbreak have noticably high case counts.
 plot(weekly)
@@ -143,11 +147,13 @@ weekly <- incidence(
   interval = "isoweek",
   groups = "sex"
 )
+```
 
+```{r plot-group-by-sex}
 #| fig.alt: >
-#|   Two histograms, in a single row, of incidence (epicurve) showing the 
-#|   weekly incidence of cases from symtom onset including days with zero 
-#|   cases, facetted by sex (left female, right male). The plot shows the 
+#|   Two histograms, in a single row, of incidence (epicurve) showing the
+#|   weekly incidence of cases from symtom onset including days with zero
+#|   cases, facetted by sex (left female, right male). The plot shows the
 #|   outbreak increasing in incidence and then declining, with epidemic curves
 #|   similar between sexes.
 plot(weekly)
@@ -188,7 +194,7 @@ linelist <- linelist %>%
 
 ## {-}
  
-```{r, plot-onset-hospitalisation}
+```{r, prep-onset-hospitalisation}
 daily <- incidence(
   linelist,
   date_index = c(
@@ -200,12 +206,14 @@ daily <- incidence(
   groups = "sex"
 )
 daily <- complete_dates(daily)
+```
 
+```{r plot-onset-hospitalisation}
 #| fig.alt: >
-#|   Six histograms, in a grid of two columns and three rows, of incidence 
-#|   (epicurves) showing the daily incidence of cases from symtom onset 
-#|   (bottom row), hospital admission (middle row), and death (top row). 
-#|   The data is facetted by sex (left female, right male) and incidence event 
+#|   Six histograms, in a grid of two columns and three rows, of incidence
+#|   (epicurves) showing the daily incidence of cases from symtom onset
+#|   (bottom row), hospital admission (middle row), and death (top row).
+#|   The data is facetted by sex (left female, right male) and incidence event
 #|   (rows). The plot shows the outbreak fluctuating, with many fewer
 #|   hospital admissions and deaths than cases.
 plot(daily)
@@ -343,9 +351,9 @@ epicontacts
 
 ```{r, plot-cases-epicontacts}
 #| fig.alt: >
-#|   Transmission chain from infectious disease outbreak. This includes only 
-#|   individuals that were infected, including confirmed, probable and 
-#|   suspected cases. Each individual is shown as a circle with a name tag, 
+#|   Transmission chain from infectious disease outbreak. This includes only
+#|   individuals that were infected, including confirmed, probable and
+#|   suspected cases. Each individual is shown as a circle with a name tag,
 #|   and arrows connecting the cases to show directionality of transmission.
 plot(epicontacts)
 ```


### PR DESCRIPTION
This PR closes #212 by adding alt text (`fig.alt`) to all figures in the vignettes. 

This uses the yaml syntax to add alt text in each code chunk that plots. 

Code chunks that previously used figure captions `fig.cap` (which is used as alt text when not provided) have been replaced by `fig.alt` with a more detailed description of the plot. As opposed to `fig.cap`, `fig.alt` is not rendered in the vignette, so some captions that contained important information for the reader have been copied as text chunks in the vignette. 

`fig.width` and `fig.height` is now set in `knitr::opts_chunk` once per vignette rather than in each code chunk that contains plotting code.