### PR TITLE
Set `$outcome` to `NA` if `$date_outcome` is set to `NA` in `truncate_linelist()`

### DIFF
--- a/R/truncate_linelist.R
+++ b/R/truncate_linelist.R
@@ -120,6 +120,9 @@ truncate_linelist <- function(linelist,
   reported_lgl_idx <- trunc_date > linelist$date_reporting
   linelist <- linelist[reported_lgl_idx, ]
 
+  # convert outcomes more recent than truncation time to NA by outcome date
+  linelist$outcome[linelist$date_outcome > trunc_date] <- NA_character_
+
   # get date columns to be modified if after truncation time
   date_col_lgl_idx <- vapply(
     linelist, inherits, FUN.VALUE = logical(1), what = "Date"

--- a/tests/testthat/test-truncate_linelist.R
+++ b/tests/testthat/test-truncate_linelist.R
@@ -141,6 +141,20 @@ test_that("truncate_linelist sets dates as NA when between events", {
   )
 })
 
+test_that("truncate_linelist sets outcome as NA if date_outcome is >= trunc", {
+  # simulate with recovery times
+  set.seed(123)
+  ll <- sim_linelist(
+    onset_to_recovery = function(x) rlnorm(n = x, meanlog = 2, sdlog = 1)
+  )
+  expect_false(anyNA(ll$date_outcome))
+  expect_false(anyNA(ll$outcome))
+  ll_trunc <- truncate_linelist(ll, truncation_day = 60)
+  expect_true(anyNA(ll_trunc$date_outcome))
+  expect_true(anyNA(ll_trunc$outcome))
+  expect_identical(is.na(ll_trunc$outcome), is.na(ll_trunc$date_outcome))
+})
+
 test_that("truncate_linelist warns if truncation_day is Date and unit given", {
   expect_warning(
     truncate_linelist(


### PR DESCRIPTION
This PR addresses #227 by updating `truncate_linelist()` to make sure `$outcome` for each individual in the line list are set to `NA` if the `$date_outcome` on the same row are set to `NA` by `truncate_linelist()` because the `$date_reporting` is before the truncation date, but the outcome date is afterwards.

A unit tests is added to make sure that the number and placement of `NA`s in `$outcome` and `$date_outcome` by `truncate_linelist()` is identical.