### PR TITLE
Replace argument `x` with `n` in anonymous sampling functions

### DIFF
--- a/R/create_config.R
+++ b/R/create_config.R
@@ -60,13 +60,13 @@
 #'
 #' # example with customised Ct distribution
 #' create_config(
-#'   ct_distribution = function(x) rlnorm(n = x, meanlog = 2, sdlog = 1)
+#'   ct_distribution = function(n) rlnorm(n = n, meanlog = 2, sdlog = 1)
 #' )
 create_config <- function(...) {
   .args <- list(
-    last_contact_distribution = function(x) stats::rpois(n = x, lambda = 3),
-    first_contact_distribution = function(x) stats::rpois(n = x, lambda = 3),
-    ct_distribution = function(x) stats::rnorm(n = x, mean = 25, sd = 2),
+    last_contact_distribution = function(n) stats::rpois(n = n, lambda = 3),
+    first_contact_distribution = function(n) stats::rpois(n = n, lambda = 3),
+    ct_distribution = function(n) stats::rnorm(n = n, mean = 25, sd = 2),
     network = "adjusted",
     time_varying_death_risk = NULL
   )

--- a/R/sim_contacts.R
+++ b/R/sim_contacts.R
@@ -62,7 +62,7 @@
 #'   prob_infection = 0.5
 #' )
 sim_contacts <- function(contact_distribution = function(x) stats::dpois(x = x, lambda = 2), # nolint line_length_linter.
-                         infectious_period = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5), # nolint line_length_linter.
+                         infectious_period = function(n) stats::rlnorm(n = n, meanlog = 2, sdlog = 0.5), # nolint line_length_linter.
                          prob_infection = 0.5,
                          outbreak_start_date = as.Date("2023-01-01"),
                          anonymise = FALSE,

--- a/R/sim_linelist.R
+++ b/R/sim_linelist.R
@@ -294,10 +294,10 @@
 #' )
 #' head(linelist)
 sim_linelist <- function(contact_distribution = function(x) stats::dpois(x = x, lambda = 2), # nolint start line_lenght_linter
-                         infectious_period = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5),
+                         infectious_period = function(n) stats::rlnorm(n = n, meanlog = 2, sdlog = 0.5),
                          prob_infection = 0.5,
-                         onset_to_hosp = function(x) stats::rlnorm(n = x, meanlog = 1.5, sdlog = 0.5),
-                         onset_to_death = function(x) stats::rlnorm(n = x, meanlog = 2.5, sdlog = 0.5), # nolint end line_lenght_linter
+                         onset_to_hosp = function(n) stats::rlnorm(n = n, meanlog = 1.5, sdlog = 0.5),
+                         onset_to_death = function(n) stats::rlnorm(n = n, meanlog = 2.5, sdlog = 0.5), # nolint end line_lenght_linter
                          onset_to_recovery = NULL,
                          reporting_delay = NULL,
                          hosp_risk = 0.2,

--- a/R/sim_outbreak.R
+++ b/R/sim_outbreak.R
@@ -68,10 +68,10 @@
 #'   onset_to_death = onset_to_death
 #' )
 sim_outbreak <- function(contact_distribution = function(x) stats::dpois(x = x, lambda = 2), # nolint start line_length_linter
-                         infectious_period = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5),
+                         infectious_period = function(n) stats::rlnorm(n = n, meanlog = 2, sdlog = 0.5),
                          prob_infection = 0.5,
-                         onset_to_hosp = function(x) stats::rlnorm(n = x, meanlog = 1.5, sdlog = 0.5),
-                         onset_to_death = function(x) stats::rlnorm(n = x, meanlog = 2.5, sdlog = 0.5), # nolint end line_length_linter
+                         onset_to_hosp = function(n) stats::rlnorm(n = n, meanlog = 1.5, sdlog = 0.5),
+                         onset_to_death = function(n) stats::rlnorm(n = n, meanlog = 2.5, sdlog = 0.5), # nolint end line_length_linter
                          onset_to_recovery = NULL,
                          reporting_delay = NULL,
                          hosp_risk = 0.2,

--- a/man/create_config.Rd
+++ b/man/create_config.Rd
@@ -71,6 +71,6 @@ create_config()
 
 # example with customised Ct distribution
 create_config(
-  ct_distribution = function(x) rlnorm(n = x, meanlog = 2, sdlog = 1)
+  ct_distribution = function(n) rlnorm(n = n, meanlog = 2, sdlog = 1)
 )
 }

