### PR TITLE
Add `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This PR adds the `dependabot.yml` file to `.github/` to automatically check for Github actions version updates on a monthly basis and to open pull requests with the updated workflow `.yaml` files.