### PR TITLE
Add warning callout block for missing incidence interval

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Suggests:
     dplyr,
     epicontacts (>= 1.1.3),
     ggplot2,
-    incidence2 (>= 2.3.0),
+    incidence2 (>= 2.6.2),
     knitr,
     rmarkdown,
     spelling,

--- a/vignettes/design-principles.Rmd
+++ b/vignettes/design-principles.Rmd
@@ -72,7 +72,7 @@ The aim is to restrict the number of dependencies to a minimal required set for 
 
 The soft dependencies (and their minimum version requirements) are:
 
-* [{incidence2}](https://CRAN.R-project.org/package=incidence2) (>= 2.3.0)
+* [{incidence2}](https://CRAN.R-project.org/package=incidence2) (>= 2.6.2)
 * [{epicontacts}](https://CRAN.R-project.org/package=epicontacts) (>= 1.1.3)
 * [{knitr}](https://CRAN.R-project.org/package=knitr)
 * [{ggplot2}](https://CRAN.R-project.org/package=ggplot2)

--- a/vignettes/vis-linelist.Rmd
+++ b/vignettes/vis-linelist.Rmd
@@ -98,7 +98,19 @@ To visualise the number of cases with onset on a particular day, the {incidence2
 
 Currently {simulist} outputs dates that are not rounded to the nearest day, i.e. it can be half way through a day. This is not obvious as R prints dates to the nearest day by default, and only by removing the date class (using `unclass()`) can you see the decimals (as R stores dates internally as the number of days since 1970-01-01).
 
-***Note*** storing dates as precise doubles and not as integer days may change in the near future.
+::: {.alert .alert-warning}
+
+{simulist} stores `<Date>`s as precise doubles and not as integer days. This can be misleading as R prints `<Date>`s to the nearest day. By default {incidence2} does not aggregate to the nearest day and without specifying an `interval` in `incidence()` it will aggregate to the same precision as the data. When supplied with non-whole `<Date>`s it will produce this warning. 
+
+```{r incidence-date-warn}
+# create incidence object
+daily <- incidence(
+  x = linelist,
+  date_index = "date_onset"
+)
+```
+
+:::
 
 The `interval = "daily"` is required as {incidence2} requires rounded dates to aggregate cases per unit time and specifying the `interval` will do this automatically for us. It is possible that not every date had the onset of symptoms, resulting in some dates missing entries. This is taken care of by setting `complete_dates = TRUE`, alternatively this can be achieved by using `incidence2::complete_dates()` on the `<incidence2>` object.
 


### PR DESCRIPTION
This PR relates to #207 and reconhub/incidence#134 by addressing the interoperability with {incidence2} and the use of non-integer `<Date>`s in {simulist} output. 

@avallecam raised that if the `interval` argument in `incidence2::incidence()` is not specified then the cases are not aggregated by day, but at the precision of the `<Date>` objects, in the case of `sim_linelist()` this is double precision. 

In the new v2.6.2 release of {incidence2} a warning is thrown if `<Date>`s are not `integers` and `interval` is not specified, this PR adds a warning callout block to the `vis-linelist.Rmd` (the main place that the interoperability of {simulist} and {incidence2} is discussed) to show this new warning for non-`integer` dates. 