--- a/man/sim_contacts.Rd
+++ b/man/sim_contacts.Rd
@@ -6,7 +6,7 @@
 \usage{
 sim_contacts(
   contact_distribution = function(x) stats::dpois(x = x, lambda = 2),
-  infectious_period = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5),
+  infectious_period = function(n) stats::rlnorm(n = n, meanlog = 2, sdlog = 0.5),
   prob_infection = 0.5,
   outbreak_start_date = as.Date("2023-01-01"),
   anonymise = FALSE,

--- a/man/sim_linelist.Rd
+++ b/man/sim_linelist.Rd
@@ -6,10 +6,10 @@
 \usage{
 sim_linelist(
   contact_distribution = function(x) stats::dpois(x = x, lambda = 2),
-  infectious_period = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5),
+  infectious_period = function(n) stats::rlnorm(n = n, meanlog = 2, sdlog = 0.5),
   prob_infection = 0.5,
-  onset_to_hosp = function(x) stats::rlnorm(n = x, meanlog = 1.5, sdlog = 0.5),
-  onset_to_death = function(x) stats::rlnorm(n = x, meanlog = 2.5, sdlog = 0.5),
+  onset_to_hosp = function(n) stats::rlnorm(n = n, meanlog = 1.5, sdlog = 0.5),
+  onset_to_death = function(n) stats::rlnorm(n = n, meanlog = 2.5, sdlog = 0.5),
   onset_to_recovery = NULL,
   reporting_delay = NULL,
   hosp_risk = 0.2,

--- a/man/sim_outbreak.Rd
+++ b/man/sim_outbreak.Rd
@@ -6,10 +6,10 @@
 \usage{
 sim_outbreak(
   contact_distribution = function(x) stats::dpois(x = x, lambda = 2),
-  infectious_period = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5),
+  infectious_period = function(n) stats::rlnorm(n = n, meanlog = 2, sdlog = 0.5),
   prob_infection = 0.5,
-  onset_to_hosp = function(x) stats::rlnorm(n = x, meanlog = 1.5, sdlog = 0.5),
-  onset_to_death = function(x) stats::rlnorm(n = x, meanlog = 2.5, sdlog = 0.5),
+  onset_to_hosp = function(n) stats::rlnorm(n = n, meanlog = 1.5, sdlog = 0.5),
+  onset_to_death = function(n) stats::rlnorm(n = n, meanlog = 2.5, sdlog = 0.5),
   onset_to_recovery = NULL,
   reporting_delay = NULL,
   hosp_risk = 0.2,

--- a/tests/testthat/_snaps/sim_contacts.md
+++ b/tests/testthat/_snaps/sim_contacts.md
@@ -110,7 +110,7 @@
     Code
       sim_contacts(contact_distribution = contact_distribution, infectious_period = infectious_period,
         prob_infection = 0.5, config = create_config(last_contact_distribution = function(
-          x) stats::rgeom(n = x, prob = 0.5)))
+          n) stats::rgeom(n = n, prob = 0.5)))
     Output
                             from                      to age sex date_first_contact
       1            Gabriel Berry          Preston Larson  16   m         2022-12-28
@@ -170,7 +170,7 @@
     Code
       sim_contacts(contact_distribution = contact_distribution, infectious_period = infectious_period,
         prob_infection = 0.5, config = create_config(last_contact_distribution = function(
-          x) stats::rpois(n = x, lambda = 5)))
+          n) stats::rpois(n = n, lambda = 5)))
     Output
                      from                      to age sex date_first_contact
       1      Alivia Perez      Barrington Johnson  44   m         2022-12-29

--- a/tests/testthat/_snaps/sim_linelist.md
+++ b/tests/testthat/_snaps/sim_linelist.md
@@ -708,8 +708,8 @@
     Code
       sim_linelist(contact_distribution = contact_distribution, infectious_period = infectious_period,
         prob_infection = 0.5, onset_to_hosp = onset_to_hosp, onset_to_death = onset_to_death,
-        config = create_config(last_contact_distribution = function(x) stats::rgeom(
-          n = x, prob = 0.5)))
+        config = create_config(last_contact_distribution = function(n) stats::rgeom(
+          n = n, prob = 0.5)))
     Output
          id             case_name case_type sex age date_onset date_reporting
       1   1          Claire Hicks confirmed   f  44 2023-01-01     2023-01-01
