### PR TITLE
Link Epidemiology CRAN task view in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -255,6 +255,8 @@ In some cases the packages are dedicated to simulating line list and other epide
 
 If there is another package with this functionality missing from the list that should be added, or if a package included in this list has been updated and the table should reflect this please contribute by making an [issue](https://github.com/epiverse-trace/simulist/issues) or a [pull request](https://github.com/epiverse-trace/simulist/pulls). 
 
+Other R packages for simulating epidemic dynamics can be found in the _Epidemic simulation models_ section of the [Epidemiology CRAN task view](https://cran.r-project.org/web/views/Epidemiology.html).
+
 Some packages are related to {simulist} but do not simulate line list data. These include:
 
 - [`{outbreaks}`](https://CRAN.R-project.org/package=outbreaks) an R package containing a library of outbreak data sets, including line list data, for a variety of past and simulated outbreaks, e.g. Ebola and MERS.

--- a/README.md
+++ b/README.md
@@ -465,6 +465,10 @@ been updated and the table should reflect this please contribute by
 making an [issue](https://github.com/epiverse-trace/simulist/issues) or
 a [pull request](https://github.com/epiverse-trace/simulist/pulls).
 
+Other R packages for simulating epidemic dynamics can be found in the
+*Epidemic simulation models* section of the [Epidemiology CRAN task
+view](https://cran.r-project.org/web/views/Epidemiology.html).
+
 Some packages are related to {simulist} but do not simulate line list
 data. These include:
 


### PR DESCRIPTION
In the _Related projects_ section of the README the Epidemiology CRAN task view is linked as a useful resource for other epidemiological simulation packages. 

I've scanned the packages listed in the Epidemic simulation models section and I didn't see any line list simulators that could be added to the _Related projects_ table.