### PR TITLE
Fix figure rendering in vignettes by using single quotes in alt text

### DIFF
--- a/vignettes/age-struct-pop.Rmd
+++ b/vignettes/age-struct-pop.Rmd
@@ -102,8 +102,8 @@ We can plot the age distribution for individuals in the line list, binned into 5
 #|   A histogram for the age distribution of individuals in a simulated line
 #|   list sampled from a uniform distribution between 5 and 75. Ages are binned
 #|   into 5 year age groups. There is a small amount of variation in counts
-#|   of individuals in each group. The y-axis is labelled "Number of
-#|   Individuals", and the x-axis is labelled "Age".
+#|   of individuals in each group. The y-axis is labelled 'Number of
+#|   Individuals', and the x-axis is labelled 'Age'.
 ggplot(linelist[, c("sex", "age")]) +
   geom_histogram(
     mapping = aes(x = age),
@@ -161,7 +161,7 @@ Again we can plot the age distribution to see the age structure for individuals 
 #|   in the data.frame above. Ages are binned into 5 year age groups. There is
 #|   variation in counts of individuals in each group, and the histograms
 #|   between male (m) and female (f) are similar. The y-axis is labelled
-#|   "Number of Individuals", and the x-axis is labelled "Age".
+#|   'Number of Individuals', and the x-axis is labelled 'Age'.
 ggplot(linelist[, c("sex", "age")]) +
   geom_histogram(
     mapping = aes(x = age),
@@ -224,8 +224,8 @@ labels <- abs(breaks)
 ```{r, plot-age-struct-young}
 #| fig.alt: >
 #|   An age pyramid for a simulated line list with an age-structured population.
-#|   The y-axis is labeled "Lower bound of Age Category", the x-axis is labelled
-#|   "Population". The left of the age pyramid plots the number of female
+#|   The y-axis is labeled 'Lower bound of Age Category', the x-axis is labelled
+#|   'Population'. The left of the age pyramid plots the number of female
 #|   individuals (red) in each age category and the right of the age pyramid
 #|   plots the number of male individuals (blue) in each age category. The age
 #|   pyramid shows many young people in the population, aged below 10, and

--- a/vignettes/reporting-delays-truncation.Rmd
+++ b/vignettes/reporting-delays-truncation.Rmd
@@ -118,9 +118,9 @@ Here from the first 6 rows of the line list you can see differences between the 
 #|   A dot plot with the event dates in the line list plotted a points on the
 #|   figure, connected by horizontal lines. One row in the dot plot corresponds
 #|   to one case (i.e. one row in the line list). The y-axis label is
-#|   "Case name", and the x-axis label is "Event date". The event types are
-#|   "Date admission" (red square), "Date Onset" (blue circle), "Date Outcome"
-#|   (green triangle), and "Date Reporting" (purple diamond). The plot shows
+#|   'Case name', and the x-axis label is 'Event date'. The event types are
+#|   'Date admission' (red square), 'Date Onset' (blue circle), 'Date Outcome'
+#|   (green triangle), and 'Date Reporting' (purple diamond). The plot shows
 #|   the distribution of delay times between each event for each individual in
 #|   the line list, with the y-axis order by earliest date of symptom onset at
 #|   the bottom.
@@ -254,9 +254,9 @@ trunc_date <- max(tidy_linelist$value, na.rm = TRUE) - truncation_day
 #|   A dot plot with the event dates in the line list plotted a points on the
 #|   figure, connected by horizontal lines. One row in the dot plot corresponds
 #|   to one case (i.e. one row in the line list). The y-axis label is
-#|   "Case name", and the x-axis label is "Event date". The event types are
-#|   "Date admission" (red square), "Date Onset" (blue circle), "Date Outcome"
-#|   (green triangle), and "Date Reporting" (purple diamond). The plot shows
+#|   'Case name', and the x-axis label is 'Event date'. The event types are
+#|   'Date admission' (red square), 'Date Onset' (blue circle), 'Date Outcome'
+#|   (green triangle), and 'Date Reporting' (purple diamond). The plot shows
 #|   the distribution of delay times between each event for each individual in
 #|   the line list, with the y-axis order by earliest date of symptom onset at
 #|   the bottom. There is a vertical dashed line showing when the truncation day

--- a/vignettes/time-varying-cfr.Rmd
+++ b/vignettes/time-varying-cfr.Rmd
@@ -148,7 +148,7 @@ linelist <- linelist %>%
 #|   from symptom onset and incidence of deaths. Case fatality risk for
 #|   hospitalised individuals is 0.5 and the risk of non-hospitalised
 #|   individuals is 0.05, and these risks are constant through time. The
-#|   y-axis is labelled "count" and the x-axis is labelled "date_index". The
+#|   y-axis is labelled 'count' and the x-axis is labelled 'date_index'. The
 #|   plot shows fluctuating number of cases over time with substantially
 #|   fewer deaths than cases.
 daily <- incidence(
@@ -213,7 +213,7 @@ daily <- incidence(
 #|   from symptom onset and incidence of deaths. Case fatality risk for
 #|   hospitalised individuals is 0.9 and the risk of non-hospitalised
 #|   individuals is 0.75, and these risks are constant through time. The
-#|   y-axis is labelled "count" and the x-axis is labelled "date_index". The
+#|   y-axis is labelled 'count' and the x-axis is labelled 'date_index'. The
 #|   plot shows growth and subsequent decline of the outbreak, with a similar
 #|   number of cases and deaths over time.
 plot(daily)
@@ -313,7 +313,7 @@ daily <- incidence(
 #|   from symptom onset and incidence of deaths. The baseline case fatality
 #|   risk for  hospitalised individuals is 0.9 and the risk of non-hospitalised
 #|   individuals is 0.75, and these decline exponentially through time. The
-#|   y-axis is labelled "count" and the x-axis is labelled "date_index". The
+#|   y-axis is labelled 'count' and the x-axis is labelled 'date_index'. The
 #|   plot shows fluctuating cases over time, and only a few deaths early in the
 #|   epidemic and no deaths later in the outbreak.
 plot(daily)
@@ -402,8 +402,8 @@ daily <- incidence(
 #|   from symptom onset and incidence of deaths. The baseline case fatality
 #|   risk for  hospitalised individuals is 0.9 and the risk of non-hospitalised
 #|   individuals is 0.75, and these change in a step-wise manner at day 60 of
-#|   the epidemic. The y-axis is labelled "count" and the x-axis is labelled
-#|   "date_index". The plot shows fluctuating cases over time, and deaths only
+#|   the epidemic. The y-axis is labelled 'count' and the x-axis is labelled
+#|   'date_index'. The plot shows fluctuating cases over time, and deaths only
 #|   occuring early in the  epidemic and no deaths later in the outbreak.
 plot(daily)
 ```
@@ -488,8 +488,8 @@ daily <- incidence(
 #|   from symptom onset and incidence of deaths. The maximum case fatality
 #|   risk for  hospitalised individuals is 0.9 and the risk of non-hospitalised
 #|   individuals is 0.75, and these change in a step-wise manner at day 50 and
-#|   100 of the epidemic. The y-axis is labelled "count" and the x-axis is
-#|   labelled "date_index". The plot shows fluctuating cases over time, and
+#|   100 of the epidemic. The y-axis is labelled 'count' and the x-axis is
+#|   labelled 'date_index'. The plot shows fluctuating cases over time, and
 #|   deaths closely resemble the number of cases over time.
 plot(daily)
 ```


### PR DESCRIPTION
This PR addresses #226 by replacing the double quotes in alt text blocks with single quotes. The double quotes causes issues with rendering the figures both on the pkgdown website and on CRAN, see #226 for an example. Using single quotes resolves this issue, tested locally using `pkgdown::build_site()`.