@@ -756,8 +756,8 @@
     Code
       sim_linelist(contact_distribution = contact_distribution, infectious_period = infectious_period,
         prob_infection = 0.5, onset_to_hosp = onset_to_hosp, onset_to_death = onset_to_death,
-        config = create_config(last_contact_distribution = function(x) stats::rpois(
-          n = x, lambda = 5)))
+        config = create_config(last_contact_distribution = function(n) stats::rpois(
+          n = n, lambda = 5)))
     Output
          id              case_name case_type sex age date_onset date_reporting
       1   1           Kevin Pullen suspected   m   1 2023-01-01     2023-01-01

--- a/tests/testthat/test-add_cols.R
+++ b/tests/testthat/test-add_cols.R
@@ -1,17 +1,17 @@
-onset_to_hosp <- function(x) {
-  stats::rlnorm(n = x, meanlog = 0.947, sdlog = 1.628)
+onset_to_hosp <- function(n) {
+  stats::rlnorm(n = n, meanlog = 0.947, sdlog = 1.628)
 }
-onset_to_death <- function(x) {
-  stats::rlnorm(n = x, meanlog = 2.863, sdlog = 0.534)
+onset_to_death <- function(n) {
+  stats::rlnorm(n = n, meanlog = 2.863, sdlog = 0.534)
 }
-onset_to_recovery <- function(x) rep(NA, times = x)
+onset_to_recovery <- function(n) rep(NA, times = n)
 
 test_that(".add_date_contact works as expected", {
   ll <- readRDS(file = file.path("testdata", "pre_date_contact.rds"))
   linelist <- .add_date_contact(
     .data = ll,
-    first_contact_distribution = function(x) stats::rpois(n = x, lambda = 3),
-    last_contact_distribution = function(x) stats::rpois(n = x, lambda = 3),
+    first_contact_distribution = function(n) stats::rpois(n = n, lambda = 3),
+    last_contact_distribution = function(n) stats::rpois(n = n, lambda = 3),
     outbreak_start_date = as.Date("2023-01-01")
   )
   expect_s3_class(linelist, class = "data.frame")
@@ -29,10 +29,10 @@ test_that(".add_date_contact fails as expected for non-integers", {
   expect_error(
     .add_date_contact(
       .data = ll,
-      first_contact_distribution = function(x) {
-        stats::rlnorm(n = x, meanlog = 1, sdlog = 1)
+      first_contact_distribution = function(n) {
+        stats::rlnorm(n = n, meanlog = 1, sdlog = 1)
       },
-      last_contact_distribution = function(x) stats::rpois(n = x, lambda = 3),
+      last_contact_distribution = function(n) stats::rpois(n = n, lambda = 3),
       outbreak_start_date = as.Date("2023-01-01")
     ),
     regexp = "(contact distribution)*(must)*(produce)*(nonnegative integers)"
@@ -41,8 +41,8 @@ test_that(".add_date_contact fails as expected for non-integers", {
   expect_error(
     .add_date_contact(
       .data = ll,
-      first_contact_distribution = function(x) "x",
-      last_contact_distribution = function(x) stats::rpois(n = x, lambda = 3),
+      first_contact_distribution = function(n) "n",
+      last_contact_distribution = function(n) stats::rpois(n = n, lambda = 3),
       outbreak_start_date = as.Date("2023-01-01")
     ),
     regexp = "(contact distribution)*(must)*(produce)*(nonnegative integers)"
@@ -52,7 +52,7 @@ test_that(".add_date_contact fails as expected for non-integers", {
     .add_date_contact(
       .data = ll,
       first_contact_distribution = "pois",
-      last_contact_distribution = function(x) stats::rpois(n = x, lambda = 3),
+      last_contact_distribution = function(n) stats::rpois(n = n, lambda = 3),
       outbreak_start_date = as.Date("2023-01-01")
     ),
     regexp = "(Assertion)*(failed)*(Must be a function, not 'character')"
@@ -212,7 +212,7 @@ test_that(".add_ct works as expected", {
   ll <- readRDS(file.path("testdata", "pre_ct.rds"))
   linelist <- .add_ct(
     .data = ll,
-    distribution = function(x) stats::rnorm(n = x, mean = 3, sd = 0.5)
+    distribution = function(n) stats::rnorm(n = n, mean = 3, sd = 0.5)
   )
   expect_s3_class(linelist, class = "data.frame")
   expect_type(linelist$ct_value, type = "double")
@@ -224,7 +224,7 @@ test_that(".add_ct works as expected with different parameter", {
   ll <- readRDS(file.path("testdata", "pre_ct.rds"))
   linelist <- .add_ct(
     .data = ll,
-    distribution = function(x) stats::rnorm(n = x, mean = 30, sd = 2)
+    distribution = function(n) stats::rnorm(n = n, mean = 30, sd = 2)
   )
   expect_s3_class(linelist, class = "data.frame")
   expect_type(linelist$ct_value, type = "double")
@@ -235,12 +235,12 @@ test_that(".add_ct works as expected with different parameter", {
 test_that(".add_ct fails as expected", {
   ll <- readRDS(file.path("testdata", "pre_ct.rds"))
   expect_error(
-    .add_ct(.data = ll, distribution = function(x) "x"),
+    .add_ct(.data = ll, distribution = function(n) "n"),
     regexp = "(Ct distribution)*(must)*(produce)*(positive numbers)"
   )
 
   expect_error(
-    .add_ct(.data = ll, distribution = function(x) -1),
+    .add_ct(.data = ll, distribution = function(n) -1),
     regexp = "(Ct distribution)*(must)*(produce)*(positive numbers)"
   )
 

--- a/tests/testthat/test-checkers.R
+++ b/tests/testthat/test-checkers.R
@@ -162,14 +162,14 @@ test_that(".check_df fails as expected for age", {
 })
 
 contact_distribution <- function(x) stats::dpois(x = x, lambda = 2)
-infectious_period <- function(x) stats::rgamma(n = x, shape = 1, scale = 1)
-onset_to_hosp <- function(x) {
-  stats::rlnorm(n = x, meanlog = 0.947, sdlog = 1.628)
+infectious_period <- function(n) stats::rgamma(n = n, shape = 1, scale = 1)
+onset_to_hosp <- function(n) {
+  stats::rlnorm(n = n, meanlog = 0.947, sdlog = 1.628)
 }
-onset_to_death <- function(x) {
-  stats::rlnorm(n = x, meanlog = 2.863, sdlog = 0.534)
+onset_to_death <- function(n) {
+  stats::rlnorm(n = n, meanlog = 2.863, sdlog = 0.534)
 }
-onset_to_recovery <- function(x) stats::rlnorm(n = x, meanlog = 3, sdlog = 1)
+onset_to_recovery <- function(n) stats::rlnorm(n = n, meanlog = 3, sdlog = 1)
 
 test_that(".check_sim_input works as expected", {
   chk <- .check_sim_input(
@@ -359,7 +359,7 @@ test_that(".cross_check_sim_input works as expected with <data.frame> risks", {
 test_that(".cross_check_sim_input warns as expected", {
   expect_warning(
     .cross_check_sim_input(
-      onset_to_hosp = function(x) rep(NA, times = x),
+      onset_to_hosp = function(n) rep(NA, times = n),
       onset_to_death = onset_to_death,
       hosp_risk = 0.2,
       hosp_death_risk = 0.5,
@@ -373,7 +373,7 @@ test_that(".cross_check_sim_input warns as expected", {
 
   expect_warning(
     .cross_check_sim_input(
-      onset_to_hosp = function(x) rep(NA, times = x),
+      onset_to_hosp = function(n) rep(NA, times = n),
       onset_to_death = onset_to_death,
       hosp_risk = 0.2,
       hosp_death_risk = 0.5,
@@ -387,7 +387,7 @@ test_that(".cross_check_sim_input warns as expected", {
   expect_warning(
     .cross_check_sim_input(
       onset_to_hosp = onset_to_hosp,
-      onset_to_death = function(x) rep(NA, times = x),
+      onset_to_death = function(n) rep(NA, times = n),
       hosp_risk = 0.2,
       hosp_death_risk = 0.5,
       non_hosp_death_risk = 0.05

--- a/tests/testthat/test-create_config.R
+++ b/tests/testthat/test-create_config.R
@@ -13,7 +13,7 @@ test_that("create_config works as expected with defaults", {
 
 test_that("create_config works as expected modifying element", {
   config <- create_config(
-    last_contact_distribution = function(x) rgeom(n = x, prob = 0.5)
+    last_contact_distribution = function(n) rgeom(n = n, prob = 0.5)
   )
   expect_type(config, type = "list")
   expect_length(config, 5)
@@ -26,15 +26,15 @@ test_that("create_config works as expected modifying element", {
   )
   expect_identical(
     config$last_contact_distribution,
-    function(x) rgeom(n = x, prob = 0.5)
+    function(n) rgeom(n = n, prob = 0.5)
   )
 })
 
 test_that("create_config works as expected with spliced list", {
   config <- create_config(
     !!!list(
-      last_contact_distribution = function(x) rpois(n = x, lambda = 2),
-      ct_distribution = function(x) rlnorm(n = x, meanlog = 2, sdlog = 1)
+      last_contact_distribution = function(n) rpois(n = n, lambda = 2),
+      ct_distribution = function(n) rlnorm(n = n, meanlog = 2, sdlog = 1)
     )
   )
   expect_type(config, type = "list")
@@ -48,17 +48,17 @@ test_that("create_config works as expected with spliced list", {
   )
   expect_identical(
     config$last_contact_distribution,
-    function(x) rpois(n = x, lambda = 2)
+    function(n) rpois(n = n, lambda = 2)
   )
   expect_identical(
     config$ct_distribution,
-    function(x) rlnorm(n = x, meanlog = 2, sdlog = 1)
+    function(n) rlnorm(n = n, meanlog = 2, sdlog = 1)
   )
 
   config <- create_config(
-    last_contact_distribution = function(x) rpois(n = x, lambda = 4),
+    last_contact_distribution = function(n) rpois(n = n, lambda = 4),
     !!!list(
-      ct_distribution = function(x) rlnorm(n = x, meanlog = 3, sdlog = 1)
+      ct_distribution = function(n) rlnorm(n = n, meanlog = 3, sdlog = 1)
     )
   )
   expect_type(config, type = "list")
@@ -72,18 +72,18 @@ test_that("create_config works as expected with spliced list", {
   )
   expect_identical(
     config$last_contact_distribution,
-    function(x) rpois(n = x, lambda = 4)
+    function(n) rpois(n = n, lambda = 4)
   )
   expect_identical(
     config$ct_distribution,
-    function(x) rlnorm(n = x, meanlog = 3, sdlog = 1)
+    function(n) rlnorm(n = n, meanlog = 3, sdlog = 1)
   )
 })
 
 test_that("create_config fails as expected misspelling modifying element", {
   # test also checks that partial name matching of list names does not happen
   expect_error(
-    create_config(last_contact_dist = function(x) rpois(n = x, lambda = 1)),
+    create_config(last_contact_dist = function(n) rpois(n = n, lambda = 1)),
     regexp = "Incorrect argument names supplied to create_config"
   )
 })
@@ -95,7 +95,7 @@ test_that("create_config fails as expected with unnamed elements", {
   )
   expect_error(
     create_config(
-      ct_distribution = function(x) rlnorm(n = x, meanlog = 2, sdlog = 1),
+      ct_distribution = function(n) rlnorm(n = n, meanlog = 2, sdlog = 1),
       "unadjusted"
     ),
     regexp = "Incorrect argument names supplied to create_config"
@@ -105,14 +105,14 @@ test_that("create_config fails as expected with unnamed elements", {
 test_that("create_config fails as expected with list input", {
   expect_error(
     create_config(
-      list(ct_distribution = function(x) rlnorm(n = x, meanlog = 2, sdlog = 1))
+      list(ct_distribution = function(n) rlnorm(n = n, meanlog = 2, sdlog = 1))
     ),
     regexp = "Incorrect argument names supplied to create_config"
   )
   expect_error(
     create_config(
-      list(last_contact_distribution = function(x) rpois(n = x, lambda = 1)),
-      ct_distribution = function(x) rlnorm(n = x, meanlog = 2, sdlog = 1)
+      list(last_contact_distribution = function(n) rpois(n = n, lambda = 1)),
+      ct_distribution = function(n) rlnorm(n = n, meanlog = 2, sdlog = 1)
     ),
     regexp = "Incorrect argument names supplied to create_config"
   )

--- a/tests/testthat/test-sim_contacts.R
+++ b/tests/testthat/test-sim_contacts.R
@@ -4,7 +4,7 @@ test_that("sim_contacts works as expected with defaults", {
 })
 
 contact_distribution <- function(x) stats::dpois(x = x, lambda = 2)
-infectious_period <- function(x) stats::rgamma(n = x, shape = 1, scale = 1)
+infectious_period <- function(n) stats::rgamma(n = n, shape = 1, scale = 1)
 
 test_that("sim_contacts works as expected", {
   set.seed(1)
@@ -25,7 +25,7 @@ test_that("sim_contacts works as expected with modified config", {
       infectious_period = infectious_period,
       prob_infection = 0.5,
       config = create_config(
-        last_contact_distribution = function(x) stats::rgeom(n = x, prob = 0.5)
+        last_contact_distribution = function(n) stats::rgeom(n = n, prob = 0.5)
       )
     )
   )
@@ -39,7 +39,7 @@ test_that("sim_contacts works as expected with modified config parameters", {
       infectious_period = infectious_period,
       prob_infection = 0.5,
       config = create_config(
-        last_contact_distribution = function(x) stats::rpois(n = x, lambda = 5)
+        last_contact_distribution = function(n) stats::rpois(n = n, lambda = 5)
       )
     )
   )
@@ -52,7 +52,7 @@ test_that("sim_contacts fails as expected with modified config", {
       infectious_period = infectious_period,
       prob_infection = 0.5,
       config = create_config(
-        last_contact_distribution = function(x) stats::rgeom(n = x, lambda = 1)
+        last_contact_distribution = function(n) stats::rgeom(n = n, lambda = 1)
       )
     ),
     regexp = "(used argument)*(lambda = 1)"

--- a/tests/testthat/test-sim_linelist.R
+++ b/tests/testthat/test-sim_linelist.R
@@ -4,12 +4,12 @@ test_that("sim_linelist works as expected with defaults", {
 })
 
 contact_distribution <- function(x) stats::dpois(x = x, lambda = 2)
-infectious_period <- function(x) stats::rgamma(n = x, shape = 1, scale = 1)
-onset_to_hosp <- function(x) {
-  stats::rlnorm(n = x, meanlog = 0.947, sdlog = 1.628)
+infectious_period <- function(n) stats::rgamma(n = n, shape = 1, scale = 1)
+onset_to_hosp <- function(n) {
+  stats::rlnorm(n = n, meanlog = 0.947, sdlog = 1.628)
 }
-onset_to_death <- function(x) {
-  stats::rlnorm(n = x, meanlog = 2.863, sdlog = 0.534)
+onset_to_death <- function(n) {
+  stats::rlnorm(n = n, meanlog = 2.863, sdlog = 0.534)
 }
 
 test_that("sim_linelist works as expected", {
@@ -118,8 +118,8 @@ test_that("sim_linelist gives expected proportion of ages with age struct", {
     contact_distribution = contact_distribution,
     infectious_period = infectious_period,
     prob_infection = 0.5,
-    onset_to_hosp = function(x) stats::rlnorm(n = x, meanlog = 1, sdlog = 0.5),
-    onset_to_death = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5),
+    onset_to_hosp = function(n) stats::rlnorm(n = n, meanlog = 1, sdlog = 0.5),
+    onset_to_death = function(n) stats::rlnorm(n = n, meanlog = 2, sdlog = 0.5),
     population_age = age_struct,
     outbreak_size = c(500, 5000)
   )
@@ -153,7 +153,7 @@ test_that("sim_linelist works as expected with modified config", {
       onset_to_hosp = onset_to_hosp,
       onset_to_death = onset_to_death,
       config = create_config(
-        last_contact_distribution = function(x) stats::rgeom(n = x, prob = 0.5)
+        last_contact_distribution = function(n) stats::rgeom(n = n, prob = 0.5)
       )
     )
   )
@@ -169,7 +169,7 @@ test_that("sim_linelist works as expected with modified config parameters", {
       onset_to_hosp = onset_to_hosp,
       onset_to_death = onset_to_death,
       config = create_config(
-        last_contact_distribution = function(x) stats::rpois(n = x, lambda = 5)
+        last_contact_distribution = function(n) stats::rpois(n = n, lambda = 5)
       )
     )
   )
@@ -199,7 +199,7 @@ test_that("sim_linelist fails as expected with modified config", {
       onset_to_hosp = onset_to_hosp,
       onset_to_death = onset_to_death,
       config = create_config(
-        last_contact_distribution = function(x) stats::rgeom(n = x, lambda = 1)
+        last_contact_distribution = function(n) stats::rgeom(n = n, lambda = 1)
       )
     ),
     regexp = "(unused argument)*(lambda = 1)"

--- a/tests/testthat/test-sim_network_bp.R
+++ b/tests/testthat/test-sim_network_bp.R
@@ -1,5 +1,5 @@
 contact_distribution <- function(x) stats::dpois(x = x, lambda = 2)
-infectious_period <- function(x) stats::rgamma(n = x, shape = 1, scale = 1)
+infectious_period <- function(n) stats::rgamma(n = n, shape = 1, scale = 1)
 
 test_that(".sim_network_bp works as expected", {
   set.seed(1)
@@ -56,7 +56,7 @@ test_that(".sim_network_bp warns as expected", {
 })
 
 test_that(".sim_network_bp errors with negative infectious period", {
-  infectious_period <- function(x) stats::rnorm(n = x, mean = 10, sd = 5)
+  infectious_period <- function(n) stats::rnorm(n = n, mean = 10, sd = 5)
   set.seed(3)
   expect_error(
     .sim_network_bp(

--- a/tests/testthat/test-sim_outbreak.R
+++ b/tests/testthat/test-sim_outbreak.R
@@ -5,12 +5,12 @@ test_that("sim_outbreak works as expected with defaults", {
 
 
 contact_distribution <- function(x) stats::dpois(x = x, lambda = 2)
-infectious_period <- function(x) stats::rgamma(n = x, shape = 1, scale = 1)
-onset_to_hosp <- function(x) {
-  stats::rlnorm(n = x, meanlog = 0.947, sdlog = 1.628)
+infectious_period <- function(n) stats::rgamma(n = n, shape = 1, scale = 1)
+onset_to_hosp <- function(n) {
+  stats::rlnorm(n = n, meanlog = 0.947, sdlog = 1.628)
 }
-onset_to_death <- function(x) {
-  stats::rlnorm(n = x, meanlog = 2.863, sdlog = 0.534)
+onset_to_death <- function(n) {
+  stats::rlnorm(n = n, meanlog = 2.863, sdlog = 0.534)
 }
 
 test_that("sim_outbreak works as expected", {

--- a/tests/testthat/test-truncate_linelist.R
+++ b/tests/testthat/test-truncate_linelist.R
@@ -128,8 +128,8 @@ test_that("truncate_linelist sets dates as NA when between events", {
   # hospitalisation and onset to death to truncate between reporting and event
   ll <- sim_linelist(
     hosp_risk = 0.9,
-    onset_to_hosp = function(x) stats::rlnorm(n = x, meanlog = 3, sdlog = 0.1),
-    onset_to_death = function(x) stats::rlnorm(n = x, meanlog = 3, sdlog = 0.1)
+    onset_to_hosp = function(n) stats::rlnorm(n = n, meanlog = 3, sdlog = 0.1),
+    onset_to_death = function(n) stats::rlnorm(n = n, meanlog = 3, sdlog = 0.1)
   )
   ll_trunc <- truncate_linelist(ll, truncation_day = 30)
   # it is possible that the proportion of NAs in the truncated data is lower
@@ -145,7 +145,7 @@ test_that("truncate_linelist sets outcome as NA if date_outcome is >= trunc", {
   # simulate with recovery times
   set.seed(123)
   ll <- sim_linelist(
-    onset_to_recovery = function(x) rlnorm(n = x, meanlog = 2, sdlog = 1)
+    onset_to_recovery = function(n) rlnorm(n = n, meanlog = 2, sdlog = 1)
   )
   expect_false(anyNA(ll$date_outcome))
   expect_false(anyNA(ll$outcome))

--- a/vignettes/reporting-delays-truncation.Rmd
+++ b/vignettes/reporting-delays-truncation.Rmd
@@ -106,7 +106,7 @@ linelist <- sim_linelist(
   prob_infection = 0.5,
   onset_to_hosp = onset_to_hosp,
   onset_to_death = onset_to_death,
-  reporting_delay = function(x) rlnorm(n = x, meanlog = 1, sdlog = 1)
+  reporting_delay = function(n) rlnorm(n = n, meanlog = 1, sdlog = 1)
 )
 head(linelist)
 ```
@@ -198,7 +198,7 @@ linelist <- sim_linelist(
   prob_infection = 0.5,
   onset_to_hosp = onset_to_hosp,
   onset_to_death = onset_to_death,
-  reporting_delay = function(x) rep(5, times = x)
+  reporting_delay = function(n) rep(5, times = n)
 )
 head(linelist)
 linelist$date_reporting - linelist$date_onset
@@ -223,7 +223,7 @@ linelist <- sim_linelist(
   prob_infection = 0.5,
   onset_to_hosp = onset_to_hosp,
   onset_to_death = onset_to_death,
-  reporting_delay = function(x) rlnorm(n = x, meanlog = 2, sdlog = 0.5)
+  reporting_delay = function(n) rlnorm(n = n, meanlog = 2, sdlog = 0.5)
 )
 
 # first 6 rows of linelist
@@ -410,7 +410,7 @@ linelist <- sim_linelist(
   prob_infection = 0.5,
   onset_to_hosp = onset_to_hosp,
   onset_to_death = onset_to_death,
-  reporting_delay = function(x) rlnorm(n = x, meanlog = 2, sdlog = 0.5),
+  reporting_delay = function(n) rlnorm(n = n, meanlog = 2, sdlog = 0.5),
   outbreak_size = c(500, 5000)
 )
 ```

--- a/vignettes/simulist.Rmd
+++ b/vignettes/simulist.Rmd
@@ -231,9 +231,9 @@ The `contact_distribution`, `infectious_period`, `onset_to_hosp`, `onset_to_deat
 
 ```{r, sim-outbreak-func}
 contact_distribution <- function(x) dpois(x = x, lambda = 2)
-infectious_period <- function(x) rgamma(n = x, shape = 2, scale = 2)
-onset_to_hosp <- function(x) rlnorm(n = x, meanlog = 1.5, sdlog = 0.5)
-onset_to_death <- function(x) rweibull(n = x, shape = 1, scale = 5)
+infectious_period <- function(n) rgamma(n = n, shape = 2, scale = 2)
+onset_to_hosp <- function(n) rlnorm(n = n, meanlog = 1.5, sdlog = 0.5)
+onset_to_death <- function(n) rweibull(n = n, shape = 1, scale = 5)
 
 outbreak <- sim_outbreak(
   contact_distribution = contact_distribution,
@@ -251,10 +251,10 @@ head(outbreak$contacts)
 ```{r, sim-outbreak-anon-func}
 outbreak <- sim_outbreak(
   contact_distribution = function(x) dpois(x = x, lambda = 2),
-  infectious_period = function(x) rgamma(n = x, shape = 2, scale = 2),
+  infectious_period = function(n) rgamma(n = n, shape = 2, scale = 2),
   prob_infection = 0.5,
-  onset_to_hosp = function(x) rlnorm(n = x, meanlog = 1.5, sdlog = 0.5),
-  onset_to_death = function(x) rweibull(n = x, shape = 1, scale = 5)
+  onset_to_hosp = function(n) rlnorm(n = n, meanlog = 1.5, sdlog = 0.5),
+  onset_to_death = function(n) rweibull(n = n, shape = 1, scale = 5)
 )
 head(outbreak$linelist)
 head(outbreak$contacts)


### PR DESCRIPTION
This PR changes the sole argument in random number sampling functions from `x` to `n`. This is more idiomatic for R which uses the argument `n` in random number generating functions (e.g. `rlnorm()`). 

This should hopefully differentiate between the `contact_distribution` argument and the delay distribution arguments in the documentation, where the former requires a density and the latter require random number generating functions.

This PR makes no functional changes. 