### PR TITLE
Add @sbfnk as package contributor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,8 @@ Authors@R: c(
            comment = c(ORCID = "0000-0001-8814-9421")),
     person("Chris", "Hartgerink", , "chris@data.org", role = "rev",
            comment = c(ORCID = "0000-0003-1050-6809")),
+    person("Sebastian", "Funk", , "sebastian.funk@lshtm.ac.uk", role = "ctb",
+           comment = c(ORCID = "0000-0002-2842-3406")),
     person("London School of Hygiene and Tropical Medicine, LSHTM", role = "cph",
            comment = c(ROR = "00a0jsq62"))
   )

--- a/man/simulist-package.Rd
+++ b/man/simulist-package.Rd
@@ -31,6 +31,7 @@ Other contributors:
   \item Pratik R. Gupte \email{pratik.gupte@lshtm.ac.uk} (\href{https://orcid.org/0000-0001-5294-7819}{ORCID}) [contributor, reviewer]
   \item Adam Kucharski \email{adam.kucharski@lshtm.ac.uk} (\href{https://orcid.org/0000-0001-8814-9421}{ORCID}) [reviewer]
   \item Chris Hartgerink \email{chris@data.org} (\href{https://orcid.org/0000-0003-1050-6809}{ORCID}) [reviewer]
+  \item Sebastian Funk \email{sebastian.funk@lshtm.ac.uk} (\href{https://orcid.org/0000-0002-2842-3406}{ORCID}) [contributor]
   \item London School of Hygiene and Tropical Medicine, LSHTM (00a0jsq62) [copyright holder]
 }
 


### PR DESCRIPTION
This PR adds @sbfnk as a package contributor for his contributions around the new truncation functionality included in the new version of {simulist}. This contributions were both offline discussions and reviewing pull requests (#179 & #201)